### PR TITLE
reservoir inflow

### DIFF
--- a/src/flow.jl
+++ b/src/flow.jl
@@ -69,7 +69,12 @@ function update(
 
     q_sum = zeros(n)
     h_sum = zeros(n)
-    sf.to_river .= 0.0 
+    sf.to_river .= 0.0
+    # because of possible iterations set reservoir inflow at start to zero, the total sum of
+    # inflow at each sub time step is calculated
+    if !isnothing(sf.reservoir)
+        sf.reservoir.inflow .= 0.0
+    end 
 
     for _ = 1:its
         for v in order
@@ -86,7 +91,6 @@ function update(
                         upstream_excl_pits,
                         eltype(sf.q),
                     )
-                    # TODO: if in a loop should also take average!!!
                     sf.to_river[v] += sum_at(
                         i -> sf.q[i] * frac_toriver[i],
                         upstream_excl_pits,

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -164,7 +164,7 @@ function update(res::SimpleReservoir, i, inflow, timestepsecs)
 
     # update values in place
     res.outflow[i] = outflow / timestepsecs
-    res.inflow[i] = inflow
+    res.inflow[i] += inflow * timestepsecs
     res.demandrelease[i] = demandrelease / timestepsecs
     res.percfull[i] = percfull
     res.volume[i] = vol

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -94,7 +94,7 @@ end
 @testset "reservoir simple" begin
     res = model.lateral.river.reservoir
     @test res.outflow[2] ≈ 0.2174998592483153
-    @test res.inflow[2] ≈ 0.00022354279860698295
+    @test res.inflow[2] ≈ 13.458065150960186
     @test res.volume[2] ≈  2.776155238441744e7
     @test res.precipitation[2] ≈ 0.1765228509902954
     @test res.evaporation[2] ≈ 0.5372688174247742


### PR DESCRIPTION
Reservoir inflow did not have correct units [m3/s]. Calculate reservoir inflow [m3] as total sum during model time step, with or without iterations kinematic wave.