### PR TITLE
re-initialize lake storage with warm waterlevel

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed path to initialize lake to: dirname(static_path) 
 - Fixed outflow = 0, when lake level is below lake threshold. Before a negative value
   could enter the log function and model would fail. 
+- Fixed the lake storage initialization. For continuation runs (`reinit = false`), this
+  caused the lake to be reset to the initial conditions instead of the saved state.
 
 ## v0.3.1 - 2021-05-19
 

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -337,6 +337,13 @@ function initialize_sbm_model(config::Config)
         vertical.zi .= zi
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         lateral.river.volume .= lateral.river.h .* lateral.river.width .* lateral.river.dl
+
+        if do_lakes
+            # storage must be re-initialized after loading the state with the current
+            # waterlevel otherwise the storage will be based on the initial water level
+            lakes.storage .=
+                initialize_storage(lakes.storfunc, lakes.area, lakes.waterlevel, lakes.sh)
+        end
     end
 
     # make sure the forcing is already loaded


### PR DESCRIPTION
Before this it was only initialized in `initialize_natural_lake`, which ran before the lake waterlevel was loaded from the state (if present). This effectively caused the lakes to be reset back to their initial cold start condition.