### PR TITLE
don't run benchmarks during CI

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CFTime = "179af706-886a-5703-950a-314cd64e0468"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -1,0 +1,47 @@
+# These benchmarks need to be revised, and run not as part of the tests, but separately.
+# https://juliaci.github.io/PkgBenchmark.jl/stable/
+
+#=
+
+"Prints a benchmark results just like btime"
+function print_benchmark(trialmin)
+    trialtime = BenchmarkTools.time(trialmin)
+    trialallocs = BenchmarkTools.allocs(trialmin)
+    println(
+        "  ",
+        BenchmarkTools.prettytime(trialtime),
+        " (",
+        trialallocs,
+        " allocation",
+        trialallocs == 1 ? "" : "s",
+        ": ",
+        BenchmarkTools.prettymemory(BenchmarkTools.memory(trialmin)),
+        ")",
+    )
+end
+
+
+# test/run_hbv.jl
+benchmark = @benchmark Wflow.update(model)
+trialmin = BenchmarkTools.minimum(benchmark)
+println("HBV Model update")
+print_benchmark(trialmin)
+
+# test/run_sbm_gwf.jl
+benchmark = @benchmark Wflow.run(tomlpath)
+trialmin = BenchmarkTools.minimum(benchmark)
+println("SBM GWF Model update (run)")
+print_benchmark(trialmin)
+
+# test/run_sbm.jl
+benchmark = @benchmark Wflow.update(model)
+trialmin = BenchmarkTools.minimum(benchmark)
+println("SBM Model update")
+print_benchmark(trialmin)
+
+# test/run_sediment.jl
+benchmark = @benchmark Wflow.run(tomlpath)
+trialmin = BenchmarkTools.minimum(benchmark)
+println("Sediment Model update (run)")
+print_benchmark(trialmin)
+=#

--- a/test/run_hbv.jl
+++ b/test/run_hbv.jl
@@ -63,10 +63,4 @@ end
     @test q[network.river.order[end]] ≈ 363.5647479049738f0
 end
 
-benchmark = @benchmark Wflow.update(model)
-trialmin = BenchmarkTools.minimum(benchmark)
-
-println("HBV Model update")
-print_benchmark(trialmin)
-
 Wflow.close_files(model, delete_output = false)

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -133,12 +133,6 @@ evap = copy(model.vertical.potential_evaporation)
 lai = copy(model.vertical.leaf_area_index)
 res_evap = copy(model.lateral.river.reservoir.evaporation)
 
-benchmark = @benchmark Wflow.update(model)
-trialmin = BenchmarkTools.minimum(benchmark)
-
-println("SBM Model update")
-print_benchmark(trialmin)
-# @profview Wflow.update(model)
 Wflow.close_files(model, delete_output = false)
 
 # test for setting a pit

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -65,11 +65,6 @@ end
 
 Wflow.close_files(model)
 
-benchmark = @benchmark Wflow.run(tomlpath)
-trialmin = BenchmarkTools.minimum(benchmark)
-println("SBM GWF Model update (run)")
-print_benchmark(trialmin)
-
 @testset "no drains" begin
     config.model.drains = false
     delete!(Dict(config.output.lateral.subsurface), "drain")

--- a/test/run_sediment.jl
+++ b/test/run_sediment.jl
@@ -52,8 +52,3 @@ end
 end
 
 Wflow.close_files(model)
-
-benchmark = @benchmark Wflow.run(tomlpath)
-trialmin = BenchmarkTools.minimum(benchmark)
-println("Sediment Model update (run)")
-print_benchmark(trialmin)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,6 @@ using Statistics
 using Test
 using UnPack
 using Wflow
-using BenchmarkTools
 using Base.MathConstants: eulergamma
 using Base.Threads
 using BasicModelInterface

--- a/test/testing_utils.jl
+++ b/test/testing_utils.jl
@@ -1,21 +1,3 @@
-
-"Prints a benchmark results just like btime"
-function print_benchmark(trialmin)
-    trialtime = BenchmarkTools.time(trialmin)
-    trialallocs = BenchmarkTools.allocs(trialmin)
-    println(
-        "  ",
-        BenchmarkTools.prettytime(trialtime),
-        " (",
-        trialallocs,
-        " allocation",
-        trialallocs == 1 ? "" : "s",
-        ": ",
-        BenchmarkTools.prettymemory(BenchmarkTools.memory(trialmin)),
-        ")",
-    )
-end
-
 # Not all special functions have been implemented yet:
 # https://github.com/JuliaMath/SpecialFunctions.jl/issues/19
 # (MIT licensed)


### PR DESCRIPTION
I'll merge this quickly to get CI passing again. This seems to be the main cause of testing issues on multiple threads.

Benchmarks will be enabled again soon, but run separately as part of
https://juliaci.github.io/PkgBenchmark.jl/stable/. However they also need to be revised to make sure they don't keep running the same timestep in each benchmark iteration.