### PR TITLE
recharge rate

### DIFF
--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -426,7 +426,8 @@ function update_sbm_gwf(model)
 
     Q = zeros(vertical.n)
     # exchange of recharge between vertical sbm concept and groundwater flow domain
-    lateral.subsurface.recharge.rate .= vertical.recharge ./ 1000.0
+    # recharge rate groundwater [m d⁻¹]
+    lateral.subsurface.recharge.rate .= vertical.recharge ./ 1000.0 .* (1.0/Δt_sbm)
     # update groundwater domain
     update(lateral.subsurface.flow, Q, Δt_sbm)
     


### PR DESCRIPTION
to convert recharge SBM [mm/ timestep SBM] to [m/day] (recharge rate groundwater) correctly, requires also scaling by timestep SBM