### PR TITLE
add the kinematic wave code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /dev/
 /docs/build/
 /docs/site/
+/test/data/

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -1,5 +1,8 @@
 module Wflow
 
-greet() = print("Hello World!")
+using LightGraphs
+using NCDatasets
+
+include("kinematic_wave.jl")
 
 end # module

--- a/src/kinematic_wave.jl
+++ b/src/kinematic_wave.jl
@@ -1,0 +1,89 @@
+
+"Map from PCRaster LDD value to a CartesianIndex"
+const pcrdir = [
+    CartesianIndex(1, -1),  # 1
+    CartesianIndex(1, 0),  # 2
+    CartesianIndex(1, 1),  # 3
+    CartesianIndex(0, -1),  # 4
+    CartesianIndex(0, 0),  # 5
+    CartesianIndex(0, 1),  # 6
+    CartesianIndex(-1, -1),  # 7
+    CartesianIndex(-1, 0),  # 8
+    CartesianIndex(-1, 1),  # 9
+]
+
+"Get a list of indices that are active, based on a nodata value"
+function active_indices(A, nodata)
+    inds = CartesianIndices(size(A))
+    filter(i -> !isequal(A[i], nodata), inds)
+end
+
+"Convert a gridded drainage direction to a directed graph"
+function flowgraph(ldd::AbstractVector, inds::AbstractVector, pcrdir::AbstractVector)
+    # prepare a directed graph to be filled
+    n = length(inds)
+    dag = DiGraph(n)
+
+    # loop over ldd, adding the edge to the downstream node
+    for (from_node, from_index) in enumerate(inds)
+        ldd_val = ldd[from_node]
+        # skip pits to prevent cycles
+        ldd_val == 5 && continue
+        to_index = from_index + pcrdir[ldd_val]
+        # find the node id of the downstream cell
+        to_node = searchsortedfirst(inds, to_index)
+        add_edge!(dag, from_node, to_node)
+    end
+    @assert is_directed(dag)
+    @assert !is_cyclic(dag)
+    return dag
+end
+
+# 2.5x faster power method
+"Faster method for exponentiation"
+pow(x, y) = exp2(y * log2(x))
+
+"Kinematic wave flow rate for a single cell and timestep"
+function kinematic_wave(Qin, Qold, q, α, β, Δt, Δx)
+    ϵ = 1.0e-12
+    max_iters = 3000
+
+    if Qin + Qold + q ≈ 0.0
+        return 0.0
+    else
+        # common terms
+        ab_pQ = α * β * pow(((Qold + Qin) / 2.0), (β - 1.0))
+        Δtx = Δt / Δx
+        C = Δtx * Qin + α * pow(Qold, β) + Δt * q
+
+        Qkx = (Δtx * Qin + Qold * ab_pQ + Δt * q) / (Δtx + ab_pQ)
+        if isnan(Qkx)
+            Qkx = 0.0
+        end
+        Qkx = max(Qkx, 1.0e-30)
+        count = 1
+
+        while true
+            fQkx = Δtx * Qkx + α * pow(Qkx, β) - C
+            dfQkx = Δtx + α * β * pow(Qkx, (β - 1.0))
+            Qkx = Qkx - fQkx / dfQkx
+            Qkx = max(Qkx, 1.0e-30)
+            if (abs(fQkx) <= ϵ) || (count >= max_iters)
+                break
+            end
+            count += 1
+        end
+
+        return Qkx
+    end
+end
+
+"Kinematic wave flow rate over the whole network for a single timestep"
+function kin_wave!(Q, dag, toposort, Qold, q, α, β, DCL, Δt)
+    for v in toposort
+        upstream_nodes = inneighbors(dag, v)
+        Qin = isempty(upstream_nodes) ? 0.0 : sum(Q[i] for i in upstream_nodes)
+        Q[v] = kinematic_wave(Qin, Qold[v], q, α[v], β, Δt, DCL[v])
+    end
+    return Q
+end

--- a/test/kinematic_wave.jl
+++ b/test/kinematic_wave.jl
@@ -1,0 +1,50 @@
+const Δt = 86400.0
+const ldd_mv = 255
+
+# read the staticmaps into memory
+nc = NCDataset(staticmaps_path)
+ldd_2d = nc["ldd"][:]
+slope_2d = nc["slope"][:]
+N_2d = nc["N"][:]
+Qold_2d = nc["Qold"][:]
+Bw_2d = nc["Bw"][:]
+waterlevel_2d = nc["waterlevel"][:]
+DCL_2d = nc["DCL"][:]
+close(nc)
+
+inds = Wflow.active_indices(ldd_2d, ldd_mv)
+n = length(inds)
+
+# take out only the active cells
+ldd = ldd_2d[inds]
+slope = slope_2d[inds]
+N = N_2d[inds]
+Qold = Qold_2d[inds]
+Bw = Bw_2d[inds]
+waterlevel = waterlevel_2d[inds]
+DCL = DCL_2d[inds]
+
+# create the directed acyclic graph from the drainage direction array
+dag = Wflow.flowgraph(ldd, inds, Wflow.pcrdir)
+# a topological sort is used for visiting nodes in order from upstream to downstream
+toposort = topological_sort_by_dfs(dag)
+sink = toposort[end]
+@test ldd[sink] == 5  # the most downstream node must be a sink
+
+# calculate parameters of kinematic wave
+const q = 0.000001
+const β = 0.6
+const AlpPow = (2.0 / 3.0) * β
+AlpTermR = (N ./ sqrt.(slope)) .^ β
+P = Bw + (2.0 * waterlevel)
+α = AlpTermR .* P .^ AlpPow
+
+Q = zeros(n)
+Q = Wflow.kin_wave!(Q, dag, toposort, Qold, q, α, β, DCL, Δt)
+
+@testset "flow rate" begin
+    @test sum(Q) ≈ 2.957806043289641e6
+    @test Q[toposort[1]] ≈ 0.00021453683608501235
+    @test Q[toposort[n-100]] ≈ 4054.9507466731234
+    @test Q[sink] ≈ 4131.101474418251
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 using Wflow
 using Test
+using NCDatasets
+using LightGraphs
+
+# ensure test data is present
+datadir = joinpath(@__DIR__, "data")
+isdir(datadir) || mkdir(datadir)
+staticmaps_path = joinpath(datadir, "staticmaps.nc")
+isfile(staticmaps_path) || download("https://github.com/visr/wflow-artifacts/releases/download/v0.1.0/staticmaps.nc", staticmaps_path)
 
 @testset "Wflow.jl" begin
-    # Write your own tests here.
+    include("kinematic_wave.jl")
 end


### PR DESCRIPTION
- downloads a NetCDF with test data as grids
- turns this into a directed graph
- computes a topological sort along the graph
- calculates flow along the topological sort and tests result

@verseve this is the single threaded benchmark code, pretty much as-is. We may end up changing some aspects, but I think it's useful to already have this code here, hooked up to some tests. I uploaded the test data to https://github.com/visr/wflow-artifacts/releases to avoid putting it in this repository, though we can move it to another place later as well.