### PR TITLE
Graph pits

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -20,6 +20,14 @@ const basetimestep = Second(Day(1))
 # in case the input data is permuted the other way
 permute_indices(inds) = [CartesianIndex(i[2], i[1]) for i in inds]
 
+"Set at indices pit values (default = 5) in a gridded local drainage direction vector"
+function set_pit_ldd(pits_2d, ldd, indices; pit = 5)
+    pits = pits_2d[indices]
+    index = filter(i -> isequal(pits[i], true), 1:length(indices))
+    ldd[index] .= pit
+    return ldd
+end
+
 """
     active_indices(subcatch_2d, nodata)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,7 +26,7 @@ function testdata(version, source_filename, target_filename)
 end
 
 staticmaps_rhine_path = testdata(v"0.1", "staticmaps.nc", "staticmaps-rhine.nc")
-staticmaps_moselle_path = testdata(v"0.2", "staticmaps.nc", "staticmaps-moselle.nc")
+staticmaps_moselle_path = testdata(v"0.2.1", "staticmaps.nc", "staticmaps-moselle.nc")
 staticmaps_lahn_path = testdata(v"0.2", "staticmaps-lahn.nc", "staticmaps-lahn.nc")
 forcing_moselle_path = testdata(v"0.2", "forcing-2000.nc", "forcing-moselle.nc")
 forcing_lahn_path = testdata(v"0.2", "forcing-lahn.nc", "forcing-lahn.nc")


### PR DESCRIPTION
Pits can be added to the drainage network to get flow at the sub-catchment level (no flow between sub-catchments). Convenient for coupling wflow to a network model like RIBASIM.
Test had been added to run_sbm.jl.
Model type should be provided in the TOML config file.
