### PR TITLE
export NetCDF scalar timeseries

### DIFF
--- a/docs/src/structure.md
+++ b/docs/src/structure.md
@@ -205,8 +205,7 @@ n = "N"
 slope = "Slope"
 ```
 
-### Output netCDF section
-
+### Output netCDF section (grid data)
 This optional section of the TOML file contains the output netCDF file for writing gridded
 model output, including a mapping between internal model parameter components and external
 netCDF variables.
@@ -236,6 +235,43 @@ ssf = "ssf"
 [output.lateral.land]
 q = "q_land"
 h = "h_land"
+```
+
+### Output netCDF section (scalar data)
+Besides gridded data, it is also possible to write scalar data to a NetCDF file. Below is an
+example that writes scalar data to the file "output\_scalar\_moselle.nc". For each NetCDF
+variable a `name` (external variable name) and `parameter` (internal model parameter) is
+required. A `reducer` can be specified to apply to the model output, see for more
+information the following section [Output CSV section](@ref). When a `map` is provided to
+extract data for certain locations (e.g. `gauges`) or areas (e.g. `subcatchment`), the
+NetCDF location names are extracted from these maps. For a specific location (grid cell) a
+`location` is required. In the section [Output CSV section](@ref), similar functionality is
+available for CSV. For integration with Delft-FEWS, see also [Run from Delft-FEWS](@ref),
+it is recommended to write scalar data to NetCDF format since the General Adapter of
+Delft-FEWS can ingest this data format directly.
+
+```toml
+[netcdf]
+path = "data/output_scalar_moselle.nc"
+
+[[netcdf.variable]]
+name = "Q"
+map = "gauges"
+parameter = "lateral.river.q"
+
+[[netcdf.variable]]
+coordinate.x = 6.255
+coordinate.y = 50.012
+name = "temp_coord"
+location = "temp_bycoord"
+parameter = "vertical.temperature"
+
+[[netcdf.variable]]
+location = "temp_byindex"
+name = "temp_index"
+index.x = 100
+index.y = 50
+parameter = "vertical.temperature"
 ```
 
 ### Output CSV section

--- a/docs/src/vertical/sbm.md
+++ b/docs/src/vertical/sbm.md
@@ -96,7 +96,7 @@ adds or removes (partly) layer(s) based on the `soilthickness`.
 
 Assuming a unit head gradient, the transfer of water (``st``) from a ``U`` store layer is
 controlled by the saturated hydraulic conductivity ``K_{sat}`` at depth ``z`` (bottom layer)
-or :math:`z_{i}`, the effective saturation degree of the layer, and a Brooks-Corey power
+or ``z_{i}``, the effective saturation degree of the layer, and a Brooks-Corey power
 coefficient (parameter ``c``) based on the pore size distribution index ``\lambda`` (Brooks
 and Corey (1964)):
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -643,18 +643,19 @@ function out_map(ncnames_dict, modelmap)
 end
 
 
-function get_reducer_func(col, rev_inds, x_nc, y_nc, dims_xy, config, nc_static)
-    if occursin("reservoir", col["parameter"])
+function get_reducer_func(col, rev_inds, args...)
+    parameter = col["parameter"]
+    if occursin("reservoir", parameter)
         reducer_func =
-            reducer(col, rev_inds.reservoir, x_nc, y_nc, dims_xy, config, nc_static)
-    elseif occursin("lake", col["parameter"])
-        reducer_func = reducer(col, rev_inds.lake, x_nc, y_nc, dims_xy, config, nc_static)
-    elseif occursin("river", col["parameter"])
-        reducer_func = reducer(col, rev_inds.river, x_nc, y_nc, dims_xy, config, nc_static)
-    elseif occursin("drain", col["parameter"])
-        reducer_func = reducer(col, rev_inds.drain, x_nc, y_nc, dims_xy, config, nc_static)
+            reducer(col, rev_inds.reservoir, args...)
+    elseif occursin("lake", parameter)
+        reducer_func = reducer(col, rev_inds.lake, args...)
+    elseif occursin("river", parameter)
+        reducer_func = reducer(col, rev_inds.river, args...)
+    elseif occursin("drain", parameter)
+        reducer_func = reducer(col, rev_inds.drain, args...)
     else
-        reducer_func = reducer(col, rev_inds.land, x_nc, y_nc, dims_xy, config, nc_static)
+        reducer_func = reducer(col, rev_inds.land, args...)
     end
 end
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -228,7 +228,7 @@ function create_tracked_netcdf(path)
 end
 
 "prepare an output dataset for scalar data"
-function setup_netcdf(output_path, ncvars, calendar, time_units, float_type = Float32)
+function setup_scalar_netcdf(output_path, ncvars, calendar, time_units, float_type = Float32)
     ds = create_tracked_netcdf(output_path)
     defDim(ds, "time", Inf)  # unlimited
     defVar(
@@ -260,7 +260,7 @@ function setup_netcdf(output_path, ncvars, calendar, time_units, float_type = Fl
 end
 
 "prepare an output dataset for grid data"
-function setup_netcdf(
+function setup_grid_netcdf(
     output_path,
     ncx,
     ncy,
@@ -684,7 +684,7 @@ function prepare_writer(
         output_ncnames = ncnames(config.output)
         # fill the output_map by mapping parameter NetCDF names to arrays
         output_map = out_map(output_ncnames, modelmap)
-        ds = setup_netcdf(
+        ds = setup_grid_netcdf(
             nc_path,
             x_nc,
             y_nc,
@@ -706,7 +706,7 @@ function prepare_writer(
         state_ncnames = ncnames(config.state)
         state_map = out_map(state_ncnames, modelmap)
         nc_state_path = joinpath(tomldir, config.state.path_output)
-        ds_outstate = setup_netcdf(
+        ds_outstate = setup_grid_netcdf(
             nc_state_path,
             x_nc,
             y_nc,
@@ -724,17 +724,17 @@ function prepare_writer(
     end
 
     # create an output NetCDF that will hold all timesteps of selected parameters for scalar
-    # data, but only if config.nc.variable has been set. 
-    if haskey(config, "nc") && haskey(config.nc, "variable")
-        nc_scalar_path = joinpath(tomldir, config.nc.path)
+    # data, but only if config.netcdf.variable has been set. 
+    if haskey(config, "netcdf") && haskey(config.netcdf, "variable")
+        nc_scalar_path = joinpath(tomldir, config.netcdf.path)
         # get NetCDF info for scalar data (variable name, locationset (dim) and 
         # location ids)
-        ncvars_dims = nc_variables_dims(config.nc.variable, nc_static, config)
-        ds_scalar = setup_netcdf(nc_scalar_path, ncvars_dims, calendar, time_units)
+        ncvars_dims = nc_variables_dims(config.netcdf.variable, nc_static, config)
+        ds_scalar = setup_scalar_netcdf(nc_scalar_path, ncvars_dims, calendar, time_units)
         # create a vector of (parameter, reducer) named tuples which will be used to
         # retrieve and reduce data during a model run
         nc_scalar = []
-        for var in config.nc.variable
+        for var in config.netcdf.variable
             parameter = var["parameter"]
             reducer_func =
                 get_reducer_func(var, rev_inds, x_nc, y_nc, dims_xy, config, nc_static)

--- a/src/io.jl
+++ b/src/io.jl
@@ -85,10 +85,9 @@ end
 
 function get_at!(buffer, var::NCDatasets.CFVariable, i)
     # assumes the dataset has 12 time steps, from January to December
-    dims = length(NCDatasets.dimnames(var))
     dim = findfirst(==("time"), NCDatasets.dimnames(var))
     # load in place, using a lower level NCDatasets function
-    if dims == 3
+    if ndims(var) == 3
         if dim == 1
             NCDatasets.load!(var.var, buffer, i, :, :)
         elseif dim == 3
@@ -96,14 +95,28 @@ function get_at!(buffer, var::NCDatasets.CFVariable, i)
         else
             error("Time dimension expected at position 1 or 3 (number of dimensions is 3)")
         end
-    elseif dims == 4
+    elseif ndims(var) == 4
         if dim == 1
-            NCDatasets.load!(var.var, buffer, i, 1, :, :)
+            len = size(var, 2)
+            if len == 1
+                NCDatasets.load!(var.var, buffer, i, 1, :, :)
+            else
+                dimname = NCDatasets.dimnames(var)[2]
+                error("Unsupported dimension $dimname of size $len")
+            end
         elseif dim == 4
-            NCDatasets.load!(var.var, buffer, :, :, 1, i)
+            len = size(var, 3)
+            if len == 1
+                NCDatasets.load!(var.var, buffer, :, :, 1, i)
+            else
+                dimname = NCDatasets.dimnames(var)[3]
+                error("Unsupported dimension $dimname of size $len")
+            end
         else
             error("Time dimension expected at position 1 or 4 (number of dimensions is 4)")
         end
+    else
+        error("Expected a 3 or 4 dimensional variable in the NetCDF")
     end
     return buffer
 end

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -40,6 +40,36 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
     @test row.recharge_1 ≈ -0.027398093386017383
 end
 
+@testset "NetCDF scalar output" begin
+    ds = model.writer.dataset_scalar
+    @test ds["time"][1] == DateTime("2000-01-01T00:00:00")
+    @test ds["Q"][:] ≈ [
+        0.023884907,
+        0.012411069,
+        0.004848609,
+        0.011474802,
+        0.0005262529,
+        0.013467698,
+        0.003408281,
+        0.09773275,
+        0.0021476103,
+        0.0026493936,
+        0.0008708129,
+        0.0007291489,
+        0.0021553952,
+        0.002229833,
+        0.003104503,
+        3.3423893,
+        1.35827,
+        5.9423304,
+        1.6809973,
+    ]
+    @test ds["Q_gauges"].attrib["cf_role"] == "timeseries_id"
+    @test ds["temp_index"][:] ≈ [2.3279827]
+    @test ds["temp_coord"][:] ≈ [2.3279827]
+    @test keys(ds.dim) == ["time", "Q_gauges", "temp_bycoord", "temp_byindex"]
+end
+
 @testset "first timestep" begin
     sbm = model.vertical
 

--- a/test/sbm_config.toml
+++ b/test/sbm_config.toml
@@ -149,6 +149,28 @@ ssf = "ssf"
 h = "h_land"
 q = "q_land"
 
+[nc]
+path = "data/output_scalar_moselle.nc"
+
+[[nc.variable]]
+name = "Q"
+map = "gauges"
+parameter = "lateral.river.q"
+
+[[nc.variable]]
+coordinate.x = 6.255
+coordinate.y = 50.012
+name = "temp_coord"
+location = "temp_bycoord"
+parameter = "vertical.temperature"
+
+[[nc.variable]]
+location = "temp_byindex"
+name = "temp_index"
+index.x = 100
+index.y = 50
+parameter = "vertical.temperature"
+
 [csv]
 path = "data/output_moselle.csv"
 

--- a/test/sbm_config.toml
+++ b/test/sbm_config.toml
@@ -149,22 +149,22 @@ ssf = "ssf"
 h = "h_land"
 q = "q_land"
 
-[nc]
+[netcdf]
 path = "data/output_scalar_moselle.nc"
 
-[[nc.variable]]
+[[netcdf.variable]]
 name = "Q"
 map = "gauges"
 parameter = "lateral.river.q"
 
-[[nc.variable]]
+[[netcdf.variable]]
 coordinate.x = 6.255
 coordinate.y = 50.012
 name = "temp_coord"
 location = "temp_bycoord"
 parameter = "vertical.temperature"
 
-[[nc.variable]]
+[[netcdf.variable]]
 location = "temp_byindex"
 name = "temp_index"
 index.x = 100


### PR DESCRIPTION
This is similar to the CSV option. Scalar timeseries are exported to another file than the gridded time series, for allowing import of these timeseries by Delft-FEWS (General Adapter).