### PR TITLE
close the staticmaps NetCDF during initialization

### DIFF
--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -522,6 +522,7 @@ function initialize_hbv_model(config::Config)
         dims_xy,
         nc,
     )
+    close(nc)
 
     # for each domain save the directed acyclic graph, the traversion order,
     # and the indices that map it back to the two dimensional grid

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -384,6 +384,7 @@ function initialize_sbm_gwf_model(config::Config)
         nc,
         maxlayers = sbm.maxlayers,
     )
+    close(nc)
 
     # for each domain save the directed acyclic graph, the traversion order,
     # and the indices that map it back to the two dimensional grid

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -268,6 +268,7 @@ function initialize_sbm_model(config::Config)
         nc,
         maxlayers = sbm.maxlayers,
     )
+    close(nc)
 
     # for each domain save the directed acyclic graph, the traversion order,
     # and the indices that map it back to the two dimensional grid

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -151,6 +151,7 @@ function initialize_sediment_model(config::Config)
         dims_xy,
         nc,
     )
+    close(nc)
 
     # for each domain save the directed acyclic graph, the traversion order,
     # and the indices that map it back to the two dimensional grid


### PR DESCRIPTION
If the cyclic data is in there as well, the NCReader also opens the same file, but that is a different handle that is already being closed properly. With this, all files are closed, tested by running a simulation, and before closing the session, moving all input+output data to a different folder. That's how I found this file was left open as well.