### PR TITLE
River waterbodies

### DIFF
--- a/src/flow.jl
+++ b/src/flow.jl
@@ -114,7 +114,7 @@ function update(
                     # downstream river cell
                     i = sf.reservoir_index[v]
                     update(sf.reservoir, i, sf.q[v] + inflow_wb[v], adt)
-                    j = outneighbors(graph, v)[1]
+                    j = only(outneighbors(graph, v))
                     sf.qin[j] = sf.reservoir.outflow[i]
 
                 elseif !isnothing(sf.lake) && sf.lake_index[v] != 0
@@ -122,7 +122,7 @@ function update(
                     # cell
                     i = sf.lake_index[v]
                     update(sf.lake, i, sf.q[v] + inflow_wb[v], doy, adt)
-                    j = outneighbors(graph, v)[1]
+                    j = only(outneighbors(graph, v))
                     sf.qin[j] = sf.lake.outflow[i]
                 end
             end

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -567,6 +567,7 @@ end
 function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
     @unpack lateral, vertical, network, clock, config = model
 
+    inds_riv = network.index_river
     kinwave_it = get(config.model, "kin_wave_iteration", false)
 
     update_forcing!(model)

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -610,7 +610,7 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
     )
 
     # determine lateral inflow (from overland flow) for river flow
-    lateral.river.qlat .= (lateral.land.to_river[network.index_river]) ./ lateral.river.dl
+    lateral.river.qlat .= (lateral.land.to_river[inds_riv]) ./ lateral.river.dl
 
     # run kinematic wave for river flow
     # check if reservoirs or lakes are defined, the inflow from overland flow is required

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -230,7 +230,7 @@ function initialize_sbm_model(config::Config)
         its = kw_river_tstep > 0 ? ceil(Int(tosecond(Δt) / kw_river_tstep)) :
               kw_river_tstep,
         width = riverwidth,
-        wb_pit = pits[inds_riv], #fill(false, nriv),
+        wb_pit = pits[inds_riv],
         alpha_term = alpha_term,
         alpha_pow = alpha_pow,
         α = alpha_term .* pow.(riverwidth .+ 2.0 .* h_river, alpha_pow),

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -161,6 +161,7 @@ function initialize_sbm_model(config::Config)
         n = n_land,
         dl = dl,
         q = fill(0.0, n),
+        qin = fill(0.0, n),
         q_av = fill(0.0, n),
         qlat = fill(0.0, n),
         h = h,
@@ -220,6 +221,7 @@ function initialize_sbm_model(config::Config)
         n = n_river,
         dl = riverlength,
         q = fill(0.0, nriv),
+        qin = fill(0.0, nriv),
         q_av = fill(0.0, nriv),
         qlat = fill(0.0, nriv),
         h = h_river,
@@ -228,7 +230,7 @@ function initialize_sbm_model(config::Config)
         its = kw_river_tstep > 0 ? ceil(Int(tosecond(Δt) / kw_river_tstep)) :
               kw_river_tstep,
         width = riverwidth,
-        wb_pit = fill(false, nriv),
+        wb_pit = pits[inds_riv], #fill(false, nriv),
         alpha_term = alpha_term,
         alpha_pow = alpha_pow,
         α = alpha_term .* pow.(riverwidth .+ 2.0 .* h_river, alpha_pow),
@@ -273,12 +275,14 @@ function initialize_sbm_model(config::Config)
     # from the initialization functions
     land = (
         graph = graph,
+        upstream_nodes = filter_upsteam_nodes(graph, olf.wb_pit),
         order = topological_sort_by_dfs(graph),
         indices = inds,
         reverse_indices = rev_inds,
     )
     river = (
         graph = graph_riv,
+        upstream_nodes = filter_upsteam_nodes(graph_riv, rf.wb_pit),
         order = topological_sort_by_dfs(graph_riv),
         indices = inds_riv,
         reverse_indices = rev_inds_riv,
@@ -361,7 +365,7 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:SBM,R,W}
     lateral.subsurface.zi .= vertical.zi
 
     # update lateral subsurface flow domain
-    update(lateral.subsurface, network.land, network.frac_toriver, lateral.river.rivercells)
+    update(lateral.subsurface, network.land, network.frac_toriver)
 
     # update vertical sbm concept (runoff, ustorelayerdepth and satwaterdepth)
     update_after_lateralflow(
@@ -374,11 +378,11 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:SBM,R,W}
     lateral.land.qlat .=
         (vertical.runoff .* vertical.xl .* vertical.yl .* 0.001) ./ lateral.land.Δt ./
         lateral.land.dl
+    
     update(
         lateral.land,
         network.land,
         frac_toriver = network.frac_toriver,
-        river = lateral.river.rivercells,
         do_iter = kinwave_it,
     )
 
@@ -394,8 +398,26 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:SBM,R,W}
             lateral.subsurface.to_river[inds_riv] ./ 1.0e9 ./ lateral.river.Δt .+
             lateral.land.to_river[inds_riv] .+ net_runoff_river
         ) ./ lateral.river.dl
-    update(lateral.river, network.river, do_iter = kinwave_it, doy = dayofyear(clock.time))
 
+    if !isnothing(lateral.river.reservoir) || !isnothing(lateral.river.lake)
+        inflow_wb =
+            lateral.subsurface.ssf[inds_riv] ./ 1.0e9 ./ lateral.river.Δt .+
+            lateral.land.q_av[inds_riv]
+        update(
+            lateral.river,
+            network.river,
+            inflow_wb = inflow_wb,
+            do_iter = kinwave_it,
+            doy = dayofyear(clock.time),
+        )
+    else
+        update(
+            lateral.river,
+            network.river,
+            do_iter = kinwave_it,
+            doy = dayofyear(clock.time),
+        )
+    end
     write_output(model)
 
     # update the clock

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,16 @@ function set_pit_ldd(pits_2d, ldd, indices; pit = 5)
     return ldd
 end
 
+"Filter upstream neighbors of graph based on logical vector"
+function filter_upsteam_nodes(graph, vec_logical::Vector{Bool})
+    upstream_nodes = Vector{Int}[]
+    for v in topological_sort_by_dfs(graph)
+        ups_nodes = inneighbors(graph, v)
+        push!(upstream_nodes, filter(i -> !vec_logical[i], ups_nodes))
+    end
+    return upstream_nodes
+end
+
 """
     active_indices(subcatch_2d, nodata)
 

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -15,13 +15,13 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
     @testset "model information functions" begin
         @test BMI.get_component_name(model) == "sbm"
-        @test BMI.get_input_item_count(model) == 180
-        @test BMI.get_output_item_count(model) == 180
+        @test BMI.get_input_item_count(model) == 182
+        @test BMI.get_output_item_count(model) == 182
         @test BMI.get_input_var_names(model)[[1, 5, 120, 179]] == [
             "vertical.Δt",
             "vertical.n_unsatlayers",
             "lateral.land.sl",
-            "lateral.river.reservoir.precipitation",
+            "lateral.river.reservoir.percfull",
         ]
     end
 
@@ -46,7 +46,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
     @testset "update and get and set functions" begin
         @test BMI.get_current_time(model) == 9.467712e8
-        @test mean(BMI.get_value(model, "vertical.zi")) ≈ 276.2527755988906
+        @test mean(BMI.get_value(model, "vertical.zi")) ≈ 276.252648379751
         @test BMI.get_value_at_indices(model, "lateral.river.q", [1, 100, 5617]) ≈
               [0.0019494398840044726, 0.0552464309192915, 2.662842827356121]
         BMI.set_value(model, "vertical.zi", fill(300.0, 50070))

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -15,7 +15,7 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
 
     @test row.time == DateTime("2000-01-01T00:00:00")
     @test row.Q ≈ 7.815587720999557
-    @test row.volume ≈ 4.364358112965045e7
+    @test row.volume ≈ 4.364251626782245e7
     @test row.temp_bycoord ≈ 2.3279826641082764
     @test row.temp_byindex ≈ 2.3279826641082764
     @test row.Q_6336050 ≈ 0.023884907014593577
@@ -68,7 +68,7 @@ end
 
 @testset "subsurface flow" begin
     ssf = model.lateral.subsurface.ssf
-    @test sum(ssf) ≈ 6.368136336079665e16
+    @test sum(ssf) ≈ 6.368140761295825e16
     @test ssf[network.land.order[1]] ≈ 3.0449782003445332e13
     @test ssf[network.land.order[end-100]] ≈ 7.855716706804882e11
     @test ssf[network.land.order[end]] ≈ 2.1612469198596365e11
@@ -84,7 +84,7 @@ end
 
 @testset "river flow" begin
     q = model.lateral.river.q_av
-    @test sum(q) ≈ 2811.093099307159
+    @test sum(q) ≈ 2807.935527751757
     @test q[4061] ≈ 0.0016288040314320486
     @test q[5617] ≈ 7.338204361667292
     @test q[network.river.order[end]] ≈ 0.00610520650626283
@@ -93,8 +93,8 @@ end
 @testset "reservoir simple" begin
     res = model.lateral.river.reservoir
     @test res.outflow[2] ≈ 0.2174998592483153
-    @test res.inflow[2] ≈ 13.458065150960186
-    @test res.volume[2] ≈ 2.776155238441744e7
+    @test res.inflow[2] ≈ 50.170880948187055
+    @test res.volume[2] ≈ 2.776162917050312e7
     @test res.precipitation[2] ≈ 0.1765228509902954
     @test res.evaporation[2] ≈ 0.5372688174247742
 end


### PR DESCRIPTION
Reservoirs and lakes (water bodies) are now handled differently within the kinematic wave, and more in line with the original implementation in Python. Outflow goes to the next downstream river cell (instead of remaining in the cell where the water body is located). Inflow consists of subsurface, land and overland flow. 

The filtering of upstream nodes (water bodies are excluded) is done in the initialization of the model, and stored as part of the network information. This filtering in the update function seemed a bit expensive, and the SBM Models Update benchmark seems faster (hits more often ~700 ms now, instead of ~900 ms). 