### PR TITLE
run JuliaFormatter on all code

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,10 +5,7 @@ pages = [
     "Home" => "index.md",
     "Quick start" => "quick-start.md",
     "Model structure" => "structure.md",
-    "Models" => [
-        "wflow_sbm" => "model/sbm.md",
-        "wflow_hbv" => "model/hbv.md",
-    ],
+    "Models" => ["wflow_sbm" => "model/sbm.md", "wflow_hbv" => "model/hbv.md"],
     "Vertical components" => [
         "SBM" => "vertical/sbm.md",
         "HBV" => "vertical/hbv.md",
@@ -32,7 +29,7 @@ makedocs(;
         canonical = "https://deltares.github.io/Wflow.jl",
         assets = String[],
     ),
-    pages = pages
+    pages = pages,
 )
 
 deploydocs(; repo = "github.com/Deltares/Wflow.jl")

--- a/docs/src/lateral/gwf.md
+++ b/docs/src/lateral/gwf.md
@@ -96,6 +96,7 @@ head [L] of the head boundary and  ``\phi`` the head of the aquifer cell.
 A volumetric well rate [L``^3`` T``^{-1}``] can be specified as a boundary condition.
 
 
-!!! note For an unconfined aquifer the boundary fluxes are checked, in case of a dry aquifer
-    cell a negative flux is not allowed.
+!!! note 
+    For an unconfined aquifer the boundary fluxes are checked, in case of a dry aquifer cell
+    a negative flux is not allowed.
 

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -92,7 +92,7 @@ function run_simulation(config::Config)
     else
         error("unknown model type")
     end
-    
+
     run_simulation(model)
 end
 

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -2,23 +2,18 @@
 # https://github.com/Deltares/BasicModelInterface.jl
 
 # BMI grid type based on grid identifier
-const gridtype = Dict{Int, String}(
+const gridtype = Dict{Int,String}(
     0 => "unstructured",
     1 => "unstructured",
     2 => "unstructured",
     3 => "unstructured",
-    4 => "unstructured"
+    4 => "unstructured",
 )
 
 # Mapping of grid identifier to a key, to get the active indices of the model domain.
 # See also function active_indices(network, key::Tuple).
-const grids = Dict{Int, String}(
-    0 => "reservoir",
-    1 => "lake",
-    2 => "river",
-    3 => "drain",
-    4 => "land"
-)
+const grids =
+    Dict{Int,String}(0 => "reservoir", 1 => "lake", 2 => "river", 3 => "drain", 4 => "land")
 
 """
     BMI.initialize(::Type{<:Wflow.Model}, config_file)
@@ -55,7 +50,7 @@ function BMI.update_until(model::Model, time::Float64)
     n_iter = Int(max(0, (time - curtime) / model.clock.Δt.value))
     end_time = curtime + n_iter * config.timestepsecs
     @info("update model until $end_time")
-    for i in 1:n_iter
+    for i = 1:n_iter
         update_func(model)
     end
     return model
@@ -92,10 +87,13 @@ exchanged.
 """
 function BMI.get_input_var_names(model::Model)
     @unpack config = model
-    if haskey(config,"API")
+    if haskey(config, "API")
         var_names = Vector{String}()
         for c in config.API.components
-            append!(var_names, collect(string.(c,".", fieldnames(typeof(param(model, c))))))
+            append!(
+                var_names,
+                collect(string.(c, ".", fieldnames(typeof(param(model, c))))),
+            )
         end
         return var_names
     else
@@ -129,12 +127,12 @@ function BMI.get_var_grid(model::Model, name::String)
 end
 
 function BMI.get_var_type(model::Model, name::String)
-    string(typeof(param(model,name)))
+    string(typeof(param(model, name)))
 end
 
 function BMI.get_var_units(model::Model, name::String)
     s = split(name, ".")
-    get_units(param(model,join(s[1:end-1], ".")), Symbol(s[end]))
+    get_units(param(model, join(s[1:end-1], ".")), Symbol(s[end]))
 end
 
 function BMI.get_var_itemsize(model::Model, name::String)
@@ -200,7 +198,7 @@ end
 Set a model variable `name` to the values in vector `src`, overwriting the current contents.
 The type and size of `src` must match the model’s internal array.
 """
-function BMI.set_value(model::Model, name::String, src::Vector{T}) where T<:AbstractFloat
+function BMI.set_value(model::Model, name::String, src::Vector{T}) where {T<:AbstractFloat}
     BMI.get_value_ptr(model, name) .= src
 end
 
@@ -210,7 +208,12 @@ end
 
     Set a model variable `name` to the values in vector `src`, at indices `inds`.
 """
-function BMI.set_value_at_indices(model::Model, name::String, inds::Vector{Int}, src::Vector{T}) where T<:AbstractFloat
+function BMI.set_value_at_indices(
+    model::Model,
+    name::String,
+    inds::Vector{Int},
+    src::Vector{T},
+) where {T<:AbstractFloat}
     BMI.get_value_ptr(model, name)[inds] .= src
 end
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -31,7 +31,7 @@
     # end
 end
 
-statevars(::SurfaceFlow) = (:q,:h,:h_av,)
+statevars(::SurfaceFlow) = (:q, :h, :h_av)
 
 function update(
     sf::SurfaceFlow,
@@ -57,7 +57,7 @@ function update(
                     courant[v] = (sf.Δt / sf.dl[v]) * sf.cel[v]
                 end
             end
-            filter!(x->x≠0.0,courant)
+            filter!(x -> x ≠ 0.0, courant)
             its = isempty(courant) ? 1 : ceil(Int, (1.25 * quantile!(courant, 0.95)))
         end
     else
@@ -102,7 +102,7 @@ function update(
                         eltype(sf.to_river),
                     )
                 elseif river[v] && sf.wb_pit[v] && sf.width[v] == 0.0
-                    sf.to_river[v]  += sum_at(sf.q, upstream_nodes)
+                    sf.to_river[v] += sum_at(sf.q, upstream_nodes)
                     qin = 0.0
                 else
                     qin = sum_at(sf.q, upstream_nodes)
@@ -165,7 +165,7 @@ end
     exfiltwater::Vector{T}                  # Exfiltration [mm]  (groundwater above surface level, saturated excess conditions)
     recharge::Vector{T}                     # Net recharge to saturated store [mm]
     ssf::Vector{T} | "mm3 Δt-1"             # Subsurface flow [mm³ Δt⁻¹]
-    ssfin::Vector{T} | "mm3 Δt-1" 
+    ssfin::Vector{T} | "mm3 Δt-1"
     ssfmax::Vector{T} | "mm2 Δt-1"          # Maximum subsurface flow [mm² Δt⁻¹]
     to_river::Vector{T} | "mm3 Δt-1"        # Part of subsurface flow [mm³ Δt⁻¹] that flows to the river
     wb_pit::Vector{Bool} | "-"              # Boolean location (0 or 1) of a waterbody (wb, reservoir or lake).

--- a/src/groundwater/aquifer.jl
+++ b/src/groundwater/aquifer.jl
@@ -173,7 +173,7 @@ function horizontal_conductance(
     nzi::Int,
     aquifer::A,
     connectivity::Connectivity,
-) where A <: Aquifer
+) where {A<:Aquifer}
     k1 = aquifer.k[i]
     k2 = aquifer.k[j]
     H1 = aquifer.top[i] - aquifer.bottom[i]
@@ -191,12 +191,13 @@ Conductance for a confined aquifer is constant, and only has to be set once.
 For an unconfined aquifer, conductance is computed per timestep by multiplying by
 degree of saturation [0.0 - 1.0].
 """
-function initialize_conductance!(aquifer::A, connectivity::Connectivity) where A <: Aquifer
-    for i in 1:connectivity.ncell
+function initialize_conductance!(aquifer::A, connectivity::Connectivity) where {A<:Aquifer}
+    for i = 1:connectivity.ncell
         # Loop over connections for cell j
         for nzi in connections(connectivity, i)
             j = connectivity.rowval[nzi]
-            aquifer.conductance[nzi] = horizontal_conductance(i, j, nzi, aquifer, connectivity)
+            aquifer.conductance[nzi] =
+                horizontal_conductance(i, j, nzi, aquifer, connectivity)
         end
     end
 end
@@ -246,7 +247,7 @@ end
 
 
 function flux!(Q, aquifer, connectivity)
-    for i in 1:connectivity.ncell
+    for i = 1:connectivity.ncell
         # Loop over connections for cell j
         for nzi in connections(connectivity, i)
             # connection from i -> j
@@ -277,7 +278,9 @@ The following criterion can be found in Chu & Willis (1984)
 function stable_timestep(aquifer)
     Δtₘᵢₙ = Inf
     for i in eachindex(aquifer.head)
-        Δt = aquifer.area[i] * storativity(aquifer)[i] / (aquifer.k[i] * saturated_thickness(aquifer, i))
+        Δt =
+            aquifer.area[i] * storativity(aquifer)[i] /
+            (aquifer.k[i] * saturated_thickness(aquifer, i))
         Δtₘᵢₙ = Δt < Δtₘᵢₙ ? Δt : Δtₘᵢₙ
     end
     return 0.25 * Δtₘᵢₙ
@@ -303,17 +306,18 @@ function update(gwf, Q, Δt)
 end
 
 
-Base.@kwdef struct GroundwaterFlow{A, B}
+Base.@kwdef struct GroundwaterFlow{A,B}
     aquifer::A
     connectivity::Connectivity
     constanthead::ConstantHead
     boundaries::Vector{B}
     function GroundwaterFlow(
-            aquifer::A,
-            connectivity,
-            constanthead,
-            boundaries::Vector{B}) where {A <: Aquifer, B <: AquiferBoundaryCondition}
+        aquifer::A,
+        connectivity,
+        constanthead,
+        boundaries::Vector{B},
+    ) where {A<:Aquifer,B<:AquiferBoundaryCondition}
         initialize_conductance!(aquifer, connectivity)
-        new{A, B}(aquifer, connectivity, constanthead, boundaries)
-    end 
+        new{A,B}(aquifer, connectivity, constanthead, boundaries)
+    end
 end

--- a/src/groundwater/boundary_conditions.jl
+++ b/src/groundwater/boundary_conditions.jl
@@ -10,7 +10,7 @@ end
 
 
 # Do nothing for a confined aquifer: aquifer can always provide flux
-check_flux(flux, aquifer::ConfinedAquifer, index::Int) = flux 
+check_flux(flux, aquifer::ConfinedAquifer, index::Int) = flux
 
 
 @get_units struct River{T} <: AquiferBoundaryCondition
@@ -39,8 +39,8 @@ function flux!(Q, river::River, aquifer)
     end
     return Q
 end
-            
-        
+
+
 @get_units struct Drainage{T} <: AquiferBoundaryCondition
     elevation::Vector{T}
     conductance::Vector{T}
@@ -88,7 +88,8 @@ end
 
 function flux!(Q, recharge::Recharge, aquifer)
     for (i, index) in enumerate(recharge.index)
-        recharge.flux[i] = check_flux(recharge.rate[i] * aquifer.area[index], aquifer, index)
+        recharge.flux[i] =
+            check_flux(recharge.rate[i] * aquifer.area[index], aquifer, index)
         Q[index] += recharge.flux[i]
     end
     return Q

--- a/src/groundwater/connectivity.jl
+++ b/src/groundwater/connectivity.jl
@@ -35,7 +35,7 @@ end
 
 Returns connections for a single cell, identified by ``id``.
 """
-connections(C::Connectivity, id::Int) = C.colptr[id]:(C.colptr[id + 1] - 1)
+connections(C::Connectivity, id::Int) = C.colptr[id]:(C.colptr[id+1]-1)
 
 
 """
@@ -69,7 +69,7 @@ const neighbors = [
 ]
 
 # Constructor for the Connectivity structure for structured input
-function Connectivity(indices, reverse_indices, Δx::Vector{T}, Δy::Vector{T}) where T
+function Connectivity(indices, reverse_indices, Δx::Vector{T}, Δy::Vector{T}) where {T}
     # indices: These map from the 1D internal domain to the 2D external domain.
     # reverse_indices: from the 2D external domain to the 1D internal domain,
     # providing an Int which can be used as a linear index
@@ -92,9 +92,7 @@ function Connectivity(indices, reverse_indices, Δx::Vector{T}, Δy::Vector{T}) 
             J = I + neighbor
             if (1 <= J[1] <= nrow) && (1 <= J[2] <= ncol && reverse_indices[J] != 0) # Check if it's inbounds and neighbor is active
                 rowval[i] = reverse_indices[J]
-                length1[i], length2[i], width[i] = connection_geometry(
-                    I, J, Δx, Δy
-                )
+                length1[i], length2[i], width[i] = connection_geometry(I, J, Δx, Δy)
                 i += 1
             end
         end

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -38,13 +38,14 @@ function initialize_hbv_model(config::Config)
     inds, rev_inds = active_indices(subcatch_2d, missing)
     n = length(inds)
 
-    cfmax = ncread(
-        nc,
-        param(config, "input.vertical.cfmax", nothing);
-        sel = inds,
-        defaults = 3.75653,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    cfmax =
+        ncread(
+            nc,
+            param(config, "input.vertical.cfmax", nothing);
+            sel = inds,
+            defaults = 3.75653,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     tt = ncread(
         nc,
         param(config, "input.vertical.tt", nothing);
@@ -82,14 +83,15 @@ function initialize_hbv_model(config::Config)
         type = Float64,
         fill = 0.0,
     )
-    g_cfmax = ncread(
-        nc,
-        param(config, "input.vertical.g_cfmax", nothing);
-        sel = inds,
-        defaults = 3.0,
-        type = Float64,
-        fill = 0.0,
-    ).* (Δt / basetimestep)
+    g_cfmax =
+        ncread(
+            nc,
+            param(config, "input.vertical.g_cfmax", nothing);
+            sel = inds,
+            defaults = 3.0,
+            type = Float64,
+            fill = 0.0,
+        ) .* (Δt / basetimestep)
     g_sifrac = ncread(
         nc,
         param(config, "input.vertical.g_sifrac", nothing);
@@ -113,7 +115,7 @@ function initialize_hbv_model(config::Config)
         defaults = 5500.0,
         type = Float64,
         fill = 0.0,
-    )   
+    )
     fc = ncread(
         nc,
         param(config, "input.vertical.fc", nothing);
@@ -135,20 +137,22 @@ function initialize_hbv_model(config::Config)
         defaults = 0.53,
         type = Float64,
     )
-    k4 = ncread(
-        nc,
-        param(config, "input.vertical.k4", nothing);
-        sel = inds,
-        defaults = 0.02307,
-        type = Float64,
-    ) .* (Δt / basetimestep)
-    kquickflow = ncread(
-        nc,
-        param(config, "input.vertical.kquickflow", nothing);
-        sel = inds,
-        defaults = 0.09880,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    k4 =
+        ncread(
+            nc,
+            param(config, "input.vertical.k4", nothing);
+            sel = inds,
+            defaults = 0.02307,
+            type = Float64,
+        ) .* (Δt / basetimestep)
+    kquickflow =
+        ncread(
+            nc,
+            param(config, "input.vertical.kquickflow", nothing);
+            sel = inds,
+            defaults = 0.09880,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     suz = ncread(
         nc,
         param(config, "input.vertical.suz", nothing);
@@ -156,27 +160,30 @@ function initialize_hbv_model(config::Config)
         defaults = 100.0,
         type = Float64,
     )
-    k0 = ncread(
-        nc,
-        param(config, "input.vertical.k0", nothing);
-        sel = inds,
-        defaults = 0.30,
-        type = Float64,
-    ) .* (Δt / basetimestep)
-    khq = ncread(
-        nc,
-        param(config, "input.vertical.khq", nothing);
-        sel = inds,
-        defaults = 0.09880,
-        type = Float64,
-    ) .* (Δt / basetimestep)
-    hq = ncread(
-        nc,
-        param(config, "input.vertical.hq", nothing);
-        sel = inds,
-        defaults = 3.27,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    k0 =
+        ncread(
+            nc,
+            param(config, "input.vertical.k0", nothing);
+            sel = inds,
+            defaults = 0.30,
+            type = Float64,
+        ) .* (Δt / basetimestep)
+    khq =
+        ncread(
+            nc,
+            param(config, "input.vertical.khq", nothing);
+            sel = inds,
+            defaults = 0.09880,
+            type = Float64,
+        ) .* (Δt / basetimestep)
+    hq =
+        ncread(
+            nc,
+            param(config, "input.vertical.hq", nothing);
+            sel = inds,
+            defaults = 3.27,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     alphanl = ncread(
         nc,
         param(config, "input.vertical.alphanl", nothing);
@@ -184,13 +191,14 @@ function initialize_hbv_model(config::Config)
         defaults = 1.1,
         type = Float64,
     )
-    perc = ncread(
-        nc,
-        param(config, "input.vertical.perc", nothing);
-        sel = inds,
-        defaults = 0.4,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    perc =
+        ncread(
+            nc,
+            param(config, "input.vertical.perc", nothing);
+            sel = inds,
+            defaults = 0.4,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     cfr = ncread(
         nc,
         param(config, "input.vertical.cfr", nothing);
@@ -219,13 +227,14 @@ function initialize_hbv_model(config::Config)
         defaults = 1.0,
         type = Float64,
     )
-    cflux = ncread(
-        nc,
-        param(config, "input.vertical.cflux", nothing);
-        sel = inds,
-        defaults = 2.0,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    cflux =
+        ncread(
+            nc,
+            param(config, "input.vertical.cflux", nothing);
+            sel = inds,
+            defaults = 2.0,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     icf = ncread(
         nc,
         param(config, "input.vertical.icf", nothing);
@@ -267,7 +276,7 @@ function initialize_hbv_model(config::Config)
 
     xl = fill(mv, n)
     yl = fill(mv, n)
-    for i=1:n
+    for i = 1:n
         xl[i] = sizeinmetres ? cellength : lattometres(y[i])[1] * cellength
         yl[i] = sizeinmetres ? cellength : lattometres(y[i])[2] * cellength
     end
@@ -275,10 +284,10 @@ function initialize_hbv_model(config::Config)
     threshold = fc .* lp
 
     altitude =
-    ncread(nc, param(config, "input.vertical.altitude"); sel = inds, type = Float64)
+        ncread(nc, param(config, "input.vertical.altitude"); sel = inds, type = Float64)
 
     hbv = HBV{Float64}(
-        Δt =tosecond(Δt),
+        Δt = tosecond(Δt),
         n = n,
         yl = yl,
         xl = xl,
@@ -288,9 +297,10 @@ function initialize_hbv_model(config::Config)
         lp = lp,
         threshold = threshold,
         k4 = k4,
-        kquickflow = set_kquickflow ? kquickflow : pow.(khq, 1.0 .+ alphanl) .* pow.(hq, -alphanl),
+        kquickflow = set_kquickflow ? kquickflow :
+                     pow.(khq, 1.0 .+ alphanl) .* pow.(hq, -alphanl),
         suz = suz,
-        k0 = k0,              
+        k0 = k0,
         khq = khq,
         hq = hq,
         alphanl = alphanl,
@@ -326,20 +336,20 @@ function initialize_hbv_model(config::Config)
         precipitation = fill(mv, n),
         temperature = fill(mv, n),
         potential_evaporation = fill(mv, n),
-        potsoilevap = fill(mv, n),            
-        soilevap = fill(mv, n),               
-        intevap = fill(mv, n),                
-        actevap = fill(mv, n),                
-        rainfallplusmelt = fill(mv, n),       
-        directrunoff = fill(mv, n),           
-        hbv_seepage = fill(mv, n),            
-        in_upperzone = fill(mv, n),           
-        quickflow = fill(mv, n),              
-        real_quickflow = fill(mv, n),         
-        percolation = fill(mv, n),            
-        capflux = fill(mv, n),                
-        baseflow = fill(mv, n),               
-        runoff = fill(mv, n),    
+        potsoilevap = fill(mv, n),
+        soilevap = fill(mv, n),
+        intevap = fill(mv, n),
+        actevap = fill(mv, n),
+        rainfallplusmelt = fill(mv, n),
+        directrunoff = fill(mv, n),
+        hbv_seepage = fill(mv, n),
+        in_upperzone = fill(mv, n),
+        quickflow = fill(mv, n),
+        real_quickflow = fill(mv, n),
+        percolation = fill(mv, n),
+        capflux = fill(mv, n),
+        baseflow = fill(mv, n),
+        runoff = fill(mv, n),
     )
 
     modelsize_2d = size(subcatch_2d)
@@ -355,24 +365,26 @@ function initialize_hbv_model(config::Config)
     inds_riv, rev_inds_riv = active_indices(river_2d, 0)
     nriv = length(inds_riv)
 
-     # reservoirs
-     pits = zeros(Bool, modelsize_2d)
-     if do_reservoirs
-         reservoirs, resindex, reservoir, pits = initialize_simple_reservoir(config, nc, inds_riv, nriv, pits)
-     else
-         reservoir = ()
-     end
- 
-     # lakes
-     if do_lakes
-         lakes, lakeindex, lake, pits = initialize_natural_lake(config, static_path, nc, inds_riv, nriv, pits)
-     else
-         lake = ()
-     end
+    # reservoirs
+    pits = zeros(Bool, modelsize_2d)
+    if do_reservoirs
+        reservoirs, resindex, reservoir, pits =
+            initialize_simple_reservoir(config, nc, inds_riv, nriv, pits)
+    else
+        reservoir = ()
+    end
 
-     ldd_2d = ncread(nc, param(config, "input.ldd"); allow_missing = true)
-     ldd = ldd_2d[inds]
-     if do_pits
+    # lakes
+    if do_lakes
+        lakes, lakeindex, lake, pits =
+            initialize_natural_lake(config, static_path, nc, inds_riv, nriv, pits)
+    else
+        lake = ()
+    end
+
+    ldd_2d = ncread(nc, param(config, "input.ldd"); allow_missing = true)
+    ldd = ldd_2d[inds]
+    if do_pits
         pits_2d = ncread(nc, param(config, "input.pits"); type = Bool, fill = false)
         ldd = set_pit_ldd(pits_2d, ldd, inds)
     end
@@ -400,11 +412,11 @@ function initialize_hbv_model(config::Config)
     h = fill(0.0, n)
     alpha_term = pow.(n_land ./ sqrt.(βₗ), β)
     olf = SurfaceFlow(
-        β = β, 
+        β = β,
         sl = βₗ,
         n = n_land,
         dl = dl,
-        q = fill(0.0, n),   
+        q = fill(0.0, n),
         q_av = fill(0.0, n),
         qlat = fill(0.0, n),
         h = h,
@@ -420,8 +432,8 @@ function initialize_hbv_model(config::Config)
         cel = fill(0.0, n),
         to_river = fill(0.0, n),
         rivercells = fill(false, n),
-        reservoir_index = fill(0, n), 
-        lake_index = fill(0, n),      
+        reservoir_index = fill(0, n),
+        lake_index = fill(0, n),
         reservoir = nothing,
         lake = nothing,
     )
@@ -458,17 +470,18 @@ function initialize_hbv_model(config::Config)
     h_river = fill(0.0, nriv)
     alpha_term = pow.(n_river ./ sqrt.(riverslope), β)
     rf = SurfaceFlow(
-        β = β, 
+        β = β,
         sl = riverslope,
         n = n_river,
         dl = riverlength,
-        q = fill(0.0, nriv),   
+        q = fill(0.0, nriv),
         q_av = fill(0.0, nriv),
         qlat = fill(0.0, nriv),
         h = h_river,
         h_av = fill(0.0, nriv),
         Δt = tosecond(Δt),
-        its = kw_river_tstep > 0 ? ceil(Int(tosecond(Δt) / kw_river_tstep)) : kw_river_tstep,
+        its = kw_river_tstep > 0 ? ceil(Int(tosecond(Δt) / kw_river_tstep)) :
+              kw_river_tstep,
         width = riverwidth,
         wb_pit = fill(false, nriv),
         alpha_term = alpha_term,
@@ -516,8 +529,12 @@ function initialize_hbv_model(config::Config)
         indices = inds,
         reverse_indices = rev_inds,
     )
-    river =
-        (graph = graph_riv, order = topological_sort_by_dfs(graph_riv), indices = inds_riv, reverse_indices = rev_inds_riv)
+    river = (
+        graph = graph_riv,
+        order = topological_sort_by_dfs(graph_riv),
+        indices = inds_riv,
+        reverse_indices = rev_inds_riv,
+    )
 
     model = Model(
         config,
@@ -528,15 +545,10 @@ function initialize_hbv_model(config::Config)
         reader,
         writer,
     )
-    
+
     # read and set states in model object if reinit=true
     if reinit == false
-        set_states(
-            instate_path,
-            model,
-            state_ncnames;
-            type = Float64,
-        )
+        set_states(instate_path, model, state_ncnames; type = Float64)
     end
 
     # make sure the forcing is already loaded
@@ -565,7 +577,11 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
             min.(0.5, lateral.land.sl ./ 5.67) .* min.(1.0, vertical.snow ./ 10000.0)
         maxflux = snowflux_frac .* vertical.snow
         vertical.snow .= accucapacityflux(network.land, vertical.snow, maxflux)
-        vertical.snowwater .= accucapacityflux(network.land, vertical.snowwater, vertical.snowwater .* snowflux_frac)
+        vertical.snowwater .= accucapacityflux(
+            network.land,
+            vertical.snowwater,
+            vertical.snowwater .* snowflux_frac,
+        )
     end
 
     update_after_snow(vertical, config)
@@ -582,8 +598,7 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
         do_iter = kinwave_it,
     )
 
-    lateral.river.qlat .=
-        (lateral.land.to_river[network.index_river]) ./ lateral.river.dl
+    lateral.river.qlat .= (lateral.land.to_river[network.index_river]) ./ lateral.river.dl
 
     update(lateral.river, network.river, do_iter = kinwave_it, doy = dayofyear(clock.time))
 

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -121,7 +121,7 @@ function initialize_simple_reservoir(config, nc, inds_riv, nriv, pits)
         area = resarea,
         targetfullfrac = res_targetfullfrac,
         targetminfrac = res_targetminfrac,
-        volume = res_targetfullfrac .* resmaxvolume, 
+        volume = res_targetfullfrac .* resmaxvolume,
         inflow = fill(mv, n),
         outflow = fill(mv, n),
         totaloutflow = fill(mv, n),
@@ -132,13 +132,13 @@ function initialize_simple_reservoir(config, nc, inds_riv, nriv, pits)
     )
 
     return reservoirs,
-        resindex,
-        (
-            indices_outlet = inds_res,
-            indices_coverage = inds_res_cov,
-            reverse_indices = rev_inds_reservoir,
-        ),
-        pits
+    resindex,
+    (
+        indices_outlet = inds_res,
+        indices_coverage = inds_res_cov,
+        reverse_indices = rev_inds_reservoir,
+    ),
+    pits
 end
 
 """
@@ -149,14 +149,17 @@ element rather than all at once.
 """
 function update(res::SimpleReservoir, i, inflow, timestepsecs)
 
-    vol = max(0.0, (
-        res.volume[i] +
-        (inflow * timestepsecs) +
-        (res.precipitation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
-        res.area[i] -
-        (res.evaporation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
-        res.area[i]
-    ))
+    vol = max(
+        0.0,
+        (
+            res.volume[i] +
+            (inflow * timestepsecs) +
+            (res.precipitation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
+            res.area[i] -
+            (res.evaporation[i] * (timestepsecs / tosecond(basetimestep)) / 1000.0) *
+            res.area[i]
+        ),
+    )
 
     percfull = vol / res.maxvolume[i]
     # first determine minimum (environmental) flow using a simple sigmoid curve to scale for target level
@@ -198,7 +201,7 @@ end
     storage::Vector{T} | "m3"               # storage lake [m³]
     outflow::Vector{T} | "m3 s-1"           # outflow lake [m³ s⁻¹]
     totaloutflow::Vector{T} | "m3"          # total outflow lake [m³] 
-    precipitation::Vector{T}    	        # average precipitation for lake area [mm]
+    precipitation::Vector{T}                # average precipitation for lake area [mm]
     evaporation::Vector{T}                  # average evaporation for lake area [mm]
 
     function NaturalLake{T}(args...) where {T}
@@ -323,15 +326,21 @@ function initialize_natural_lake(config, static_path, nc, inds_riv, nriv, pits)
         end
 
         if lake_storfunc[i] == 2
-            sh[i] =
-                CSV.read(joinpath(static_path, "lake_sh_$(lakelocs[i])"), DataFrame, type = Float64)
+            sh[i] = CSV.read(
+                joinpath(static_path, "lake_sh_$(lakelocs[i])"),
+                DataFrame,
+                type = Float64,
+            )
         else
             sh[i] = DataFrame()
         end
 
         if lake_outflowfunc[i] == 1
-            hq[i] =
-                CSV.read(joinpath(static_path, "lake_hq_$(lakelocs[i])"), DataFrame, type = Float64)
+            hq[i] = CSV.read(
+                joinpath(static_path, "lake_hq_$(lakelocs[i])"),
+                DataFrame,
+                type = Float64,
+            )
         else
             hq[i] = DataFrame()
         end

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -36,7 +36,7 @@
     # Cumulative sum of soil layers [mm], starting at soil surface (0)
     sumlayers::Vector{SVector{M,T}}
     # Infiltration capacity of the compacted areas [mm Δt⁻¹]
-    infiltcappath::Vector{T} | "mm Δt-1" 
+    infiltcappath::Vector{T} | "mm Δt-1"
     # Soil infiltration capacity [mm/Δt]
     infiltcapsoil::Vector{T} | "mm Δt-1"
     # Maximum leakage [mm/Δt] from saturated zone
@@ -211,7 +211,9 @@
     end
 end
 
-statevars(::SBM; snow=false) = snow ? (:satwaterdepth, :snow, :tsoil, :ustorelayerdepth, :snowwater, :canopystorage,) : (:satwaterdepth, :ustorelayerdepth, :canopystorage,)
+statevars(::SBM; snow = false) =
+    snow ? (:satwaterdepth, :snow, :tsoil, :ustorelayerdepth, :snowwater, :canopystorage) :
+    (:satwaterdepth, :ustorelayerdepth, :canopystorage)
 
 
 function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
@@ -229,15 +231,16 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
     n = length(inds)
 
     altitude =
-    ncread(nc, param(config, "input.vertical.altitude"); sel = inds, type = Float64)
+        ncread(nc, param(config, "input.vertical.altitude"); sel = inds, type = Float64)
 
-    cfmax = ncread(
-        nc,
-        param(config, "cfmax", nothing);
-        sel = inds,
-        defaults = 3.75653,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    cfmax =
+        ncread(
+            nc,
+            param(config, "cfmax", nothing);
+            sel = inds,
+            defaults = 3.75653,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     tt = ncread(
         nc,
         param(config, "input.vertical.tt", nothing);
@@ -266,13 +269,14 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         defaults = 0.1,
         type = Float64,
     )
-    w_soil = ncread(
-        nc,
-        param(config, "input.vertical.w_soil", nothing);
-        sel = inds,
-        defaults = 0.1125,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    w_soil =
+        ncread(
+            nc,
+            param(config, "input.vertical.w_soil", nothing);
+            sel = inds,
+            defaults = 0.1125,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     cf_soil = ncread(
         nc,
         param(config, "input.vertical.cf_soil", nothing);
@@ -289,14 +293,15 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         type = Float64,
         fill = 0.0,
     )
-    g_cfmax = ncread(
-        nc,
-        param(config, "input.vertical.g_cfmax", nothing);
-        sel = inds,
-        defaults = 3.0,
-        type = Float64,
-        fill = 0.0,
-    ).* (Δt / basetimestep)
+    g_cfmax =
+        ncread(
+            nc,
+            param(config, "input.vertical.g_cfmax", nothing);
+            sel = inds,
+            defaults = 3.0,
+            type = Float64,
+            fill = 0.0,
+        ) .* (Δt / basetimestep)
     g_sifrac = ncread(
         nc,
         param(config, "input.vertical.g_sifrac", nothing);
@@ -336,13 +341,14 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         defaults = 0.01,
         type = Float64,
     )
-    kv₀ = ncread(
-        nc,
-        param(config, "input.vertical.kv₀");
-        sel = inds,
-        defaults = 3000.0,
-        type = Float64,
-    ) .* (Δt / basetimestep)
+    kv₀ =
+        ncread(
+            nc,
+            param(config, "input.vertical.kv₀");
+            sel = inds,
+            defaults = 3000.0,
+            type = Float64,
+        ) .* (Δt / basetimestep)
     m = ncread(
         nc,
         param(config, "input.vertical.m", nothing);
@@ -364,27 +370,30 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         defaults = 2000.0,
         type = Float64,
     )
-    infiltcappath = ncread(
-        nc,
-        param(config, "input.vertical.infiltcappath", nothing);
-        sel = inds,
-        defaults = 10.0,
-        type = Float64,
-    ).* (Δt / basetimestep)
-    infiltcapsoil = ncread(
-        nc,
-        param(config, "input.vertical.infiltcapsoil", nothing);
-        sel = inds,
-        defaults = 100.0,
-        type = Float64,
-    ).* (Δt / basetimestep)
-    maxleakage = ncread(
-        nc,
-        param(config, "input.vertical.maxleakage", nothing);
-        sel = inds,
-        defaults = 0.0,
-        type = Float64,
-    ).* (Δt / basetimestep)
+    infiltcappath =
+        ncread(
+            nc,
+            param(config, "input.vertical.infiltcappath", nothing);
+            sel = inds,
+            defaults = 10.0,
+            type = Float64,
+        ) .* (Δt / basetimestep)
+    infiltcapsoil =
+        ncread(
+            nc,
+            param(config, "input.vertical.infiltcapsoil", nothing);
+            sel = inds,
+            defaults = 100.0,
+            type = Float64,
+        ) .* (Δt / basetimestep)
+    maxleakage =
+        ncread(
+            nc,
+            param(config, "input.vertical.maxleakage", nothing);
+            sel = inds,
+            defaults = 0.0,
+            type = Float64,
+        ) .* (Δt / basetimestep)
 
     c = ncread(
         nc,
@@ -451,8 +460,8 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
 
     # if leaf area index climatology provided use sl, swood and kext to calculate cmax, e_r and canopygapfraction
     if haskey(config.input.vertical, "leaf_area_index")
-    # TODO confirm if leaf area index climatology is present in the NetCDF
-    sl = ncread(
+        # TODO confirm if leaf area index climatology is present in the NetCDF
+        sl = ncread(
             nc,
             param(config, "input.vertical.specific_leaf");
             sel = inds,
@@ -581,7 +590,7 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         interception = fill(mv, n),
         soilevap = fill(mv, n),
         soilevapsat = fill(mv, n),
-        actcapflux =  fill(mv, n),
+        actcapflux = fill(mv, n),
         actevapsat = fill(mv, n),
         actevap = fill(mv, n),
         runoff_river = fill(mv, n),
@@ -592,7 +601,7 @@ function initialize_sbm(nc, config, riverfrac, xl, yl, inds)
         actinfilt = fill(mv, n),
         actinfiltsoil = fill(mv, n),
         actinfiltpath = fill(mv, n),
-        infiltsoilpath= fill(mv, n),
+        infiltsoilpath = fill(mv, n),
         infiltexcess = fill(mv, n),
         excesswater = fill(mv, n),
         exfiltsatwater = fill(mv, n),
@@ -946,10 +955,8 @@ function update_until_recharge(sbm::SBM, config)
         if n_usl > 0
             ksat = sbm.kvfrac[i][n_usl] * sbm.kv₀[i] * exp(-sbm.f[i] * sbm.zi[i])
             ustorecapacity =
-                sbm.soilwatercapacity[i] - satwaterdepth -
-                sum(@view usld[1:sbm.nlayers[i]])
-            maxcapflux =
-                max(0.0, min(ksat, actevapustore, ustorecapacity, satwaterdepth))
+                sbm.soilwatercapacity[i] - satwaterdepth - sum(@view usld[1:sbm.nlayers[i]])
+            maxcapflux = max(0.0, min(ksat, actevapustore, ustorecapacity, satwaterdepth))
 
             if sbm.zi[i] > rootingdepth
                 capfluxscale =
@@ -978,7 +985,7 @@ function update_until_recharge(sbm::SBM, config)
         transpiration = actevapsat + actevapustore
         actevap = soilevap + transpiration + ae_openw_r + ae_openw_l
 
-        
+
 
         # update the outputs and states
         sbm.n_unsatlayers[i] = n_usl

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -93,12 +93,7 @@ and set states in `model` object. Active cells are selected with the correspondi
 # Arguments
 - `type = nothing`: type to convert data to after reading. By default no conversion is done.
 """
-function set_states(
-    instate_path,
-    model,
-    state_ncnames;
-    type = nothing,
-)
+function set_states(instate_path, model, state_ncnames; type = nothing)
     @unpack network = model
     # states in NetCDF include dim time (one value) at index 3 or 4, 3 or 4 dims are allowed
     NCDataset(instate_path) do ds
@@ -132,7 +127,10 @@ function set_states(
                 # set state in model object
                 param(model, state) .= A
             else
-                error("Number of state dims should be 3 or 4, number of dims = ", string(dims))
+                error(
+                    "Number of state dims should be 3 or 4, number of dims = ",
+                    string(dims),
+                )
             end
         end
     end
@@ -316,9 +314,9 @@ function fraction_runoff_toriver(graph, ldd, index_river, slope, n)
     for i in index_river
         nbs = inneighbors(graph, i)
         for j in nbs
-             if ldd[j] != ldd[i]
-                 frac[j] = slope[j] / (slope[i] + slope[j])
-             end
+            if ldd[j] != ldd[i]
+                frac[j] = slope[j] / (slope[i] + slope[j])
+            end
         end
     end
     return frac

--- a/src/vertical_process.jl
+++ b/src/vertical_process.jl
@@ -41,9 +41,7 @@ function rainfall_interception_gash(
     # large storms P > P_sat
     largestorms = precipitation > p_sat
 
-    iwet =
-        largestorms ? (pfrac * p_sat) - cmax :
-        precipitation * pfrac
+    iwet = largestorms ? (pfrac * p_sat) - cmax : precipitation * pfrac
     isat = largestorms ? (e_r) * (precipitation - p_sat) : 0.0
     idry = largestorms ? cmax : 0.0
     itrunc = 0.0
@@ -354,7 +352,20 @@ The refreezing efficiency factor is set to 0.05.
 - `rainfall` (precipitation that occurs as rainfall)
 - `snowfall` (precipitation that occurs as snowfall)
 """
-function snowpack_hbv(snow, snowwater, precipitation, temperature, tti, tt, ttm, cfmax, whc; rfcf=1.0, sfcf=1.0,cfr=0.05)
+function snowpack_hbv(
+    snow,
+    snowwater,
+    precipitation,
+    temperature,
+    tti,
+    tt,
+    ttm,
+    cfmax,
+    whc;
+    rfcf = 1.0,
+    sfcf = 1.0,
+    cfr = 0.05,
+)
 
     # fraction of precipitation which falls as rain
     rainfrac = if iszero(tti)

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -5,7 +5,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
     model = BMI.initialize(Wflow.Model, tomlpath)
 
-    @testset "initialization and time functions" begin 
+    @testset "initialization and time functions" begin
         @test BMI.get_time_units(Wflow.Model) == "seconds since 1970-01-01T00:00:00"
         @test BMI.get_time_step(model) == 86400.0
         @test BMI.get_start_time(model) == 9.466848e8
@@ -17,12 +17,12 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         @test BMI.get_component_name(model) == "sbm"
         @test BMI.get_input_item_count(model) == 180
         @test BMI.get_output_item_count(model) == 180
-        @test BMI.get_input_var_names(model)[[1,5,120,179]] ==
-            ["vertical.Δt",
+        @test BMI.get_input_var_names(model)[[1, 5, 120, 179]] == [
+            "vertical.Δt",
             "vertical.n_unsatlayers",
             "lateral.land.sl",
             "lateral.river.reservoir.precipitation",
-            ]
+        ]
     end
 
     @testset "variable information functions" begin
@@ -31,15 +31,15 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         @test BMI.get_var_grid(model, "lateral.river.reservoir.inflow") == 0
         @test_throws ErrorException BMI.get_var_grid(model, "lateral.river.lake.volume")
         # Vector{Float64} printing on Julia 1.6+
-        @test BMI.get_var_type(model, "lateral.river.reservoir.inflow") in 
-            ["Array{Float64,1}", "Vector{Float64}"]
+        @test BMI.get_var_type(model, "lateral.river.reservoir.inflow") in
+              ["Array{Float64,1}", "Vector{Float64}"]
         @test BMI.get_var_type(model, "vertical.n") == "Int64"
         @test BMI.get_var_units(model, "vertical.θₛ") == "mm mm-1"
-        @test BMI.get_var_itemsize(model,"lateral.subsurface.ssf") == 8
-        @test BMI.get_var_nbytes(model,"vertical.n") == 8
-        @test BMI.get_var_nbytes(model,"vertical.xl") == 400560
-        @test BMI.get_var_nbytes(model,"lateral.river.q") == 45240
-        @test BMI.get_var_location(model,"lateral.river.q") == "node"
+        @test BMI.get_var_itemsize(model, "lateral.subsurface.ssf") == 8
+        @test BMI.get_var_nbytes(model, "vertical.n") == 8
+        @test BMI.get_var_nbytes(model, "vertical.xl") == 400560
+        @test BMI.get_var_nbytes(model, "lateral.river.q") == 45240
+        @test BMI.get_var_location(model, "lateral.river.q") == "node"
     end
 
     model = BMI.update(model)
@@ -47,12 +47,12 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
     @testset "update and get and set functions" begin
         @test BMI.get_current_time(model) == 9.467712e8
         @test mean(BMI.get_value(model, "vertical.zi")) ≈ 276.2527755988906
-        @test BMI.get_value_at_indices(model, "lateral.river.q", [1,100,5617]) ≈ 
-        [0.0019494398840044726,0.0552464309192915,2.662842827356121]
-        BMI.set_value(model, "vertical.zi" , fill(300.0,50070))
+        @test BMI.get_value_at_indices(model, "lateral.river.q", [1, 100, 5617]) ≈
+              [0.0019494398840044726, 0.0552464309192915, 2.662842827356121]
+        BMI.set_value(model, "vertical.zi", fill(300.0, 50070))
         @test mean(BMI.get_value(model, "vertical.zi")) == 300.0
         BMI.set_value_at_indices(model, "vertical.zi", [1], [250.0])
-        @test BMI.get_value_at_indices(model, "vertical.zi", [1,2]) == [250.0, 300.0]
+        @test BMI.get_value_at_indices(model, "vertical.zi", [1, 2]) == [250.0, 300.0]
     end
 
     @testset "model grid functions" begin
@@ -65,13 +65,13 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         @test minimum(BMI.get_grid_x(model, 4)) ≈ 5.4291666666666725
         @test maximum(BMI.get_grid_x(model, 4)) ≈ 7.845833333333333
         @test BMI.get_grid_x(model, 0) ≈ [5.920833333333338, 5.7625000000000055]
-        @test BMI.get_grid_y(model, 0) ≈ [49.9125, 48.920834] 
+        @test BMI.get_grid_y(model, 0) ≈ [49.9125, 48.920834]
         @test BMI.get_grid_node_count(model, 0) == 2
     end
 
     @testset "update until and finalize" begin
         time = BMI.get_current_time(model) + 2 * BMI.get_time_step(model)
-        @test_logs (:info, "update model until 9.46944e8" )
+        @test_logs (:info, "update model until 9.46944e8")
         model = BMI.update_until(model, time)
         BMI.finalize(model)
     end

--- a/test/groundwater.jl
+++ b/test/groundwater.jl
@@ -10,7 +10,9 @@ Non-steady flow in an unconfined rectangular aquifer, with Dirichlet h(0, t) = 0
 on the left edge, and a Neumann Boundary Condition (dh/dx = 0) on the right.
 """
 function transient_aquifer_1d(x, time, conductivity, specific_yield, aquifer_length, Β)
-    initial_head(x) / 1.0 + (Β * conductivity * initial_head(aquifer_length) * time) / (specific_yield * aquifer_length * aquifer_length)
+    initial_head(x) / 1.0 +
+    (Β * conductivity * initial_head(aquifer_length) * time) /
+    (specific_yield * aquifer_length * aquifer_length)
 end
 
 
@@ -21,7 +23,7 @@ Non-steady flow in a confined aquifer, using the well function of Theis.
 """
 function drawdown_theis(distance, time, discharge, transmissivity, storativity)
     u = (storativity * distance^2) / (4 * transmissivity * time)
-    return discharge / (4 * π  * transmissivity) * expint(u)
+    return discharge / (4 * π * transmissivity) * expint(u)
 end
 
 
@@ -64,7 +66,8 @@ end
     shape = (ncol, nrow)
     Δx = [10.0, 20.0]
     Δy = [5.0, 15.0, 25.0]
-    collect_connections(con, cell_id) = [con.rowval[nzi] for nzi in Wflow.connections(con, cell_id)]
+    collect_connections(con, cell_id) =
+        [con.rowval[nzi] for nzi in Wflow.connections(con, cell_id)]
 
     @testset "unit: connectivity" begin
         @testset "connection_geometry: y" begin
@@ -77,7 +80,7 @@ end
         @testset "connection_geometry: x" begin
             I = CartesianIndex(1, 1)
             J = CartesianIndex(1, 2)
-            @test Wflow.connection_geometry(I, J, Δx, Δy) == (5.0, 10.0, 5.0)   
+            @test Wflow.connection_geometry(I, J, Δx, Δy) == (5.0, 10.0, 5.0)
             @test_throws Exception Wflow.connection_geometry(I, I, Δx, Δy)
         end
 
@@ -88,7 +91,7 @@ end
             domain = ones(Bool, (1, 2))
             indices, reverse_indices = Wflow.active_indices(domain, false)
             conn = Wflow.Connectivity(indices, reverse_indices, Δx, [5.0])
-            @test conn.ncell == 2 
+            @test conn.ncell == 2
             @test conn.nconnection == 2
             @test conn.length1 == [5.0, 10.0]
             @test conn.length2 == [10.0, 5.0]
@@ -110,7 +113,7 @@ end
             domain = ones(Bool, (3, 1))
             indices, reverse_indices = Wflow.active_indices(domain, false)
             conn = Wflow.Connectivity(indices, reverse_indices, [10.0], Δy)
-            @test conn.ncell == 3 
+            @test conn.ncell == 3
             @test conn.nconnection == 4
             @test conn.length1 == [2.5, 7.5, 7.5, 12.5]
             @test conn.length2 == [7.5, 2.5, 12.5, 7.5]
@@ -136,7 +139,7 @@ end
             @test conn.ncell == 6
             @test conn.nconnection == 14
             @test conn.colptr == [1, 3, 6, 8, 10, 13, 15]
-            @test conn.rowval == [2, 4, 1, 3, 5, 2, 6, 1, 5, 2, 4, 6, 3, 5] 
+            @test conn.rowval == [2, 4, 1, 3, 5, 2, 6, 1, 5, 2, 4, 6, 3, 5]
             @test collect_connections(conn, 1) == [2, 4]
             @test collect_connections(conn, 2) == [1, 3, 5]
             @test collect_connections(conn, 3) == [2, 6]
@@ -158,7 +161,7 @@ end
             indices, reverse_indices = Wflow.active_indices(domain, false)
             conn = Wflow.Connectivity(indices, reverse_indices, Δx, Δy)
             @test conn.ncell == 5
-            @test conn.nconnection == 8 
+            @test conn.nconnection == 8
             @test conn.colptr == [1, 2, 3, 5, 7, 9]
             @test conn.rowval == [3, 5, 1, 4, 3, 5, 2, 4]
             @test collect_connections(conn, 1) == [3]
@@ -172,11 +175,13 @@ end
     @testset "unit: aquifer, boundary conditions" begin
         @testset "harmonicmean_conductance" begin
             # harmonicmean_conductance(k1, k2, H1, H2, l1, l2, width)
-            @test Wflow.harmonicmean_conductance(10.0, 10.0, 5.0, 5.0, 0.5, 0.5, 1.0) == 50.0
+            @test Wflow.harmonicmean_conductance(10.0, 10.0, 5.0, 5.0, 0.5, 0.5, 1.0) ==
+                  50.0
             @test Wflow.harmonicmean_conductance(10.0, 10.0, 0.0, 5.0, 0.5, 0.5, 1.0) == 0.0
             @test Wflow.harmonicmean_conductance(10.0, 10.0, 5.0, 0.0, 0.5, 0.5, 1.0) == 0.0
             # kD of 10 and 20 -> harmonicmean = 1/(1/10 + 1/20)
-            @test Wflow.harmonicmean_conductance(10.0, 10.0, 1.0, 2.0, 1.0, 1.0, 1.0) ≈ (6.0 + 2.0 / 3.0)
+            @test Wflow.harmonicmean_conductance(10.0, 10.0, 1.0, 2.0, 1.0, 1.0, 1.0) ≈
+                  (6.0 + 2.0 / 3.0)
         end
 
         nrow = 1
@@ -188,11 +193,11 @@ end
 
         @testset "saturated_thickness-confined" begin
             @test (
-                Wflow.saturated_thickness(conf_aqf, 1) == 
-                Wflow.saturated_thickness(conf_aqf, 2) == 
-                Wflow.saturated_thickness(conf_aqf, 3) == 
+                Wflow.saturated_thickness(conf_aqf, 1) ==
+                Wflow.saturated_thickness(conf_aqf, 2) ==
+                Wflow.saturated_thickness(conf_aqf, 3) ==
                 10.0
-                )
+            )
         end
 
         @testset "saturated_thickness-unconfined" begin
@@ -203,13 +208,13 @@ end
 
         @testset "horizontal_conductance" begin
             @test (
-                Wflow.horizontal_conductance(1, 2, 1, conf_aqf, connectivity) == 
+                Wflow.horizontal_conductance(1, 2, 1, conf_aqf, connectivity) ==
                 Wflow.harmonicmean_conductance(10.0, 10.0, 10.0, 10.0, 5.0, 5.0, 10.0)
             )
         end
 
         @testset "conductance" begin
-            @test Wflow.conductance(conf_aqf, 2, 3, 3) == 100.0 
+            @test Wflow.conductance(conf_aqf, 2, 3, 3) == 100.0
             @test Wflow.conductance(unconf_aqf, 2, 3, 3) == 100.0  # upstream sat. thickness
             @test Wflow.conductance(unconf_aqf, 1, 2, 1) == 75.0  # upstream sat. thickness
         end
@@ -227,7 +232,7 @@ end
             @test Wflow.minimum_head(conf_aqf)[1] == 0.0
             unconf_aqf.head .= original_head
         end
-        
+
         @testset "stable_timestep" begin
             @test Wflow.stable_timestep(conf_aqf) == 0.25
         end
@@ -255,7 +260,12 @@ end
 
         @testset "river" begin
             river = Wflow.River(
-                [2.0, 2.0], [100.0, 100.0], [200.0, 200.0], [1.0, 1.0], [0.0, 0.0], [1, 3]
+                [2.0, 2.0],
+                [100.0, 100.0],
+                [200.0, 200.0],
+                [1.0, 1.0],
+                [0.0, 0.0],
+                [1, 3],
             )
             Q = zeros(3)
             Wflow.flux!(Q, river, conf_aqf)
@@ -274,7 +284,8 @@ end
         end
 
         @testset "headboundary" begin
-            headboundary = Wflow.HeadBoundary([2.0, 2.0], [100.0, 100.0], [0.0, 0.0], [1, 2])
+            headboundary =
+                Wflow.HeadBoundary([2.0, 2.0], [100.0, 100.0], [0.0, 0.0], [1, 2])
             Q = zeros(3)
             Wflow.flux!(Q, headboundary, conf_aqf)
             @test Q[1] == 100.0 * (2.0 - 0.0)
@@ -295,22 +306,22 @@ end
             @test Q[1] == -1000.0
         end
     end
-    
+
     @testset "integration: steady 1D" begin
         connectivity, aquifer, _ = homogenous_aquifer(3, 1)
         constanthead = Wflow.ConstantHead([2.0, 4.0], [1, 3])
         gwf = Wflow.GroundwaterFlow(
-           aquifer,
-           connectivity,
-           constanthead,
-           Wflow.AquiferBoundaryCondition[],
+            aquifer,
+            connectivity,
+            constanthead,
+            Wflow.AquiferBoundaryCondition[],
         )
         # Set constant head (dirichlet) boundaries
         gwf.aquifer.head[gwf.constanthead.index] .= gwf.constanthead.head
 
-        Q = zeros(3)    
+        Q = zeros(3)
         Δt = 0.25 # days
-        for _ in 1:50
+        for _ = 1:50
             Wflow.update(gwf, Q, Δt)
         end
 
@@ -319,7 +330,7 @@ end
 
     @testset "integration: unconfined transient 1D" begin
         nrow = 1
-        ncol = 9 
+        ncol = 9
         shape = (nrow, ncol)
         conductivity = 200.0
         top = 150.0
@@ -327,7 +338,7 @@ end
         specific_yield = 0.15
         cellsize = 500.0
         Β = 1.12
-        aquifer_length = cellsize * ncol 
+        aquifer_length = cellsize * ncol
 
         # Domain, geometry
         domain = ones(Bool, shape)
@@ -336,7 +347,7 @@ end
         indices, reverse_indices = Wflow.active_indices(domain, false)
         connectivity = Wflow.Connectivity(indices, reverse_indices, Δx, Δy)
         ncell = connectivity.ncell
-        xc = collect(range(0.0, stop=aquifer_length - cellsize, step=cellsize))
+        xc = collect(range(0.0, stop = aquifer_length - cellsize, step = cellsize))
         aquifer = Wflow.UnconfinedAquifer(
             initial_head.(xc),
             fill(conductivity, ncell),
@@ -349,34 +360,36 @@ end
         # constant head on left boundary, 0 at 0
         constanthead = Wflow.ConstantHead([0.0], [1])
         gwf = Wflow.GroundwaterFlow(
-           aquifer,
-           connectivity,
-           constanthead,
-           Wflow.AquiferBoundaryCondition[],
+            aquifer,
+            connectivity,
+            constanthead,
+            Wflow.AquiferBoundaryCondition[],
         )
 
-        Δt = Wflow.stable_timestep(gwf.aquifer) 
+        Δt = Wflow.stable_timestep(gwf.aquifer)
         Q = zeros(ncell)
         time = 20.0
         nstep = Int(ceil(time / Δt))
         time = nstep * Δt
 
-        for i in 1:nstep
+        for i = 1:nstep
             Wflow.update(gwf, Q, Δt)
             # Gradient dh/dx is positive, all flow to the left
             @test all(diff(gwf.aquifer.head) .> 0.0)
         end
 
-        ϕ_analytical = [transient_aquifer_1d(x, time, conductivity, specific_yield, aquifer_length, Β) for x in xc]
+        ϕ_analytical = [
+            transient_aquifer_1d(x, time, conductivity, specific_yield, aquifer_length, Β) for x in xc
+        ]
         difference = gwf.aquifer.head .- ϕ_analytical
         # @test all(difference .< ?)  #TODO
     end
 
     @testset "integration: confined transient radial 2D" begin
-        halfnrow = 20  
+        halfnrow = 20
         wellrow = halfnrow + 1
         nrow = halfnrow * 2 + 1
-        ncol = nrow 
+        ncol = nrow
         shape = (nrow, ncol)
         conductivity = 5.0
         top = 10.0
@@ -386,9 +399,9 @@ end
         startinghead = top
         specific_storage = 0.015
         storativity = 0.15
-        aquifer_length = cellsize * ncol 
+        aquifer_length = cellsize * ncol
         discharge = -50.0
-    
+
         # Domain, geometry
         domain = ones(Bool, shape)
         Δx = fill(cellsize, ncol)
@@ -397,8 +410,8 @@ end
         connectivity = Wflow.Connectivity(indices, reverse_indices, Δx, Δy)
         ncell = connectivity.ncell
         aquifer = Wflow.ConfinedAquifer(
-            fill(startinghead, ncell),  
-            fill(conductivity, ncell), 
+            fill(startinghead, ncell),
+            fill(conductivity, ncell),
             fill(top, ncell),
             fill(bottom, ncell),
             fill(cellsize * cellsize, ncell),
@@ -407,43 +420,36 @@ end
             fill(0.0, connectivity.nconnection), # conductance, to be set
         )
 
-        cell_index = reshape(collect(range(1, ncell, step=1)), shape)
+        cell_index = reshape(collect(range(1, ncell, step = 1)), shape)
         indices = vcat(cell_index[1, :], cell_index[end, :])# , cell_index[:, 1], cell_index[:, end],)
-        constanthead = Wflow.ConstantHead(
-            fill(10.0, size(indices)),
-            indices,
-        )
+        constanthead = Wflow.ConstantHead(fill(10.0, size(indices)), indices)
         # Place a well in the middle of the domain
         well = Wflow.Well([discharge], [0.0], [reverse_indices[wellrow, wellrow]])
-        gwf = Wflow.GroundwaterFlow(
-            aquifer,
-            connectivity,
-            constanthead,
-            [well],
-        )
-    
-        Δt = Wflow.stable_timestep(gwf.aquifer) 
+        gwf = Wflow.GroundwaterFlow(aquifer, connectivity, constanthead, [well])
+
+        Δt = Wflow.stable_timestep(gwf.aquifer)
         Q = zeros(ncell)
         time = 20.0
         nstep = Int(ceil(time / Δt))
         time = nstep * Δt
-    
-        for i in 1:nstep
+
+        for i = 1:nstep
             Wflow.update(gwf, Q, Δt)
         end
 
         # test for symmetry on x and y axes
         ϕ = reshape(gwf.aquifer.head, shape)
-        @test ϕ[1:halfnrow, :] ≈ ϕ[end:-1:halfnrow + 2, :]
-        @test ϕ[:, 1:halfnrow] ≈ ϕ[:, end:-1:halfnrow + 2]
+        @test ϕ[1:halfnrow, :] ≈ ϕ[end:-1:halfnrow+2, :]
+        @test ϕ[:, 1:halfnrow] ≈ ϕ[:, end:-1:halfnrow+2]
 
         # compare with analytical solution
         start = -0.5 * aquifer_length + 0.5 * cellsize
-        stop =  0.5 * aquifer_length - 0.5 * cellsize
-        X = collect(range(start, stop=stop, step=cellsize))
-        ϕ_analytical = [drawdown_theis(x, time, discharge, transmissivity, storativity) for x in X] .+ 10.0
+        stop = 0.5 * aquifer_length - 0.5 * cellsize
+        X = collect(range(start, stop = stop, step = cellsize))
+        ϕ_analytical =
+            [drawdown_theis(x, time, discharge, transmissivity, storativity) for x in X] .+ 10.0
         # compare left-side, since it's symmetric anyway. Skip the well cell, and its first neighbor
-        difference = ϕ[1:halfnrow - 1, halfnrow] - ϕ_analytical[1:halfnrow - 1]
+        difference = ϕ[1:halfnrow-1, halfnrow] - ϕ_analytical[1:halfnrow-1]
         @test all(difference .< 0.02)
     end
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -41,14 +41,14 @@ end
     @test Wflow.timecycles(collect(1:12)) == collect(zip(1:12, fill(1, 12)))
     @test Wflow.timecycles(collect(1:366)) ==
           monthday.(Date(2000, 1, 1):Day(1):Date(2000, 12, 31))
-    
-    @test Wflow.monthday_passed((1,1), (1,1))  # same day
-    @test Wflow.monthday_passed((1,2), (1,1))  # day later
-    @test Wflow.monthday_passed((2,1), (1,1))  # month later
-    @test Wflow.monthday_passed((2,2), (1,1))  # month and day later
-    @test !Wflow.monthday_passed((2,1), (2,2))  # day before
-    @test !Wflow.monthday_passed((1,2), (2,2))  # month before
-    @test !Wflow.monthday_passed((1,1), (2,2))  # day and month before       
+
+    @test Wflow.monthday_passed((1, 1), (1, 1))  # same day
+    @test Wflow.monthday_passed((1, 2), (1, 1))  # day later
+    @test Wflow.monthday_passed((2, 1), (1, 1))  # month later
+    @test Wflow.monthday_passed((2, 2), (1, 1))  # month and day later
+    @test !Wflow.monthday_passed((2, 1), (2, 2))  # day before
+    @test !Wflow.monthday_passed((1, 2), (2, 2))  # month before
+    @test !Wflow.monthday_passed((1, 1), (2, 2))  # day and month before       
 end
 
 # test reading and setting of warm states (reinit=false)

--- a/test/reservoir_lake.jl
+++ b/test/reservoir_lake.jl
@@ -80,7 +80,12 @@ sh = [
         precipitation = [10.0, 10.0],
         evaporation = [2.0, 2.0],
         outflow = [NaN, NaN],
-        storage = Wflow.initialize_storage([2, 2], [472461536.0, 60851088.0], [395.03027, 394.87833], sh),
+        storage = Wflow.initialize_storage(
+            [2, 2],
+            [472461536.0, 60851088.0],
+            [395.03027, 394.87833],
+            sh,
+        ),
     )
 
     Wflow.update(lake, 1, 500.0, 15, 86400.0)

--- a/test/run_hbv.jl
+++ b/test/run_hbv.jl
@@ -22,14 +22,14 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
     @test row.perc_34 ≈ 1.8980000019073486
     @test row.perc_35 ≈ 2.7100000381469727
     @test row.perc_36 ≈ 3.818000078201294
-    @test row.perc_37 ≈ 2.1440000534057617    
+    @test row.perc_37 ≈ 2.1440000534057617
 end
 
 @testset "first timestep" begin
     hbv = model.vertical
     @test hbv.tt[1] ≈ 0.0
     @test model.clock.iteration == 2
-    @test hbv.altitude[1] == 484.2149963378906 
+    @test hbv.altitude[1] == 484.2149963378906
     @test hbv.soilmoisture[1] == 134.35299682617188
     @test hbv.runoff[1] == 7.406898120121746
     @test hbv.soilevap[1] == 0.0

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -48,11 +48,11 @@ end
 
     @test model.clock.iteration == 2
 
-    @test sbm.altitude[1] == 643.5469970703125
-    @test sbm.θₛ[1] == 0.48343977332115173
+    @test sbm.altitude[1] ≈ 643.5469970703125
+    @test sbm.θₛ[1] ≈ 0.48343977332115173
     @test sbm.runoff[1] == 0.0
     @test sbm.soilevap[1] == 0.0
-    @test sbm.snow[1] == 0.6029994894902302
+    @test sbm.snow[1] ≈ 0.6029994894902302
 end
 
 # run the second timestep
@@ -60,18 +60,18 @@ model = Wflow.update(model)
 
 @testset "second timestep" begin
     sbm = model.vertical
-    @test sbm.altitude[1] == 643.5469970703125
-    @test sbm.θₛ[1] == 0.48343977332115173
+    @test sbm.altitude[1] ≈ 643.5469970703125
+    @test sbm.θₛ[1] ≈ 0.48343977332115173
     @test sbm.runoff[1] == 0.0
-    @test sbm.soilevap[1] == 0.005865653627803281
-    @test sbm.snow[1] == 0.009696763863612956
+    @test sbm.soilevap[1] ≈ 0.005865653627803281
+    @test sbm.snow[1] ≈ 0.009696763863612956
 end
 
 @testset "subsurface flow" begin
     ssf = model.lateral.subsurface.ssf
     @test sum(ssf) ≈ 6.368136336079665e16
     @test ssf[network.land.order[1]] ≈ 3.0449782003445332e13
-    @test ssf[network.land.order[end-100]] ≈ 7.855716706804882e11 
+    @test ssf[network.land.order[end-100]] ≈ 7.855716706804882e11
     @test ssf[network.land.order[end]] ≈ 2.1612469198596365e11
 end
 
@@ -87,15 +87,15 @@ end
     q = model.lateral.river.q_av
     @test sum(q) ≈ 2811.093099307159
     @test q[4061] ≈ 0.0016288040314320486
-    @test q[5617] ≈  7.338204361667292
-    @test q[network.river.order[end]] ≈  0.00610520650626283
+    @test q[5617] ≈ 7.338204361667292
+    @test q[network.river.order[end]] ≈ 0.00610520650626283
 end
 
 @testset "reservoir simple" begin
     res = model.lateral.river.reservoir
     @test res.outflow[2] ≈ 0.2174998592483153
     @test res.inflow[2] ≈ 13.458065150960186
-    @test res.volume[2] ≈  2.776155238441744e7
+    @test res.volume[2] ≈ 2.776155238441744e7
     @test res.precipitation[2] ≈ 0.1765228509902954
     @test res.evaporation[2] ≈ 0.5372688174247742
 end
@@ -121,8 +121,8 @@ model = Wflow.run_simulation(config)
 # downstream from pit is at river index 1739, CartesianIndex(142, 85)
 @testset "river flow at and downstream of pit" begin
     q = model.lateral.river.q_av
-    @test q[1765] ≈  3.8628067453276365
-    @test q[1739] ≈  0.007148082967365473
+    @test q[1765] ≈ 3.8628067453276365
+    @test q[1739] ≈ 0.007148082967365473
 end
 
 Wflow.close_files(model, delete_output = false)

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -50,8 +50,8 @@ end
     q = model.lateral.river.q_av
     @test sum(q) ≈ 0.03515256649675796
     @test q[6] ≈ 0.00795266793733648
-    @test q[13] ≈  0.0005980549864213564
-    @test q[network.river.order[end]] ≈  0.008482646477950898
+    @test q[13] ≈ 0.0005980549864213564
+    @test q[network.river.order[end]] ≈ 0.008482646477950898
 end
 
 @testset "groundwater" begin
@@ -59,8 +59,8 @@ end
     @test gw.river.stage[1] ≈ 1.21057153442702
     @test gw.flow.aquifer.head[19] ≈ 1.7999999523162842
     @test gw.river.flux[1] ≈ -50.751898489778426
-    @test gw.drain.flux[1] ≈  0.0
-    @test gw.recharge.rate[19] ≈  -0.0014241196552847502
+    @test gw.drain.flux[1] ≈ 0.0
+    @test gw.recharge.rate[19] ≈ -0.0014241196552847502
 end
 
 Wflow.close_files(model, delete_output = false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,8 +36,10 @@ staticmaps_lahn_path = testdata(v"0.2.1", "staticmaps-lahn.nc", "staticmaps-lahn
 forcing_moselle_path = testdata(v"0.2", "forcing-2000.nc", "forcing-moselle.nc")
 forcing_lahn_path = testdata(v"0.2", "forcing-lahn.nc", "forcing-lahn.nc")
 instates_moselle_path = testdata(v"0.2.1", "instates-moselle.nc", "instates-moselle.nc")
-forcing_sbm_gw_path = testdata(v"0.2.1", "forcing-sbm-groundwater.nc", "forcing-sbm-groundwater.nc")
-staticmaps_sbm_gw_path = testdata(v"0.2.1", "staticmaps-sbm-groundwater.nc", "staticmaps-sbm-groundwater.nc")
+forcing_sbm_gw_path =
+    testdata(v"0.2.1", "forcing-sbm-groundwater.nc", "forcing-sbm-groundwater.nc")
+staticmaps_sbm_gw_path =
+    testdata(v"0.2.1", "staticmaps-sbm-groundwater.nc", "staticmaps-sbm-groundwater.nc")
 lake_sh_1_path = testdata(v"0.2.1", "lake_sh_1.csv", "lake_sh_1.csv")
 lake_sh_2_path = testdata(v"0.2.1", "lake_sh_2.csv", "lake_sh_2.csv")
 lake_hq_2_path = testdata(v"0.2.1", "lake_hq_2.csv", "lake_hq_2.csv")

--- a/test/testing_utils.jl
+++ b/test/testing_utils.jl
@@ -29,14 +29,14 @@ end
 #     https://github.com/stevengj/18S096-iap17/blob/master/pset3/pset3-solutions.ipynb
 
 # n coefficients of the Taylor series of E₁(z) + log(z), in type T:
-function E₁_taylor_coefficients(::Type{T}, n::Integer) where T <: Number
+function E₁_taylor_coefficients(::Type{T}, n::Integer) where {T<:Number}
     n < 0 && throw(ArgumentError("$n ≥ 0 is required"))
     n == 0 && return T[]
     n == 1 && return T[-eulergamma]
     # iteratively compute the terms in the series, starting with k=1
     term::T = 1
     terms = T[-eulergamma, term]
-    for k in 2:n
+    for k = 2:n
         term = -term * (k - 1) / (k * k)
         push!(terms, term)
     end
@@ -58,10 +58,10 @@ end
 # for numeric-literal coefficients: simplify to a ratio of two polynomials:
 # return (p,q): the polynomials p(x) / q(x) corresponding to E₁_cf(x, a...),
 # but without the exp(-x) term
-function E₁_cfpoly(n::Integer, ::Type{T}=BigInt) where T <: Real
+function E₁_cfpoly(n::Integer, ::Type{T} = BigInt) where {T<:Real}
     q = Polynomials.Polynomial(T[1])
-    p = x = Polynomials.Polynomial(T[0,1])
-    for i in n:-1:1
+    p = x = Polynomials.Polynomial(T[0, 1])
+    for i = n:-1:1
         p, q = x * p + (1 + i) * q, p # from cf = x + (1+i)/cf = x + (1+i)*q/p
         p, q = p + i * q, p     # from cf = 1 + i/cf = 1 + i*q/p
     end
@@ -71,7 +71,7 @@ end
 
 macro E₁_cf64(z, n::Integer)
     p, q = E₁_cfpoly(n, BigInt)
-    num_expr =  :(@evalpoly zz)
+    num_expr = :(@evalpoly zz)
     append!(num_expr.args, Float64.(Polynomials.coeffs(p)))
     den_expr = :(@evalpoly zz)
     append!(den_expr.args, Float64.(Polynomials.coeffs(q)))
@@ -99,13 +99,16 @@ function expint(z::Union{Float64,Complex{Float64}})
         return @E₁_cf64 z 30
     else # use Taylor expansion, ≤ 37 terms
         r² = x² + y²
-        return r² ≤ 0.36 ? (r² ≤ 2.8e-3 ? (r² ≤ 2e-7 ? @E₁_taylor64(z,4) :
-                                                        @E₁_taylor64(z,8)) :
-                                                        @E₁_taylor64(z,15)) :
-                                                        @E₁_taylor64(z,37)
+        return r² ≤ 0.36 ?
+               (
+            r² ≤ 2.8e-3 ? (r² ≤ 2e-7 ? @E₁_taylor64(z, 4) : @E₁_taylor64(z, 8)) :
+            @E₁_taylor64(z, 15)
+        ) :
+               @E₁_taylor64(z, 37)
     end
 end
-expint(z::Union{T,Complex{T},Rational{T},Complex{Rational{T}}}) where {T <: Integer} = expint(float(z))
+expint(z::Union{T,Complex{T},Rational{T},Complex{Rational{T}}}) where {T<:Integer} =
+    expint(float(z))
 
 ######################################################################
 # exponential integral Eₙ(z)
@@ -118,7 +121,7 @@ function expint(n::Integer, z)
         zinv = inv(z)
         e⁻ᶻ = exp(-z)
         Eᵢ = zinv * e⁻ᶻ
-        for i in 1:-n
+        for i = 1:-n
             Eᵢ = zinv * (e⁻ᶻ + i * Eᵢ)
         end
         return Eᵢ
@@ -127,7 +130,7 @@ function expint(n::Integer, z)
         e⁻ᶻ = exp(-z)
         Eᵢ = expint(z)
         Eᵢ *= !isinf(Eᵢ)
-        for i in 2:n
+        for i = 2:n
             Eᵢ = (e⁻ᶻ - z * Eᵢ) / (i - 1)
         end
         return Eᵢ


### PR DESCRIPTION
This uses the default style. Did this: `using JuliaFormatter; format(".")`

If you want to run this from VS Code, you can use this extension (VS Code Julia currently still has a different default formatter): https://github.com/singularitti/vscode-julia-formatter/

Already went through the diff and I think it's better in almost all cases. Only don't like this so much: https://github.com/Deltares/Wflow.jl/compare/format?expand=1#diff-b6a501ee6fbf026b1fd082d57f38964b960813f58679f4b54485649557bc26e9R102-R107
But perhaps we should just split those lines anyway.