### PR TITLE
improve error message for CSV reducer

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -967,7 +967,11 @@ function reducer(col, rev_inds, x_nc, y_nc, config, dataset)
             v::Int
             vector = inds[v]
             ind = rev_inds[i]
-            iszero(ind) && error("area $v has inactive cells")
+            if iszero(ind)
+                param = col["parameter"]
+                error("""inactive cell found in requested CSV output
+                    map \"$mapname\" value $v for parameter $param""")
+            end
             push!(vector, ind)
         end
         return A -> (f(A[inds[id]]) for id in ids)


### PR DESCRIPTION
This will now give:

```
ERROR: inactive cell found in requested CSV output
map "gauges" value 358 for parameter lateral.river.q_av
```

Before it was a bit too cryptic what area v was and why this error was thrown.