### PR TITLE
support TOML configuration files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,11 @@ authors = ["Deltares"]
 version = "0.1.0"
 
 [deps]
+CFTime = "179af706-886a-5703-950a-314cd64e0468"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -4,7 +4,9 @@ using Dates
 using LightGraphs
 using NCDatasets
 using StaticArrays
+using Pkg.TOML
 
+include("config.jl")
 include("kinematic_wave.jl")
 include("sbm.jl")
 

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,0 +1,12 @@
+"Parsed TOML configuration"
+struct Config
+    dict::Dict{String, Any}
+end
+
+# allows using getproperty, e.g. config.input.time instead of config["input"]["time"]
+function Base.getproperty(config::Config, f::Symbol)
+    dict = getfield(config, :dict)
+    a = dict[String(f)]
+    # if it is a Dict, wrap the result in Config to keep the getproperty behavior
+    return a isa AbstractDict ? Config(a) : a
+end

--- a/test/config.jl
+++ b/test/config.jl
@@ -1,0 +1,17 @@
+@testset begin "configuration file"
+    tomlpath = joinpath(@__DIR__, "config.toml")
+    parsed_toml = TOML.parsefile(tomlpath)
+    config = Wflow.Config(parsed_toml)
+    @test parsed_toml isa Dict{String, Any}
+    @test config isa Wflow.Config
+    @test getfield(config, :dict) === parsed_toml
+
+    # test if the values are parsed as expected
+    @test config.casename == "testcase"
+    @test config.λ == 1.2
+    @test config.input.starttime == DateTime(2000)
+    @test config.input.endtime == DateTime(2000, 2)
+    @test config.output.path == "specified_output.nc"
+    @test config.output.parameters isa Vector{String}
+    @test config.output.parameters == ["q", "h"]
+end

--- a/test/config.toml
+++ b/test/config.toml
@@ -17,7 +17,7 @@ parameters = [ "q", "h" ]
 # all these are not yet supported by Pkg.TOML as of Julia 1.4
 # https://github.com/toml-lang/toml#local-date-time
 # https://github.com/JuliaLang/Pkg.jl/issues/1011
-# file issues/PRs as needed, but we can use the the *Z zulu time in the meanwhile
+# file issues/PRs as needed, but we can use zulu time syntax in the meanwhile
 # odt4 = 1979-05-27 07:32:00Z
 # ldt1 = 1979-05-27T07:32:00
 # ldt2 = 1979-05-27T00:32:00.999999

--- a/test/config.toml
+++ b/test/config.toml
@@ -1,0 +1,27 @@
+# This is an example TOML configuration file. It is used to test the wflow configuration
+# features, and can also be used to work towards an example of what we want the
+# configuration file to look like.
+# TOML documentation: https://github.com/toml-lang/toml
+
+casename = "testcase"
+"λ" = 1.2  # unicode keys are supported but only between strings
+
+[input]
+starttime = 2000-01-01T00:00:00Z
+endtime = 2000-02-01T00:00:00Z
+
+[output]
+path = "specified_output.nc"
+parameters = [ "q", "h" ]
+
+# all these are not yet supported by Pkg.TOML as of Julia 1.4
+# https://github.com/toml-lang/toml#local-date-time
+# https://github.com/JuliaLang/Pkg.jl/issues/1011
+# file issues/PRs as needed, but we can use the the *Z zulu time in the meanwhile
+# odt4 = 1979-05-27 07:32:00Z
+# ldt1 = 1979-05-27T07:32:00
+# ldt2 = 1979-05-27T00:32:00.999999
+# ld1 = 1979-05-27
+# lt1 = 07:32:00
+# lt2 = 00:32:00.999999
+# physical.color = "orange"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,10 @@
+## load test dependencies and set paths to testing data
 using Wflow
 using Test
 using NCDatasets
+using Dates
 using LightGraphs
+using Pkg.TOML
 
 # ensure test data is present
 datadir = joinpath(@__DIR__, "data")
@@ -13,7 +16,10 @@ isfile(staticmaps_moselle_path) || download("https://github.com/visr/wflow-artif
 leafarea_moselle_path = joinpath(datadir, "lai_clim-moselle.nc")
 isfile(leafarea_moselle_path) || download("https://github.com/visr/wflow-artifacts/releases/download/v0.2.0/lai_clim.nc", leafarea_moselle_path)
 
+## run all tests
+
 @testset "Wflow.jl" begin
+    include("config.jl")
     include("kinematic_wave.jl")
     include("sbm.jl")
 end


### PR DESCRIPTION
This is just a stub, but good to get some feedback on. I decided to wrap 
the Dict returned by the TOML parser into a Config struct. This way, we 
can easily define functions that operate on the configuration. 
Specifically, I already implemented Base.getproperty, to make it easy to 
get values with dot notation:

```
config.input.time instead of config["input"]["time"]
```

Since TOML is used in the Pkg manager, it is included with it. Officially it is an internal API, but will likely be moved to an official standard library in the future. I noted some examples of TOML syntax that is not yet supported in the example file.