### PR TITLE
fix drains

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -34,6 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relation to precipitation and evapotranspiration fluxes. This was set to the fixed Wflow
   `basetimestep` of 86400 s, and should be set to the actual model time step from the TOML
   configuration file.
+- Add `flux` from `Drainage` (`GroundwaterFlow`) in the `sbm_gwf_model` to the overland flow
+  component instead of the river component of the kinematic wave.
 
 ## v0.3.1 - 2021-05-19
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed option `constanthead = false` (TOML file), `constant_head` field of
   `GroundwaterFlow` was not defined in this case. Fixed this by initialising empty fields
   (Vector) for struct `ConstantHead`.
+- Fixed return max(0, boundary.flux[index]) to return max(0, flux) the flux should be returned
+  when cell is dry, no negative value allowed.
+- Fixed path to initialize lake to: dirname(static_path) 
+- Fixed outflow = 0, when lake level is below lake threshold. Before a negative value
+  could enter the log function and model would fail. 
 
 ## v0.3.1 - 2021-05-19
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   configuration file.
 - Add `flux` from `Drainage` (`GroundwaterFlow`) in the `sbm_gwf_model` to the overland flow
   component instead of the river component of the kinematic wave.
+- Fixed option `constanthead = false` (TOML file), `constant_head` field of
+  `GroundwaterFlow` was not defined in this case. Fixed this by initialising empty fields
+  (Vector) for struct `ConstantHead`.
 
 ## v0.3.1 - 2021-05-19
 

--- a/src/groundwater/boundary_conditions.jl
+++ b/src/groundwater/boundary_conditions.jl
@@ -2,7 +2,7 @@ function check_flux(flux, aquifer::UnconfinedAquifer, index::Int)
     # Check if cell is dry
     if aquifer.head[index] <= aquifer.bottom[index]
         # If cell is dry, no negative flux is allowed
-        return max(0, boundary.flux[index])
+        return max(0, flux)
     else
         return flux
     end

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -463,13 +463,17 @@ function update(lake::NaturalLake, i, inflow, doy, timestepsecs)
         else
             if diff_wl >= 0.0
                 if lake.waterlevel[i] > lake.threshold[i]
-                    outflow = lake.b[i] * pow((lake.waterlevel[i] - lake.threshold[i]), lake.e[i])
+                    outflow =
+                        lake.b[i] * pow((lake.waterlevel[i] - lake.threshold[i]), lake.e[i])
                 else
                     outflow = Float(0)
                 end
             else
                 if lake.waterlevel[lo] > lake.threshold[i]
-                    outflow = -1.0 * lake.b[i] * pow((lake.waterlevel[lo] - lake.threshold[i]), lake.e[i])
+                    outflow =
+                        -1.0 *
+                        lake.b[i] *
+                        pow((lake.waterlevel[lo] - lake.threshold[i]), lake.e[i])
                 else
                     outflow = Float(0)
                 end

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -213,7 +213,7 @@ function initialize_sbm_gwf_model(config::Config)
         index_constanthead = filter(i -> !isequal(constanthead[i], mv), 1:n)
         constant_head = ConstantHead(constanthead[index_constanthead], index_constanthead)
     else
-        constant_head = ConstantHead{Float}([],[])
+        constant_head = ConstantHead{Float}(Float[],Int64[])
     end
 
     conductivity = ncread(

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -212,6 +212,8 @@ function initialize_sbm_gwf_model(config::Config)
         )
         index_constanthead = filter(i -> !isequal(constanthead[i], mv), 1:n)
         constant_head = ConstantHead(constanthead[index_constanthead], index_constanthead)
+    else
+        constant_head = ConstantHead{Float}([],[])
     end
 
     conductivity = ncread(

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -98,12 +98,12 @@ function initialize_sbm_gwf_model(config::Config)
     ldd_2d = ncread(nc, param(config, "input.ldd"); allow_missing = true)
 
     ldd = ldd_2d[inds]
-    dl = fill(Wflow.mv, n)
-    dw = fill(Wflow.mv, n)
-    sw = fill(Wflow.mv, n)
+    dl = fill(mv, n)
+    dw = fill(mv, n)
+    sw = fill(mv, n)
 
     for i = 1:n
-        dl[i] = Wflow.detdrainlength(ldd[i], xl[i], yl[i])
+        dl[i] = detdrainlength(ldd[i], xl[i], yl[i])
         dw[i] = (xl[i] * yl[i]) / dl[i]
         sw[i] = river[i] ? max(dw[i] - riverwidth[i], 0.0) : dw[i]
     end
@@ -297,9 +297,12 @@ function initialize_sbm_gwf_model(config::Config)
         # check if drain occurs where overland flow is not possible (sw = 0.0)
         # and correct if this is the case
         false_drain = filter(i -> !isequal(drain[i], 0) && sw[i] == Float(0), 1:n)
-        if length(false_drain) > 0
+        n_false_drain = length(false_drain)
+        if n_false_drain > 0
             drain_2d[inds[false_drain]] .= 0
             drain[false_drain] .= 0
+            @info "$n_false_drain drain locations are removed that occur where overland flow
+             is not possible (overland flow width is zero)"
         end
         inds_drain, rev_inds_drain = active_indices(drain_2d, 0)
 

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -213,7 +213,7 @@ function initialize_sbm_gwf_model(config::Config)
         index_constanthead = filter(i -> !isequal(constanthead[i], mv), 1:n)
         constant_head = ConstantHead(constanthead[index_constanthead], index_constanthead)
     else
-        constant_head = ConstantHead{Float}(Float[],Int64[])
+        constant_head = ConstantHead{Float}(Float[], Int64[])
     end
 
     conductivity = ncread(

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -81,7 +81,7 @@ function initialize_sbm_gwf_model(config::Config)
     if do_lakes
         lakes, lakeindex, lake, pits = initialize_natural_lake(
             config,
-            static_path,
+            dirname(static_path),
             nc,
             inds_riv,
             nriv,

--- a/test/groundwater.jl
+++ b/test/groundwater.jl
@@ -222,6 +222,7 @@ end
         @testset "minimum_head-confined" begin
             original_head = copy(conf_aqf.head)
             conf_aqf.head[1] = -10.0
+            @test Wflow.check_flux(-1.0, conf_aqf, 1) == -1.0
             @test Wflow.minimum_head(conf_aqf)[1] == -10.0
             conf_aqf.head .= original_head
         end
@@ -229,6 +230,7 @@ end
         @testset "minimum_head-unconfined" begin
             original_head = copy(unconf_aqf.head)
             unconf_aqf.head[1] = -10.0
+            @test Wflow.check_flux(-1.0, unconf_aqf, 1) == 0.0
             @test Wflow.minimum_head(conf_aqf)[1] == 0.0
             unconf_aqf.head .= original_head
         end

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -40,7 +40,7 @@ end
 
 @testset "overland flow" begin
     q = model.lateral.land.q_av
-    @test sum(q) ≈ 0.0
+    @test sum(q) ≈ 2.2298616f-7
 end
 
 @testset "river domain" begin


### PR DESCRIPTION
Link the drain flux from GroundwaterFlow to the overland flow component (sbm_gwf_model.jl). This flux was only linked to the river kinematic wave. After some discussion with @laurenebouaziz and @Huite we decided to link the drain flux only to the overland flow component. There is also a check if drains are located where overland does not occur (because of the river width. the overland flow width may be set to zero), and if this is the case these drain locations are removed.