### PR TITLE
fix get_alias for variables with expanded definition

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -56,7 +56,12 @@ function Base.setproperty!(config::Config, f::Symbol, x)
 end
 
 function get_alias(config::Config, key, alias, default)
-    get(Dict(config), key, get(Dict(config), alias, default))
+    dict = Dict(config)
+    path = pathof(config)
+    alias_or_default = get(dict, alias, default)
+    a = get(dict, key, alias_or_default)
+    # if it is a Dict, wrap the result in Config
+    return a isa AbstractDict ? Config(a, path) : a
 end
 
 # also used in autocomplete
@@ -95,9 +100,13 @@ function ncvar_name_modifier(var; verbose = true)
             end
         elseif haskey(var, "value")
             modifier = (scale = 1.0, offset = 0.0, value = param(var, "value"))
+        else
+            error("Unrecognized modifier $(Dict(var))")
         end
-    else
+    elseif isa(var, String)
         ncname = var
+    else
+        error("Unknown type")
     end
     return ncname, modifier
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -24,10 +24,19 @@ config = Wflow.Config(tomlpath)
     @test collect(keys(config.output)) == ["lateral", "vertical", "path"]
 
     # theta_s can also be provided under the alias θₛ
-    Wflow.get_alias(config.input.vertical, "theta_s", "θₛ", nothing) == "thetaR"
+    @test Wflow.get_alias(config.input.vertical, "theta_s", "θₛ", nothing) == "thetaS"
     val = pop!(config.input.vertical, "theta_s")
     config.input.vertical["θₛ"] = val
-    Wflow.get_alias(config.input.vertical, "theta_s", "θₛ", nothing) == "thetaR"
+    @test Wflow.get_alias(config.input.vertical, "theta_s", "θₛ", nothing) == "thetaS"
+
+    # modifiers can also be applied
+    kvconf = Wflow.get_alias(config.input.vertical, "kv_0", "kv₀", nothing)
+    @test kvconf isa Wflow.Config
+    ncname, modifier = Wflow.ncvar_name_modifier(kvconf)
+    @test ncname === "KsatVer"
+    @test modifier.scale == 1.0
+    @test modifier.offset == 0.0
+    @test modifier.value === nothing
 end
 
 @testset "Clock constructor" begin

--- a/test/sbm_config.toml
+++ b/test/sbm_config.toml
@@ -69,7 +69,6 @@ f = "f"
 infiltcappath = "InfiltCapPath"
 infiltcapsoil = "InfiltCapSoil"
 kext = "Kext"
-kv_0 = "KsatVer"
 leaf_area_index = "LAI"
 maxleakage = "MaxLeakage"
 pathfrac = "PathFrac"
@@ -88,6 +87,11 @@ water_holding_capacity = "WHC"
 waterfrac = "WaterFrac"
 theta_r = "thetaR"
 theta_s = "thetaS"
+
+[input.vertical.kv_0]
+netcdf.variable.name = "KsatVer"
+scale = 1.0
+offset = 0.0
 
 [input.lateral.river]
 length = "wflow_riverlength"


### PR DESCRIPTION
After #154 the variables that had aliases could no longer also have modifiers in the TOML, since `get_alias` returned a Dict instead of a Config. This fixes that and adds tests.