### PR TITLE
Surface kinwave

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,20 +2,16 @@ using Wflow
 using Documenter
 
 makedocs(;
-    modules=[Wflow],
-    authors="Deltares and contributors",
-    repo="https://github.com/Deltares/Wflow.jl/blob/{commit}{path}#L{line}",
-    sitename="Wflow.jl",
-    format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://Deltares.github.io/Wflow.jl",
-        assets=String[],
+    modules = [Wflow],
+    authors = "Deltares and contributors",
+    repo = "https://github.com/Deltares/Wflow.jl/blob/{commit}{path}#L{line}",
+    sitename = "Wflow.jl",
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://Deltares.github.io/Wflow.jl",
+        assets = String[],
     ),
-    pages=[
-        "Home" => "index.md",
-    ],
+    pages = ["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo="github.com/Deltares/Wflow.jl",
-)
+deploydocs(; repo = "github.com/Deltares/Wflow.jl")

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -17,6 +17,7 @@ include("model.jl")
 include("sbm.jl")
 include("sbm_model.jl")
 include("subsurface_flow.jl")
+include("surface_flow.jl")
 include("vertical_process.jl")
 include("utils.jl")
 

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -313,6 +313,8 @@ function update_before_lateralflow(t)
         t.interception[r] = interception
         t.ae_openw_r[r] = ae_openw_r
         t.ae_openw_l[r] = ae_openw_l
+        t.runoff_land[r] = runoff_land
+        t.runoff_river[r] = runoff_river
         t.actevapsat[r] = actevapsat
         t.actevap[r] = actevap
         t.ustorelayerdepth[r] = usld
@@ -346,7 +348,8 @@ function update_after_lateralflow(t, zi, exfiltsatwater)
             exfiltustore +
             exfiltsatwater[r] +
             t.excesswater[r] +
-            t.infiltexcess[r] +
+            t.runoff_land[r] +
+            t.infiltexcess[r] -
             t.ae_openw_l[r],
             0.0,
         )

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -24,8 +24,7 @@ function update_before_lateralflow(t)
             cmax = t.sl[r] * t.lai[r] + t.swood[r]
             canopygapfraction = exp(-t.kext[r] * t.lai[r])
             ewet = (1.0 - exp(-t.kext[r] * t.lai[r])) * potevap
-            e_r = precipitation > 0.0 ?
-                min(0.25, ewet / max(0.0001, precipitation)) : 0.0
+            e_r = precipitation > 0.0 ? min(0.25, ewet / max(0.0001, precipitation)) : 0.0
         end
 
         potevap = potevap * t.et_reftopot[r]
@@ -33,29 +32,24 @@ function update_before_lateralflow(t)
         # PotEvap = PotenEvap #??
 
         if Δt >= Hour(23)
-            throughfall, interception, stemflow, canopystorage =
-                rainfall_interception_gash(
-                    cmax,
-                    e_r,
-                    canopygapfraction,
-                    precipitation,
-                    t.canopystorage[r],
-                    maxevap = potevap,
-                )
+            throughfall, interception, stemflow, canopystorage = rainfall_interception_gash(
+                cmax,
+                e_r,
+                canopygapfraction,
+                precipitation,
+                t.canopystorage[r],
+                maxevap = potevap,
+            )
             pottrans_soil = max(0.0, potevap - interception) # now in mm
         else
-            netinterception,
-            throughfall,
-            stemflow,
-            leftover,
-            interception,
-            canopystorage = rainfall_interception_modrut(
-                precipitation,
-                potevap,
-                t.canopystorage[r],
-                canopygapfraction,
-                cmax,
-            )
+            netinterception, throughfall, stemflow, leftover, interception, canopystorage =
+                rainfall_interception_modrut(
+                    precipitation,
+                    potevap,
+                    t.canopystorage[r],
+                    canopygapfraction,
+                    cmax,
+                )
             pottrans_soil = max(0.0, leftover)  # now in mm
             interception = netinterception
         end
@@ -64,18 +58,17 @@ function update_before_lateralflow(t)
 
         if modelsnow
             tsoil = t.tsoil[r] + t.w_soil[r] * (temperature - t.tsoil[r])
-            snow, snowwater, snowmelt, rainfallplusmelt, snowfall =
-                snowpack_hbv(
-                    t.snow[r],
-                    t.snowwater[r],
-                    eff_precipitation,
-                    temperature,
-                    t.tti[r],
-                    t.tt[r],
-                    t.ttm[r],
-                    t.cfmax[r],
-                    t.whc[r],
-                )
+            snow, snowwater, snowmelt, rainfallplusmelt, snowfall = snowpack_hbv(
+                t.snow[r],
+                t.snowwater[r],
+                eff_precipitation,
+                temperature,
+                t.tti[r],
+                t.tt[r],
+                t.ttm[r],
+                t.cfmax[r],
+                t.whc[r],
+            )
             if glacierfrac
                 # Run Glacier module and add the snowpack on-top of it.
                 # Estimate the fraction of snow turned into ice (HBV-light).
@@ -103,8 +96,7 @@ function update_before_lateralflow(t)
 
         avail_forinfilt = rainfallplusmelt + irsupply_mm
         ustoredepth = sum(@view t.ustorelayerdepth[r][1:t.nlayers[r]])
-        uStorecapacity =
-            t.soilwatercapacity[r] - t.satwaterdepth[r] - ustoredepth
+        uStorecapacity = t.soilwatercapacity[r] - t.satwaterdepth[r] - ustoredepth
 
         runoff_river = min(1.0, t.riverfrac[r]) * avail_forinfilt
         runoff_land = min(1.0, t.waterfrac[r]) * avail_forinfilt
@@ -112,14 +104,8 @@ function update_before_lateralflow(t)
 
         rootingdepth = min(t.soilthickness[r] * 0.99, t.rootingdepth[r])
 
-        ae_openw_r = min(
-            wl_river * 1000.0 * t.riverfrac[r],
-            t.riverfrac[r] * pottrans_soil,
-        )
-        ae_openw_l = min(
-            wl_land * 1000.0 * t.waterfrac[r],
-            t.waterfrac[r] * pottrans_soil,
-        )
+        ae_openw_r = min(wl_river * 1000.0 * t.riverfrac[r], t.riverfrac[r] * pottrans_soil)
+        ae_openw_l = min(wl_land * 1000.0 * t.waterfrac[r], t.waterfrac[r] * pottrans_soil)
 
         restevap = pottrans_soil - ae_openw_r - ae_openw_l
 
@@ -128,8 +114,7 @@ function update_before_lateralflow(t)
         pottrans = restevap * (1.0 - canopygapfraction)
 
         # Calculate the initial capacity of the unsaturated store
-        ustorecapacity =
-            t.soilwatercapacity[r] - t.satwaterdepth[r] - ustoredepth
+        ustorecapacity = t.soilwatercapacity[r] - t.satwaterdepth[r] - ustoredepth
 
         # Calculate the infiltration flux into the soil column
         infiltsoilpath, infiltsoil, infiltpath, soilinf, pathinf, infiltexcess =
@@ -146,8 +131,7 @@ function update_before_lateralflow(t)
             )
 
 
-        usl, n_usl =
-            set_layerthickness(t.zi[r], t.sumlayers[r], t.act_thickl[r])
+        usl, n_usl = set_layerthickness(t.zi[r], t.sumlayers[r], t.act_thickl[r])
         z = cumsum(usl)
         usld = copy(t.ustorelayerdepth[r])
 
@@ -175,15 +159,10 @@ function update_before_lateralflow(t)
                 for m = 1:n_usl
                     l_sat = usl[m] * (t.θₛ[r] - t.θᵣ[r])
                     kv_z = t.kvfrac[r][m] * t.kv₀[r] * exp(-t.f[r] * z[m])
-                    ustorelayerdepth =
-                        m == 1 ? t.ustorelayerdepth[r][m] + infiltsoilpath :
+                    ustorelayerdepth = m == 1 ? t.ustorelayerdepth[r][m] + infiltsoilpath :
                         t.ustorelayerdepth[r][m] + ast
-                    ustorelayerdepth, ast = unsatzone_flow_layer(
-                        ustorelayerdepth,
-                        kv_z,
-                        l_sat,
-                        t.c[r][m],
-                    )
+                    ustorelayerdepth, ast =
+                        unsatzone_flow_layer(ustorelayerdepth, kv_z, l_sat, t.c[r][m])
                     usld = setindex(usld, ustorelayerdepth, m)
                 end
             end
@@ -196,20 +175,17 @@ function update_before_lateralflow(t)
             # atmosphere from the upper layer.
             if t.maxlayers[r] == 1
                 soilevapunsat =
-                    potsoilevap *
-                    min(1.0, saturationdeficit / t.soilwatercapacity[r])
+                    potsoilevap * min(1.0, saturationdeficit / t.soilwatercapacity[r])
             else
                 # In case only the most upper soil layer contains unsaturated storage
                 if n_usl == 1
                     # Check if groundwater level lies below the surface
                     soilevapunsat =
-                        potsoilevap *
-                        min(1.0, usld[1] / (t.zi[r] * (t.θₛ[r] - t.θᵣ[r])))
+                        potsoilevap * min(1.0, usld[1] / (t.zi[r] * (t.θₛ[r] - t.θᵣ[r])))
                 else
                     # In case first layer contains no saturated storage
                     soilevapunsat =
-                        potsoilevap *
-                        min(1.0, usld[1] / (usl[1] * ((t.θₛ[r] - t.θᵣ[r]))))
+                        potsoilevap * min(1.0, usld[1] / (usl[1] * ((t.θₛ[r] - t.θᵣ[r]))))
                 end
             end
             # Ensure that the unsaturated evaporation rate does not exceed the
@@ -227,14 +203,10 @@ function update_before_lateralflow(t)
             # this check is an improvement compared to Python (only checked for n_usl == 1)
             if n_usl == 0 || n_usl == 1
                 soilevapsat =
-                    potsoilevap * min(
-                        1.0,
-                        (t.act_thickl[r][1] - t.zi[r]) / t.act_thickl[r][1],
-                    )
-                soilevapsat = min(
-                    soilevapsat,
-                    (t.act_thickl[r][1] - t.zi[r]) * (t.θₛ[r] - t.θᵣ[r]),
-                )
+                    potsoilevap *
+                    min(1.0, (t.act_thickl[r][1] - t.zi[r]) / t.act_thickl[r][1])
+                soilevapsat =
+                    min(soilevapsat, (t.act_thickl[r][1] - t.zi[r]) * (t.θₛ[r] - t.θᵣ[r]))
             else
                 soilevapsat = 0.0
             end
@@ -283,10 +255,8 @@ function update_before_lateralflow(t)
         # Separation between compacted and non compacted areas (correction with the satflow du)
         # This is required for D-Emission/Delwaq
         if infiltsoil + infiltpath > 0.0
-            actinfiltsoil =
-                infiltsoil - du * infiltsoil / (infiltpath + infiltsoil)
-            actinfiltpath =
-                infiltpath - du * infiltpath / (infiltpath + infiltsoil)
+            actinfiltsoil = infiltsoil - du * infiltsoil / (infiltpath + infiltsoil)
+            actinfiltpath = infiltpath - du * infiltpath / (infiltpath + infiltsoil)
         else
             actinfiltsoil = 0.0
             actinfiltpath = 0.0
@@ -300,10 +270,8 @@ function update_before_lateralflow(t)
             ustorecapacity =
                 t.soilwatercapacity[r] - t.satwaterdepth[r] -
                 sum(@view usld[1:t.nlayers[r]])
-            maxcapflux = max(
-                0.0,
-                min(ksat, actevapustore, ustorecapacity, t.satwaterdepth[r]),
-            )
+            maxcapflux =
+                max(0.0, min(ksat, actevapustore, ustorecapacity, t.satwaterdepth[r]))
 
             if t.zi[r] > rootingdepth
                 capfluxscale =
@@ -316,10 +284,7 @@ function update_before_lateralflow(t)
 
             netcapflux = capflux
             for k = n_usl:-1:1
-                toadd = min(
-                    netcapflux,
-                    max(usl[k] * (t.θₛ[r] - t.θᵣ[r]) - usld[k], 0.0),
-                )
+                toadd = min(netcapflux, max(usl[k] * (t.θₛ[r] - t.θᵣ[r]) - usld[k], 0.0))
                 usld = setindex(usld, usld[k] + toadd, k)
                 netcapflux = netcapflux - toadd
                 actcapflux = actcapflux + toadd
@@ -330,8 +295,7 @@ function update_before_lateralflow(t)
         actleakage = max(0.0, min(t.maxleakage[r], deeptransfer))
 
         # recharge (mm) for saturated zone
-        recharge =
-            (transfer - actcapflux - actleakage - actevapsat - soilevapsat)
+        recharge = (transfer - actcapflux - actleakage - actevapsat - soilevapsat)
         transpiration = actevapsat + actevapustore
         actevap = soilevap + transpiration + ae_openw_r + ae_openw_l
 
@@ -397,10 +361,8 @@ function update_after_lateralflow(t, zi, exfiltsatwater)
             if k <= n_usl
                 vwc = setindex(
                     vwc,
-                    (
-                        usld[k] +
-                        (t.act_thickl[r][k] - usl[k]) * (t.θₛ[r] - t.θᵣ[r])
-                    ) / usl[k] + t.θᵣ[r],
+                    (usld[k] + (t.act_thickl[r][k] - usl[k]) * (t.θₛ[r] - t.θᵣ[r])) /
+                    usl[k] + t.θᵣ[r],
                     k,
                 )
             else
@@ -413,12 +375,10 @@ function update_after_lateralflow(t, zi, exfiltsatwater)
         for k = 1:n_usl
             rootstore_unsat =
                 rootstore_unsat +
-                (max(0.0, t.rootingdepth[r] - t.sumlayers[r][k]) / usl[k]) *
-                usld[k]
+                (max(0.0, t.rootingdepth[r] - t.sumlayers[r][k]) / usl[k]) * usld[k]
         end
 
-        rootstore_sat =
-            max(0.0, t.rootingdepth[r] - zi[r]) * (t.θₛ[r] - t.θᵣ[r])
+        rootstore_sat = max(0.0, t.rootingdepth[r] - zi[r]) * (t.θₛ[r] - t.θᵣ[r])
         rootstore = rootstore_sat + rootstore_unsat
         vwc_root = rootstore / t.rootingdepth[r] + t.θᵣ[r]
         vwc_percroot = (vwc_root / t.θₛ[r]) * 100.0

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -227,6 +227,8 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
         yl = yl,
         # length of cells in x direction [m]
         xl = xl,
+        #
+        river = river,
         # Fraction of river [-]
         riverfrac = riverfrac,
         # Degree-day factor [mm ᵒC⁻¹ Δt⁻¹]
@@ -391,6 +393,7 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     # lateral part sbm
     khfrac = readnetcdf(nc, "KsatHorFrac", inds, dparams, transp = trsp)
     βₗ = trsp ? Float64.(permutedims(nc["Slope"][:])[inds]) : Float64.(nc["Slope"][:][inds])
+    βₗ[βₗ.<0.00001] .= 0.00001
     ldd_2d = trsp ? permutedims(nc["wflow_ldd"][:]) : nc["wflow_ldd"][:]
     ldd = ldd_2d[inds]
     kh₀ = khfrac .* kv₀
@@ -426,13 +429,13 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
 
     dag = flowgraph(ldd, inds, Wflow.pcrdir)
 
-
-    inds_riv = Wflow.active_indices(river_2d, 0)
+    inds_riv = filter(i -> !isequal(river_2d[i], 0), inds)
     riverslope = trsp ? Float64.(permutedims(nc["RiverSlope"][:])[inds_riv]) :
         Float64.(nc["RiverSlope"][:][inds_riv])
+    riverslope[riverslope.<0.00001] .= 0.00001
     riverlength = riverlength_2d[inds_riv]
     riverwidth = riverwidth_2d[inds_riv]
-    n_river = readnetcdf(nc, "NRiver", inds_riv, dparams, transp = trsp)
+    n_river = readnetcdf(nc, "N_River", inds_riv, dparams, transp = trsp)
     ldd_riv = ldd_2d[inds_riv]
     dag_riv = flowgraph(ldd_riv, inds_riv, Wflow.pcrdir)
 

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -234,6 +234,10 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
         maxlayers = Fill(maxlayers, n),
         # Number of soil layers
         nlayers = nlayers,
+        # length of cells in y direction [m]
+        yl = yl,
+        # length of cells in x direction [m]
+        xl = xl,
         # Fraction of river [-]
         riverfrac = riverfrac,
         # Degree-day factor [mm ᵒC⁻¹ Δt⁻¹]

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -56,8 +56,7 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
         trsp = true
     end
 
-    subcatch_2d =
-        trsp ? permutedims(nc["wflow_subcatch"][:]) : nc["wflow_subcatch"][:]
+    subcatch_2d = trsp ? permutedims(nc["wflow_subcatch"][:]) : nc["wflow_subcatch"][:]
     # indices based on catchment
     inds = Wflow.active_indices(subcatch_2d, missing)
     n = length(inds)
@@ -67,8 +66,7 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     river_2d = trsp ? nomissing(permutedims(nc["wflow_river"][:]), 0) :
         nomissing(nc["wflow_river"][:], 0)
     river = river_2d[inds]
-    riverwidth_2d =
-        trsp ? Float64.(nomissing(permutedims(nc["wflow_riverwidth"][:]), 0)) :
+    riverwidth_2d = trsp ? Float64.(nomissing(permutedims(nc["wflow_riverwidth"][:]), 0)) :
         Float64.(nomissing(nc["wflow_riverwidth"][:], 0))
     riverwidth = riverwidth_2d[inds]
     riverlength_2d =
@@ -97,32 +95,23 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     kv₀ = readnetcdf(nc, "KsatVer", inds, dparams, transp = trsp)
     m = readnetcdf(nc, "M", inds, dparams, transp = trsp)
     hb = readnetcdf(nc, "AirEntryPressure", inds, dparams, transp = trsp)
-    soilthickness =
-        readnetcdf(nc, "SoilThickness", inds, dparams, transp = trsp)
-    infiltcappath =
-        readnetcdf(nc, "InfiltCapPath", inds, dparams, transp = trsp)
-    infiltcapsoil =
-        readnetcdf(nc, "InfiltCapSoil", inds, dparams, transp = trsp)
+    soilthickness = readnetcdf(nc, "SoilThickness", inds, dparams, transp = trsp)
+    infiltcappath = readnetcdf(nc, "InfiltCapPath", inds, dparams, transp = trsp)
+    infiltcapsoil = readnetcdf(nc, "InfiltCapSoil", inds, dparams, transp = trsp)
     maxleakage = readnetcdf(nc, "MaxLeakage", inds, dparams, transp = trsp)
     # TODO: store c, kvfrac in staticmaps.nc start at index 1
     c = fill(dparams["c"], (maxlayers, n))
     kvfrac = fill(dparams["KsatVerFrac"], (maxlayers, n))
     for i in [0:1:maxlayers-1;]
         if string("c_", i) in keys(nc)
-            c[i+1, :] =
-                trsp ? Float64.(permutedims(nc[string("c_", i)][:])[inds]) :
+            c[i+1, :] = trsp ? Float64.(permutedims(nc[string("c_", i)][:])[inds]) :
                 Float64.(nc[string("c_", i)][:][inds])
         else
-            @warn(string(
-                "c_",
-                i,
-                " not found, set to default value ",
-                dparams["c"],
-            ))
+            @warn(string("c_", i, " not found, set to default value ", dparams["c"]))
         end
         if string("KsatVerFrac_", i) in keys(nc)
-            kvfrac[i+1, :] = trsp ?
-                Float64.(permutedims(nc[string("KsatVerFrac_", i)][:])[inds]) :
+            kvfrac[i+1, :] =
+                trsp ? Float64.(permutedims(nc[string("KsatVerFrac_", i)][:])[inds]) :
                 Float64.(nc[string("KsatVerFrac_", i)][:][inds])
         else
             @warn(string(
@@ -146,8 +135,7 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     # cmax, e_r, canopygapfraction only required when lai climatoly not provided
     cmax = readnetcdf(nc, "Cmax", inds, dparams, transp = trsp)
     e_r = readnetcdf(nc, "EoverR", inds, dparams, transp = trsp)
-    canopygapfraction =
-        readnetcdf(nc, "CanopyGapFraction", inds, dparams, transp = trsp)
+    canopygapfraction = readnetcdf(nc, "CanopyGapFraction", inds, dparams, transp = trsp)
 
     # if lai climatology provided use sl, swood and kext to calculate cmax
     if isnothing(leafarea_path) == false
@@ -175,8 +163,9 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
 
         xl[i] = sizeinmetres ? cellength : lattometres(y[i])[1] * cellength
         yl[i] = sizeinmetres ? cellength : lattometres(y[i])[2] * cellength
-        riverfrac[i] = Bool(river[i]) ?
-            min((riverlength[i] * riverwidth[i]) / (xl[i] * yl[i]), 1.0) : 0.0
+        riverfrac[i] =
+            Bool(river[i]) ? min((riverlength[i] * riverwidth[i]) / (xl[i] * yl[i]), 1.0) :
+            0.0
 
         nlayers[i] = nlayers_
         act_thickl[:, i] = act_thickl_
@@ -401,8 +390,7 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
 
     # lateral part sbm
     khfrac = readnetcdf(nc, "KsatHorFrac", inds, dparams, transp = trsp)
-    βₗ = trsp ? Float64.(permutedims(nc["Slope"][:])[inds]) :
-        Float64.(nc["Slope"][:][inds])
+    βₗ = trsp ? Float64.(permutedims(nc["Slope"][:])[inds]) : Float64.(nc["Slope"][:][inds])
     ldd_2d = trsp ? permutedims(nc["wflow_ldd"][:]) : nc["wflow_ldd"][:]
     ldd = ldd_2d[inds]
     kh₀ = khfrac .* kv₀

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -56,17 +56,24 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
         trsp = true
     end
 
-    subcatch_2d = trsp ? permutedims(nc["wflow_subcatch"][:]) : nc["wflow_subcatch"][:]
+    subcatch_2d =
+        trsp ? permutedims(nc["wflow_subcatch"][:]) : nc["wflow_subcatch"][:]
     # indices based on catchment
     inds = Wflow.active_indices(subcatch_2d, missing)
     n = length(inds)
 
-    altitude = trsp ? Float64.(permutedims(nc["wflow_dem"][:])[inds]) : Float64.(nc["wflow_dem"][:][inds])
-    river_2d = trsp ? nomissing(permutedims(nc["wflow_river"][:]), 0) : nomissing(nc["wflow_river"][:], 0)
+    altitude = trsp ? Float64.(permutedims(nc["wflow_dem"][:])[inds]) :
+        Float64.(nc["wflow_dem"][:][inds])
+    river_2d = trsp ? nomissing(permutedims(nc["wflow_river"][:]), 0) :
+        nomissing(nc["wflow_river"][:], 0)
     river = river_2d[inds]
-    riverwidth_2d = trsp ? Float64.(nomissing(permutedims(nc["wflow_riverwidth"][:]), 0)) : Float64.(nomissing(nc["wflow_riverwidth"][:], 0))
+    riverwidth_2d =
+        trsp ? Float64.(nomissing(permutedims(nc["wflow_riverwidth"][:]), 0)) :
+        Float64.(nomissing(nc["wflow_riverwidth"][:], 0))
     riverwidth = riverwidth_2d[inds]
-    riverlength_2d = trsp ? Float64.(nomissing(permutedims(nc["wflow_riverlength"][:]), 0)) : Float64.(nomissing(nc["wflow_riverlength"][:], 0))
+    riverlength_2d =
+        trsp ? Float64.(nomissing(permutedims(nc["wflow_riverlength"][:]), 0)) :
+        Float64.(nomissing(nc["wflow_riverlength"][:], 0))
     riverlength = riverlength_2d[inds]
 
     # read x, y coordinates and calculate cell length [m]
@@ -90,23 +97,32 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     kv₀ = readnetcdf(nc, "KsatVer", inds, dparams, transp = trsp)
     m = readnetcdf(nc, "M", inds, dparams, transp = trsp)
     hb = readnetcdf(nc, "AirEntryPressure", inds, dparams, transp = trsp)
-    soilthickness = readnetcdf(nc, "SoilThickness", inds, dparams, transp = trsp)
-    infiltcappath = readnetcdf(nc, "InfiltCapPath", inds, dparams, transp = trsp)
-    infiltcapsoil = readnetcdf(nc, "InfiltCapSoil", inds, dparams, transp = trsp)
+    soilthickness =
+        readnetcdf(nc, "SoilThickness", inds, dparams, transp = trsp)
+    infiltcappath =
+        readnetcdf(nc, "InfiltCapPath", inds, dparams, transp = trsp)
+    infiltcapsoil =
+        readnetcdf(nc, "InfiltCapSoil", inds, dparams, transp = trsp)
     maxleakage = readnetcdf(nc, "MaxLeakage", inds, dparams, transp = trsp)
     # TODO: store c, kvfrac in staticmaps.nc start at index 1
     c = fill(dparams["c"], (maxlayers, n))
     kvfrac = fill(dparams["KsatVerFrac"], (maxlayers, n))
     for i in [0:1:maxlayers-1;]
         if string("c_", i) in keys(nc)
-            c[i+1, :] = trsp ? Float64.(permutedims(nc[string("c_", i)][:])[inds]) :
+            c[i+1, :] =
+                trsp ? Float64.(permutedims(nc[string("c_", i)][:])[inds]) :
                 Float64.(nc[string("c_", i)][:][inds])
         else
-            @warn(string("c_", i, " not found, set to default value ", dparams["c"]))
+            @warn(string(
+                "c_",
+                i,
+                " not found, set to default value ",
+                dparams["c"],
+            ))
         end
         if string("KsatVerFrac_", i) in keys(nc)
-            kvfrac[i+1, :] =
-                trsp ? Float64.(permutedims(nc[string("KsatVerFrac_", i)][:])[inds]) :
+            kvfrac[i+1, :] = trsp ?
+                Float64.(permutedims(nc[string("KsatVerFrac_", i)][:])[inds]) :
                 Float64.(nc[string("KsatVerFrac_", i)][:][inds])
         else
             @warn(string(
@@ -130,7 +146,8 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     # cmax, e_r, canopygapfraction only required when lai climatoly not provided
     cmax = readnetcdf(nc, "Cmax", inds, dparams, transp = trsp)
     e_r = readnetcdf(nc, "EoverR", inds, dparams, transp = trsp)
-    canopygapfraction = readnetcdf(nc, "CanopyGapFraction", inds, dparams, transp = trsp)
+    canopygapfraction =
+        readnetcdf(nc, "CanopyGapFraction", inds, dparams, transp = trsp)
 
     # if lai climatology provided use sl, swood and kext to calculate cmax
     if isnothing(leafarea_path) == false
@@ -158,9 +175,8 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
 
         xl[i] = sizeinmetres ? cellength : lattometres(y[i])[1] * cellength
         yl[i] = sizeinmetres ? cellength : lattometres(y[i])[2] * cellength
-        riverfrac[i] =
-            Bool(river[i]) ? min((riverlength[i] * riverwidth[i]) / (xl[i] * yl[i]), 1.0) :
-            0.0
+        riverfrac[i] = Bool(river[i]) ?
+            min((riverlength[i] * riverwidth[i]) / (xl[i] * yl[i]), 1.0) : 0.0
 
         nlayers[i] = nlayers_
         act_thickl[:, i] = act_thickl_
@@ -327,8 +343,12 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
         soilevap = fill(mv, n),
         # Actual evaporation from saturated store (transpiration and soil evaporation) [mm]
         actevapsat = fill(mv, n),
-        # Total actual evaporation (transpiration + soil evapation + open water evaporation) [mm]
+        # Total actual evapotranspiration [mm]
         actevap = fill(mv, n),
+        # Runoff from river based on riverfrac [mm]
+        runoff_river = fill(mv, n),
+        # Runoff from land based on waterfrac [mm]
+        runoff_land = fill(mv, n),
         # Actual evaporation from open water (land) [mm]
         ae_openw_l = fill(mv, n),
         # Actual evaporation from river [mm]
@@ -377,7 +397,8 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
 
     # lateral part sbm
     khfrac = readnetcdf(nc, "KsatHorFrac", inds, dparams, transp = trsp)
-    βₗ = trsp ? Float64.(permutedims(nc["Slope"][:])[inds]) : Float64.(nc["Slope"][:][inds])
+    βₗ = trsp ? Float64.(permutedims(nc["Slope"][:])[inds]) :
+        Float64.(nc["Slope"][:][inds])
     ldd_2d = trsp ? permutedims(nc["wflow_ldd"][:]) : nc["wflow_ldd"][:]
     ldd = ldd_2d[inds]
     kh₀ = khfrac .* kv₀
@@ -434,8 +455,8 @@ function initialize_sbm_model(staticmaps_path, leafarea_path)
     starttime = DateTime(2000, 1, 1)
 
     model = Model(
-        [dag, dag_riv],
-        [ssf, olf, rf],
+        (land = dag, river = dag_riv),
+        (subsurface = ssf, land = olf, river = rf),
         sbm,
         Clock(starttime, 1, Δt),
         nothing,

--- a/src/subsurface_flow.jl
+++ b/src/subsurface_flow.jl
@@ -28,7 +28,7 @@ function statenames(::Type{LateralSSF})
 
 end
 
-function update(ssf::LateralSSF, dag, toposort, n)
+function update(ssf::LateralSSF, dag, toposort)
     for v in toposort
         upstream_nodes = inneighbors(dag, v)
         ssfin = isempty(upstream_nodes) ? 0.0 : sum(ssf.ssf[i] for i in upstream_nodes)

--- a/src/subsurface_flow.jl
+++ b/src/subsurface_flow.jl
@@ -3,7 +3,7 @@ Base.@kwdef struct LateralSSF{T}
     f::Vector{T}                            # A scaling parameter [mm⁻¹] (controls exponential decline of kh₀)
     soilthickness::Vector{T}                # Soil thickness [mm]
     θₑ::Vector{T}                           # Effective porosity [-]
-    Δt::T                                   # model time step [s]
+    Δt::T                                   # model time step
     βₗ::Vector{T}                           # Slope [m m⁻¹]
     dl::Vector{T}                           # Drain length [mm]
     dw::Vector{T}                           # Flow width [mm]
@@ -13,6 +13,7 @@ Base.@kwdef struct LateralSSF{T}
     ssf::Vector{T} =
         ((kh₀ .* βₗ) ./ f) .* (exp.(-f .* zi) - exp.(-f .* soilthickness)) .* dw    # Subsurface flow [mm³ Δt⁻¹]
     ssfmax::Vector{T} = ((kh₀ .* βₗ) ./ f) .* (1.0 .- exp.(-f .* soilthickness))     # Maximum subsurface flow [mm² Δt⁻¹]
+    to_river::Vector{T} = zeros(length(f))
 end
 
 """
@@ -28,10 +29,17 @@ function statenames(::Type{LateralSSF})
 
 end
 
-function update(ssf::LateralSSF, dag, toposort)
+function update(ssf::LateralSSF, dag, toposort, frac_toriver, river)
     for v in toposort
         upstream_nodes = inneighbors(dag, v)
-        ssfin = isempty(upstream_nodes) ? 0.0 : sum(ssf.ssf[i] for i in upstream_nodes)
+        if Bool(river[v])
+            ssfin = isempty(upstream_nodes) ? 0.0 :
+                sum(ssf.ssf[i] * (1.0 - frac_toriver[i]) for i in upstream_nodes)
+            ssf.to_river[v] = isempty(upstream_nodes) ? 0.0 :
+                sum(ssf.ssf[i] * frac_toriver[i] for i in upstream_nodes)
+        else
+            ssfin = isempty(upstream_nodes) ? 0.0 : sum(ssf.ssf[i] for i in upstream_nodes)
+        end
         ssf.ssf[v], ssf.zi[v], ssf.exfiltwater[v] = kinematic_wave_ssf(
             ssfin,
             ssf.ssf[v],

--- a/src/subsurface_flow.jl
+++ b/src/subsurface_flow.jl
@@ -3,7 +3,7 @@ Base.@kwdef struct LateralSSF{T}
     f::Vector{T}                            # A scaling parameter [mm⁻¹] (controls exponential decline of kh₀)
     soilthickness::Vector{T}                # Soil thickness [mm]
     θₑ::Vector{T}                           # Effective porosity [-]
-    Δt::T                                   # model time step
+    Δt::T=1.0                               # model time step
     βₗ::Vector{T}                           # Slope [m m⁻¹]
     dl::Vector{T}                           # Drain length [mm]
     dw::Vector{T}                           # Flow width [mm]
@@ -13,7 +13,7 @@ Base.@kwdef struct LateralSSF{T}
     ssf::Vector{T} =
         ((kh₀ .* βₗ) ./ f) .* (exp.(-f .* zi) - exp.(-f .* soilthickness)) .* dw    # Subsurface flow [mm³ Δt⁻¹]
     ssfmax::Vector{T} = ((kh₀ .* βₗ) ./ f) .* (1.0 .- exp.(-f .* soilthickness))     # Maximum subsurface flow [mm² Δt⁻¹]
-    to_river::Vector{T} = zeros(length(f))
+    to_river::Vector{T} = zeros(length(f))  # Part of subsurface flow [mm³ Δt⁻¹] that flows to the river
 end
 
 """

--- a/src/surface_flow.jl
+++ b/src/surface_flow.jl
@@ -2,17 +2,17 @@ Base.@kwdef struct SurfaceFlow{T}
     β::T = 0.6                              # constant in Manning's equation
     sl::Vector{T}                           # Slope [m m⁻¹]
     n::Vector{T}                            # Manning's roughness [sl m⁻⅓]
-    dcl::Vector{T}                          # Drain length [m]
+    dl::Vector{T}                           # Drain length [m]
     q::Vector{T} = fill(0.0, length(sl))    # Discharge [m³ s⁻¹]
     q_av::Vector{T} = fill(0.0, length(sl)) # Average discharge [m³ s⁻¹]
     qlat::Vector{T} = fill(0.0, length(sl)) # Lateral discharge [m³ s⁻¹]
     h::Vector{T} = fill(0.0, length(sl))    # Water level [m]
     h_av::Vector{T} = fill(0.0, length(sl)) # Average water level [m]
     Δt::T                                   # Model time step [s]
-    riverwidth::Vector{T}                   # River width [m]
+    width::Vector{T}                        # Flow width [m]
     alpha_term::Vector{T} = pow.(n ./ sqrt.(sl), β)
     alpha_pow::T = (2.0 / 3.0) * β
-    α::Vector{T} = alpha_term .* pow.(riverwidth .+ 2.0 .* h, alpha_pow) # constant in Manning's equation
+    α::Vector{T} = alpha_term .* pow.(width .+ 2.0 .* h, alpha_pow) # constant in Manning's equation
     eps::T = 1e-03
     cel::Vector{T} = fill(0.0, length(sl))
 end

--- a/src/surface_flow.jl
+++ b/src/surface_flow.jl
@@ -1,0 +1,96 @@
+Base.@kwdef struct SurfaceFlow{T}
+    β::T = 0.6                              # constant in Manning's equation
+    sl::Vector{T}                           # Slope [m m⁻¹]
+    n::Vector{T}                            # Manning's roughness [sl m⁻⅓]
+    dcl::Vector{T}                          # Drain length [m]
+    q::Vector{T} = fill(0.0, length(sl))    # Discharge [m³ s⁻¹]
+    q_av::Vector{T} = fill(0.0, length(sl)) # Average discharge [m³ s⁻¹]
+    qlat::Vector{T} = fill(0.0, length(sl)) # Lateral discharge [m³ s⁻¹]
+    h::Vector{T} = fill(0.0, length(sl))    # Water level [m]
+    h_av::Vector{T} = fill(0.0, length(sl)) # Average water level [m]
+    Δt::T                                   # Model time step [s]
+    riverwidth::Vector{T}                   # River width [m]
+    alpha_term::Vector{T} = pow.(n ./ sqrt.(sl), β)
+    alpha_pow::T = (2.0 / 3.0) * β
+    α::Vector{T} = alpha_term .* pow.(riverwidth .+ 2.0 .* h, alpha_pow) # constant in Manning's equation
+    eps::T = 1e-03
+    cel::Vector{T} = fill(0.0, length(sl))
+end
+
+
+"""
+    statenames(::Type{SurfaceFlow})
+
+Returns Array{Symbol,1} for extracting model state fields.
+"""
+function statenames(::Type{SurfaceFlow})
+
+    states = [:q, :h]
+    # TODO: (warm) states read from netcdf file or cold state (reinit=1, setting in ini file)
+
+end
+
+function update(
+    sf::SurfaceFlow,
+    dag,
+    toposort,
+    n;
+    do_iter = false,
+    do_tstep = false,
+    ts = 1,
+)
+
+    if do_iter
+        if do_tstep
+            ts = ceil(Int(sf.Δt / tstep))
+        else
+            sf.cel[sf.q>0.0] =
+                1.0 ./
+                (sf.α[sf.q>0.0] .* sf.β * pow.(sf.q[sf.q>0.0], (sf.β - 1.0)))
+            courant = (sf.Δt ./ sf.dcl) .* sf.cel
+            ts = ceil(Int, (1.25 * quantile!(courant, 0.95)))
+        end
+    end
+
+    adt = sf.Δt / ts
+
+    q_sum = zeros(n)
+    h_sum = zeros(n)
+    for _ = 1:ts
+        for v in toposort
+            upstream_nodes = inneighbors(dag, v)
+            qin = isempty(upstream_nodes) ? 0.0 :
+                sum(sf.q[i] for i in upstream_nodes)
+            sf.q[v] = kinematic_wave(
+                qin,
+                sf.q[v],
+                sf.qlat[v],
+                sf.α[v],
+                sf.β,
+                adt,
+                sf.dcl[v],
+            )
+
+            # update alpha
+            crossarea = sf.α[v] * pow(sf.q[v], sf.β)
+            sf.h[v] = crossarea / sf.riverwidth[v]
+            wetper = sf.riverwidth[v] + (2.0 * sf.h[v]) # wetted perimeter
+            α = sf.α[v]
+            sf.α[v] = sf.alpha_term[v] * pow(wetper, sf.alpha_pow)
+
+            if abs(α - sf.α[v]) > sf.eps
+                crossarea = sf.α[v] * pow(sf.q[v], sf.β)
+                sf.h[v] = crossarea / sf.riverwidth[v]
+            end
+
+            q_sum[v] += sf.h[v]
+            h_sum[v] += sf.q[v]
+
+        end
+
+        sf.q_av = q_sum ./ ts
+        sf.h_av = h_sum ./ ts
+
+    end
+
+end

--- a/src/surface_flow.jl
+++ b/src/surface_flow.jl
@@ -52,7 +52,7 @@ function update(
                 end
             end
             courant = (sf.Δt ./ sf.dl) .* sf.cel
-            ts = max(ceil(Int, (1.25 * quantile!(courant, 0.95))),1)
+            ts = max(ceil(Int, (1.25 * quantile!(courant, 0.95))), 1)
         end
     end
 
@@ -63,17 +63,8 @@ function update(
     for _ = 1:ts
         for v in toposort
             upstream_nodes = inneighbors(dag, v)
-            qin = isempty(upstream_nodes) ? 0.0 :
-                sum(sf.q[i] for i in upstream_nodes)
-            sf.q[v] = kinematic_wave(
-                qin,
-                sf.q[v],
-                sf.qlat[v],
-                sf.α[v],
-                sf.β,
-                adt,
-                sf.dl[v],
-            )
+            qin = isempty(upstream_nodes) ? 0.0 : sum(sf.q[i] for i in upstream_nodes)
+            sf.q[v] = kinematic_wave(qin, sf.q[v], sf.qlat[v], sf.α[v], sf.β, adt, sf.dl[v])
 
             # update alpha
             crossarea = sf.α[v] * pow(sf.q[v], sf.β)

--- a/src/surface_flow.jl
+++ b/src/surface_flow.jl
@@ -10,12 +10,12 @@ Base.@kwdef struct SurfaceFlow{T}
     h_av::Vector{T} = fill(0.0, length(sl)) # Average water level [m]
     Δt::T                                   # Model time step [s]
     width::Vector{T}                        # Flow width [m]
-    alpha_term::Vector{T} = pow.(n ./ sqrt.(sl), β)
-    alpha_pow::T = (2.0 / 3.0) * β
-    α::Vector{T} = alpha_term .* pow.(width .+ 2.0 .* h, alpha_pow) # constant in Manning's equation
-    eps::T = 1e-03
-    cel::Vector{T} = fill(0.0, length(sl))
-    to_river::Vector{T} = fill(0.0, length(sl))
+    alpha_term::Vector{T} = pow.(n ./ sqrt.(sl), β)  # Constant part of α
+    alpha_pow::T = (2.0 / 3.0) * β          # Used in the power part of α
+    α::Vector{T} = alpha_term .* pow.(width .+ 2.0 .* h, alpha_pow) # Constant in momentum equation A = αQᵝ, based on Manning's equation
+    eps::T = 1e-03                          # Maximum allowed change in α, if exceeded cross sectional area and h is recalculated
+    cel::Vector{T} = fill(0.0, length(sl))  # Celerity of the kinematic wave
+    to_river::Vector{T} = fill(0.0, length(sl)) # Part of overland flow [m³ s⁻¹] that flows to the river
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -104,3 +104,12 @@ function svectorscopy(x::Matrix{T}, ::Val{N}) where {T,N}
     isbitstype(T) || error("use for bitstypes only")
     copy(reinterpret(SVector{N,T}, vec(x)))
 end
+
+function fraction_runoff_toriver(dag, index_river, slope, n)
+    frac = zeros(n)
+    for i in index_river
+        nbs = inneighbors(dag, i)
+        frac[nbs] = slope[i] ./ (slope[i] .+ slope[nbs])
+    end
+    return frac
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -79,7 +79,6 @@ end
 Determines the drainaige width for a non square grid. Input `ldd` (drainage network), `xl` (length of cells in x direction),
 `yl` (length of cells in y direction). Output is drainage width.
 """
-
 function detdrainwidth(ldd, xl, yl)
     # take into account non-square cells
     # if ldd is 8 or 2 use xlength
@@ -105,6 +104,12 @@ function svectorscopy(x::Matrix{T}, ::Val{N}) where {T,N}
     copy(reinterpret(SVector{N,T}, vec(x)))
 end
 
+"""
+    fraction_runoff_toriver(dag, index_river, slope, n)
+
+Determine ratio `frac` between slope river cell `index_river` and slope of each upstream neighbor (based on directed acyclic graph
+`dag`).
+"""
 function fraction_runoff_toriver(dag, index_river, slope, n)
     frac = zeros(n)
     for i in index_river

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -27,8 +27,7 @@ function update(model, toposort, n)
     return model
 end
 
-model =
-    Wflow.initialize_sbm_model(staticmaps_moselle_path, leafarea_moselle_path)
+model = Wflow.initialize_sbm_model(staticmaps_moselle_path, leafarea_moselle_path)
 toposort = Wflow.topological_sort_by_dfs(model.network.land)
 n = length(toposort)
 model = update(model, toposort, n)

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -92,6 +92,22 @@ end
     @test ssf[sink] ≈ 6.92054650606041e11
 end
 
+@testset "overland flow" begin
+    q = model.lateral.land.q_av
+    @test sum(q) ≈ 6.047157300328484
+    @test q[26625] ≈ 0.012407311034013137
+    @test q[39308] ≈ 0.05432182884369439
+    @test q[sink] ≈ 0.0
+end
+
+@testset "river flow" begin
+    q = model.lateral.river.q_av
+    @test sum(q) ≈ 634.3032031906259
+    @test q[4061] ≈ 2.8102258534693054
+    @test q[5617] ≈ 0.6945538314413997
+    @test q[toposort_river[end]] ≈ 0.004345249971296487
+end
+
 using BenchmarkTools, Juno
 
 benchmark = @benchmark update(


### PR DESCRIPTION
- added overland flow and river flow
- separate directed acyclic graph for river network from land network
- use of NamedTuples to distinguish between networks and lateral models in Model.jl

Now quite some arguments in update function of model (run_sbm.jl). Need to think a bit more if we want to do this differently, for example store this information as part of the sub-models? 

The river information (0=no river, 1=river) is now stored as part of the vertical model. Both overland flow and subsurface flow need this, to calculate the amount of flow to the river based on slope ratio (frac_toriver and function fraction_runoff_toriver). Mapping between different models now explicitly in model update function (units and grid cells (e.g. "index_river")). 