### PR TITLE
order of reducers for CSV writing

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -640,17 +640,7 @@ function prepare_writer(
         csv_cols = []
         for col in config.csv.column
             parameter = col["parameter"]
-            if occursin("river", col["parameter"])
-                reducer_func = reducer(
-                    col,
-                    rev_inds.river,
-                    x_nc,
-                    y_nc,
-                    dims_xy,
-                    config,
-                    nc_static,
-                )
-            elseif occursin("reservoir", col["parameter"])
+            if occursin("reservoir", col["parameter"])
                 reducer_func = reducer(
                     col,
                     rev_inds.reservoir,
@@ -664,6 +654,16 @@ function prepare_writer(
                 reducer_func = reducer(
                     col,
                     rev_inds.lake,
+                    x_nc,
+                    y_nc,
+                    dims_xy,
+                    config,
+                    nc_static,
+                )
+            elseif occursin("river", col["parameter"])
+                reducer_func = reducer(
+                    col,
+                    rev_inds.river,
                     x_nc,
                     y_nc,
                     dims_xy,

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -139,14 +139,14 @@ element rather than all at once.
 """
 function update(res::SimpleReservoir, i, inflow, timestepsecs)
 
-    vol = (
+    vol = max(0.0, (
         res.volume[i] +
         (inflow * timestepsecs) +
         (res.precipitation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
         res.area[i] -
         (res.evaporation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
         res.area[i]
-    )
+    ))
 
     percfull = vol / res.maxvolume[i]
     # first determine minimum (environmental) flow using a simple sigmoid curve to scale for target level


### PR DESCRIPTION
changed the order of reducer components. this is now in line with function active_indices(network, key::Tuple). because reservoir and lake parameters also contain "river" in the parameter name, these parameters should be handled first.