### PR TITLE
Option to fix alpha value in the kinematic wave

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Option `update_alpha`. When true (default) the ``\alpha`` parameter of the kinematic wave
+  is updated because of changes in water height (this can result in large water balance
+  errors). When false a fixed ``\alpha`` is used. See also [Surface routing](@ref).
+
 ## v0.4.0 - 2021-09-02
 
 ### Changed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Option `update_alpha`. When true (default) the ``\alpha`` parameter of the kinematic wave
-  is updated because of changes in water height (this can result in large water balance
-  errors). When false a fixed ``\alpha`` is used. See also [Surface routing](@ref).
+- Option `update_alpha`. When true the ``\alpha`` parameter of the kinematic wave is updated
+  because of changes in water height (this can result in large water balance errors). When
+  false (default) a fixed ``\alpha`` is used. See also [Surface routing](@ref).
 
 ## v0.4.0 - 2021-09-02
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-### Added
-- Option `update_alpha`. When true the ``\alpha`` parameter of the kinematic wave is updated
-  because of changes in water height (this can result in large water balance errors). When
-  false (default) a fixed ``\alpha`` is used. See also [Surface routing](@ref).
+### Changed
+- The ``\alpha`` parameter of the kinematic wave has a fixed value now and is not updated
+  because of changes in water height (this could result in large water balance errors). See
+  also [Surface routing](@ref).
 
 ## v0.4.0 - 2021-09-02
 

--- a/docs/src/lateral/kinwave.md
+++ b/docs/src/lateral/kinwave.md
@@ -34,25 +34,17 @@ kw_river_tstep = 900
 kw_land_tstep = 3600
 ```
 
-By default the ``\alpha`` parameter of the kinematic wave is fixed and not updated because
-of changes in water height (wetted perimeter). There is an option to update the ``\alpha``
-value, by setting the option `update_alpha` to true in the TOML file (note that this can
-result in large water balance errors):
-
-```toml
-[model]
-update_alpha = true
-```
-
-For the river part a bankfull height map (default value is 1.0 m) can be provided as
-follows, to calculate the fixed ``\alpha`` value based on half bankfull height:
+The ``\alpha`` parameter of the kinematic wave is fixed. To estimate the wetted perimeter
+for the calculation of the ``\alpha`` parameter a bankfull height map (default value is 1.0
+m) for the river can be provided as follows: 
 
 ```toml
 [input.lateral.river]
 h_bankfull = "river_bankfullheight"
 ```
-For the land part the wetted perimeter is based on the flow width for the fixed ``\alpha``
-value.
+
+The wetted perimeter of the river is based on half bankfull height. For the land part the
+wetted perimeter is based on the flow width.
 
 ## Subsurface flow routing
 In the SBM model the kinematic wave approach is used to route subsurface flow laterally. The

--- a/docs/src/lateral/kinwave.md
+++ b/docs/src/lateral/kinwave.md
@@ -33,6 +33,27 @@ kw_river_tstep = 900
 # Fixed sub-timestep for iterations of overland flow (land cells)
 kw_land_tstep = 3600
 ```
+
+By default the ``\alpha`` parameter of the kinematic wave is updated because of changes in
+water height (wetted perimeter). This can result in large water balance errors. To reduce
+these errors, there is an option to run with a fixed ``\alpha`` value, by setting the option
+`update_alpha` to false in the TOML file:
+
+```toml
+[model]
+update_alpha = false
+```
+
+For the river part a bankfull height map (default value is 1.0 m) can be provided as
+follows, to calculate the fixed ``\alpha`` value based on half bankfull height:
+
+```toml
+[input.lateral.river]
+h_bankfull = "river_bankfullheight"
+```
+For the land part the wetted perimeter is based on the flow width for the fixed ``\alpha``
+value.
+
 ## Subsurface flow routing
 In the SBM model the kinematic wave approach is used to route subsurface flow laterally. The
 saturated store ``S`` can be drained laterally by saturated downslope subsurface flow per

--- a/docs/src/lateral/kinwave.md
+++ b/docs/src/lateral/kinwave.md
@@ -34,14 +34,14 @@ kw_river_tstep = 900
 kw_land_tstep = 3600
 ```
 
-By default the ``\alpha`` parameter of the kinematic wave is updated because of changes in
-water height (wetted perimeter). This can result in large water balance errors. To reduce
-these errors, there is an option to run with a fixed ``\alpha`` value, by setting the option
-`update_alpha` to false in the TOML file:
+By default the ``\alpha`` parameter of the kinematic wave is fixed and not updated because
+of changes in water height (wetted perimeter). There is an option to update the ``\alpha``
+value, by setting the option `update_alpha` to true in the TOML file (note that this can
+result in large water balance errors):
 
 ```toml
 [model]
-update_alpha = false
+update_alpha = true
 ```
 
 For the river part a bankfull height map (default value is 1.0 m) can be provided as

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -28,8 +28,7 @@
     reservoir::R                            # Reservoir model struct of arrays
     lake::L                                 # Lake model struct of arrays
     kinwave_it::Bool                        # Boolean for iterations kinematic wave
-    update_alpha::Bool                      # Boolean to update α when h is changing
-
+    
     # TODO unclear why this causes a MethodError
     # function SurfaceFlow{T,R,L}(args...) where {T,R,L}
     #     equal_size_vectors(args)
@@ -57,12 +56,8 @@ function update(
     ns = length(subdomain_order)
 
     @. sf.alpha_term = pow(sf.n / sqrt(sf.sl), sf.β)
-    if sf.update_alpha
-        @. sf.α = sf.alpha_term * pow(sf.width + 2.0 * sf.h, sf.alpha_pow)
-    else
-        # use fixed alpha value based on 0.5 * h_bankfull
-        @. sf.α = sf.alpha_term * pow(sf.width + sf.h_bankfull, sf.alpha_pow)
-    end
+    # use fixed alpha value based on 0.5 * h_bankfull
+    @. sf.α = sf.alpha_term * pow(sf.width + sf.h_bankfull, sf.alpha_pow)
 
     # two options for iteration, fixed or based on courant number.
     if sf.kinwave_it
@@ -165,15 +160,6 @@ function update(
                     # update alpha
                     crossarea = sf.α[v] * pow(sf.q[v], sf.β)
                     sf.h[v] = crossarea / sf.width[v]
-                    if sf.update_alpha
-                        wetper = sf.width[v] + (2.0 * sf.h[v]) # wetted perimeter
-                        α = sf.α[v]
-                        sf.α[v] = sf.alpha_term[v] * pow(wetper, sf.alpha_pow)
-                        if abs(α - sf.α[v]) > sf.eps
-                            crossarea = sf.α[v] * pow(sf.q[v], sf.β)
-                            sf.h[v] = crossarea / sf.width[v]
-                        end
-                    end
 
                     sf.q_av[v] += sf.q[v]
                     sf.h_av[v] += sf.h[v]

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -172,9 +172,9 @@ function update(
                         if abs(α - sf.α[v]) > sf.eps
                             crossarea = sf.α[v] * pow(sf.q[v], sf.β)
                             sf.h[v] = crossarea / sf.width[v]
-                        end                  
+                        end
                     end
-                    
+
                     sf.q_av[v] += sf.q[v]
                     sf.h_av[v] += sf.h[v]
                 end

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -60,7 +60,8 @@ function update(
     if sf.update_alpha
         @. sf.α = sf.alpha_term * pow(sf.width + 2.0 * sf.h, sf.alpha_pow)
     else
-        @. sf.α = sf.alpha_term * pow(sf.width + 2.0 * 0.5 * sf.h_bankfull, sf.alpha_pow)
+        # use fixed alpha value based on 0.5 * h_bankfull
+        @. sf.α = sf.alpha_term * pow(sf.width + sf.h_bankfull, sf.alpha_pow)
     end
 
     # two options for iteration, fixed or based on courant number.

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -27,6 +27,8 @@
     lake_index::Vector{Int} | "-"           # map cell to 0 (no lake) or i (pick lake i in lake field)
     reservoir::R                            # Reservoir model struct of arrays
     lake::L                                 # Lake model struct of arrays
+    kinwave_it::Bool                        # Boolean for iterations kinematic wave
+    update_alpha::Bool                      # Boolean to update α when h is changing
 
     # TODO unclear why this causes a MethodError
     # function SurfaceFlow{T,R,L}(args...) where {T,R,L}
@@ -42,8 +44,6 @@ function update(
     network;
     frac_toriver = nothing,
     inflow_wb = nothing,
-    do_iter = false,
-    update_alpha = true,
     doy = 0,
 )
     @unpack graph,
@@ -57,14 +57,14 @@ function update(
     ns = length(subdomain_order)
 
     @. sf.alpha_term = pow(sf.n / sqrt(sf.sl), sf.β)
-    if update_alpha
+    if sf.update_alpha
         @. sf.α = sf.alpha_term * pow(sf.width + 2.0 * sf.h, sf.alpha_pow)
     else
         @. sf.α = sf.alpha_term * pow(sf.width + 2.0 * 0.5 * sf.h_bankfull, sf.alpha_pow)
     end
 
     # two options for iteration, fixed or based on courant number.
-    if do_iter
+    if sf.kinwave_it
         if sf.its > 0
             its = sf.its
         else
@@ -164,7 +164,7 @@ function update(
                     # update alpha
                     crossarea = sf.α[v] * pow(sf.q[v], sf.β)
                     sf.h[v] = crossarea / sf.width[v]
-                    if update_alpha
+                    if sf.update_alpha
                         wetper = sf.width[v] + (2.0 * sf.h[v]) # wetted perimeter
                         α = sf.α[v]
                         sf.α[v] = sf.alpha_term[v] * pow(wetper, sf.alpha_pow)

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -22,9 +22,10 @@ function initialize_hbv_model(config::Config)
 
     kw_river_tstep = get(config.model, "kw_river_tstep", 0)
     kw_land_tstep = get(config.model, "kw_land_tstep", 0)
+    kinwave_it = get(config.model, "kin_wave_iteration", false)::Bool
+    update_alpha = get(config.model, "update_alpha", true)::Bool
 
     nc = NCDataset(static_path)
-    dims = dimnames(nc[param(config, "input.subcatchment")])
 
     subcatch_2d = ncread(nc, param(config, "input.subcatchment"); allow_missing = true)
     # indices based on catchment
@@ -269,9 +270,6 @@ function initialize_hbv_model(config::Config)
 
     threshold = fc .* lp
 
-    altitude =
-        ncread(nc, param(config, "input.vertical.altitude"); sel = inds, type = Float)
-
     hbv = HBV{Float}(
         Δt = Float(tosecond(Δt)),
         n = n,
@@ -412,6 +410,7 @@ function initialize_hbv_model(config::Config)
         volume = zeros(Float, n),
         h = zeros(Float, n),
         h_av = zeros(Float, n),
+        h_bankfull = zeros(Float,n),
         Δt = Float(tosecond(Δt)),
         its = kw_land_tstep > 0 ? Int(cld(tosecond(Δt), kw_land_tstep)) : kw_land_tstep,
         width = dw,
@@ -427,6 +426,8 @@ function initialize_hbv_model(config::Config)
         lake_index = fill(0, n),
         reservoir = nothing,
         lake = nothing,
+        kinwave_it = kinwave_it,
+        update_alpha = update_alpha,
     )
 
     graph = flowgraph(ldd, inds, pcr_dir)
@@ -441,6 +442,13 @@ function initialize_hbv_model(config::Config)
         param(config, "input.lateral.river.n", nothing);
         sel = inds_riv,
         defaults = 0.036,
+        type = Float,
+    )
+    h_bankfull = ncread(
+        nc,
+        param(config, "input.lateral.river.h_bankfull", nothing);
+        sel = inds_riv,
+        defaults = 1.0,
         type = Float,
     )
     ldd_riv = ldd_2d[inds_riv]
@@ -466,6 +474,7 @@ function initialize_hbv_model(config::Config)
         volume = zeros(Float, nriv),
         h = zeros(Float, nriv),
         h_av = zeros(Float, nriv),
+        h_bankfull = h_bankfull,
         Δt = Float(tosecond(Δt)),
         its = kw_river_tstep > 0 ? ceil(Int(tosecond(Δt) / kw_river_tstep)) :
               kw_river_tstep,
@@ -482,6 +491,8 @@ function initialize_hbv_model(config::Config)
         reservoir = do_reservoirs ? reservoirs : nothing,
         lake = do_lakes ? lakes : nothing,
         rivercells = river,
+        kinwave_it = kinwave_it,
+        update_alpha = update_alpha,
     )
 
     # setup subdomains for the land and river kinematic wave domain, if nthreads = 1
@@ -617,7 +628,6 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
         lateral.land,
         network.land,
         frac_toriver = network.frac_toriver,
-        do_iter = kinwave_it,
     )
 
     # determine lateral inflow (from overland flow) for river flow
@@ -631,14 +641,12 @@ function update(model::Model{N,L,V,R,W}) where {N,L,V<:HBV,R,W}
             lateral.river,
             network.river,
             inflow_wb = lateral.land.q_av[inds_riv],
-            do_iter = kinwave_it,
             doy = dayofyear(clock.time),
         )
     else
         update(
             lateral.river,
             network.river,
-            do_iter = kinwave_it,
             doy = dayofyear(clock.time),
         )
     end

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -23,7 +23,6 @@ function initialize_hbv_model(config::Config)
     kw_river_tstep = get(config.model, "kw_river_tstep", 0)
     kw_land_tstep = get(config.model, "kw_land_tstep", 0)
     kinwave_it = get(config.model, "kin_wave_iteration", false)::Bool
-    update_alpha = get(config.model, "update_alpha", false)::Bool
 
     nc = NCDataset(static_path)
 
@@ -427,7 +426,6 @@ function initialize_hbv_model(config::Config)
         reservoir = nothing,
         lake = nothing,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     graph = flowgraph(ldd, inds, pcr_dir)
@@ -492,7 +490,6 @@ function initialize_hbv_model(config::Config)
         lake = do_lakes ? lakes : nothing,
         rivercells = river,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     # setup subdomains for the land and river kinematic wave domain, if nthreads = 1

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -33,7 +33,6 @@ function initialize_sbm_gwf_model(config::Config)
     kw_river_tstep = get(config.model, "kw_river_tstep", 0)
     kw_land_tstep = get(config.model, "kw_land_tstep", 0)
     kinwave_it = get(config.model, "kin_wave_iteration", false)::Bool
-    update_alpha = get(config.model, "update_alpha", false)::Bool
 
     nc = NCDataset(static_path)
 
@@ -149,7 +148,6 @@ function initialize_sbm_gwf_model(config::Config)
         reservoir = nothing,
         lake = nothing,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     graph = flowgraph(ldd, inds, pcr_dir)
@@ -212,7 +210,6 @@ function initialize_sbm_gwf_model(config::Config)
         lake = do_lakes ? lakes : nothing,
         rivercells = river,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     # unconfined aquifer

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -23,7 +23,7 @@ function initialize_sbm_model(config::Config)
     kw_river_tstep = get(config.model, "kw_river_tstep", 0)
     kw_land_tstep = get(config.model, "kw_land_tstep", 0)
     kinwave_it = get(config.model, "kin_wave_iteration", false)::Bool
-    update_alpha = get(config.model, "update_alpha", true)::Bool
+    update_alpha = get(config.model, "update_alpha", false)::Bool
 
     nc = NCDataset(static_path)
 
@@ -172,7 +172,7 @@ function initialize_sbm_model(config::Config)
         volume = zeros(Float, n),
         h = zeros(Float, n),
         h_av = zeros(Float, n),
-        h_bankfull = zeros(Float,n),
+        h_bankfull = zeros(Float, n),
         Δt = Float(tosecond(Δt)),
         its = kw_land_tstep > 0 ? Int(cld(tosecond(Δt), kw_land_tstep)) : kw_land_tstep,
         width = sw,
@@ -448,11 +448,7 @@ function update_after_subsurfaceflow(model::Model{N,L,V,R,W}) where {N,L,V<:SBM,
     lateral.land.qlat .= lateral.land.inwater ./ lateral.land.dl
 
     # run kinematic wave for overland flow
-    update(
-        lateral.land,
-        network.land,
-        frac_toriver = network.frac_toriver,
-    )
+    update(lateral.land, network.land, frac_toriver = network.frac_toriver)
 
     # determine net runoff from vertical sbm concept in river cells, and lateral inflow from
     # overland flow lateral subsurface flow and net runoff to the river cells
@@ -485,11 +481,7 @@ function update_after_subsurfaceflow(model::Model{N,L,V,R,W}) where {N,L,V<:SBM,
             doy = dayofyear(clock.time),
         )
     else
-        update(
-            lateral.river,
-            network.river,
-            doy = dayofyear(clock.time),
-        )
+        update(lateral.river, network.river, doy = dayofyear(clock.time))
     end
     write_output(model)
 

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -23,7 +23,6 @@ function initialize_sbm_model(config::Config)
     kw_river_tstep = get(config.model, "kw_river_tstep", 0)
     kw_land_tstep = get(config.model, "kw_land_tstep", 0)
     kinwave_it = get(config.model, "kin_wave_iteration", false)::Bool
-    update_alpha = get(config.model, "update_alpha", false)::Bool
 
     nc = NCDataset(static_path)
 
@@ -189,7 +188,6 @@ function initialize_sbm_model(config::Config)
         reservoir = nothing,
         lake = nothing,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     graph = flowgraph(ldd, inds, pcr_dir)
@@ -255,7 +253,6 @@ function initialize_sbm_model(config::Config)
         lake = do_lakes ? lakes : nothing,
         rivercells = river,
         kinwave_it = kinwave_it,
-        update_alpha = update_alpha,
     )
 
     # setup subdomains for the land and river kinematic wave domain, if nthreads = 1

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -18,9 +18,9 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
         @testset "model information functions" begin
             @test BMI.get_component_name(model) == "sbm"
-            @test BMI.get_input_item_count(model) == 188
-            @test BMI.get_output_item_count(model) == 188
-            @test BMI.get_input_var_names(model)[[1, 5, 120, 188]] == [
+            @test BMI.get_input_item_count(model) == 186
+            @test BMI.get_output_item_count(model) == 186
+            @test BMI.get_input_var_names(model)[[1, 5, 120, 186]] == [
                 "vertical.Δt",
                 "vertical.n_unsatlayers",
                 "lateral.land.q_av",

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -50,7 +50,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
             @test BMI.get_current_time(model) == 9.467712e8
             @test mean(BMI.get_value(model, "vertical.zi")) ≈ 276.252648379751
             @test BMI.get_value_at_indices(model, "lateral.river.q", [1, 100, 5617]) ≈
-                  [0.9784867989663215, 1.6359646870951168, 0.027160430280557993]
+                  [0.977477441147684, 1.6249108073518905, 0.025951495367363228]
             BMI.set_value(model, "vertical.zi", fill(300.0, 50070))
             @test mean(BMI.get_value(model, "vertical.zi")) == 300.0
             BMI.set_value_at_indices(model, "vertical.zi", [1], [250.0])

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -18,9 +18,9 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
         @testset "model information functions" begin
             @test BMI.get_component_name(model) == "sbm"
-            @test BMI.get_input_item_count(model) == 182
-            @test BMI.get_output_item_count(model) == 182
-            @test BMI.get_input_var_names(model)[[1, 5, 120, 182]] == [
+            @test BMI.get_input_item_count(model) == 188
+            @test BMI.get_output_item_count(model) == 188
+            @test BMI.get_input_var_names(model)[[1, 5, 120, 188]] == [
                 "vertical.Δt",
                 "vertical.n_unsatlayers",
                 "lateral.land.q_av",

--- a/test/run_hbv.jl
+++ b/test/run_hbv.jl
@@ -13,10 +13,10 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
     row = csv_first_row(model.writer.csv_path)
 
     @test row.time == DateTime("2000-01-01T00:00:00")
-    @test row.Q ≈ 517.9761666607884f0
+    @test row.Q ≈ 514.5673131622699f0
     @test row.temp_bycoord ≈ 2.965437173843384f0
     @test row.temp_byindex ≈ 1.1716821193695068f0
-    @test row.Q_1 ≈ 501.6252231440609f0
+    @test row.Q_1 ≈ 498.0969773774267f0
     @test row.perc_33 ≈ 2.308000087738037f0
     @test row.perc_34 ≈ 1.8980000019073486f0
     @test row.perc_35 ≈ 2.7100000381469727f0
@@ -57,10 +57,10 @@ end
 
 @testset "river flow" begin
     q = model.lateral.river.q_av
-    @test sum(q) ≈ 51943.24072462076f0
+    @test sum(q) ≈ 52077.14258235775f0
     @test q[651] ≈ 5.693405508134953f0
     @test q[1056] ≈ 8.839306661545436f0
-    @test q[network.river.order[end]] ≈ 363.5647479049738f0
+    @test q[network.river.order[end]] ≈ 359.0484738820008f0
 end
 
 Wflow.close_files(model, delete_output = false)

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -14,29 +14,29 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
     row = csv_first_row(model.writer.csv_path)
 
     @test row.time == DateTime("2000-01-01T00:00:00")
-    @test row.Q ≈ 7.815587720999557f0
+    @test row.Q ≈ 7.680739298259266f0
     @test row.volume ≈ 2.7783643457819197f7
     @test row.temp_bycoord ≈ 2.3279826641082764f0
     @test row.temp_byindex ≈ 2.3279826641082764f0
-    @test row.Q_6336050 ≈ 0.02388490515704142f0
-    @test row.Q_6336510 ≈ 0.012411069754330572f0
-    @test row.Q_6836100 ≈ 0.004848609260578462f0
-    @test row.Q_6336500 ≈ 0.011474801875419624f0
-    @test row.Q_6836190 ≈ 0.0005262529349807199f0
-    @test row.Q_6336800 ≈ 0.013467698526109831f0
-    @test row.Q_6336900 ≈ 0.003408280699908697f0
-    @test row.Q_6336930 ≈ 0.09773275295006544f0
-    @test row.Q_6336910 ≈ 0.002147610203630289f0
-    @test row.Q_6336920 ≈ 0.002649393436607859f0
-    @test row.Q_6136100 ≈ 0.0008708128761381345f0
-    @test row.Q_6136500 ≈ 0.000729148906480041f0
-    @test row.Q_6136520 ≈ 0.002155395279410574f0
-    @test row.Q_6136150 ≈ 0.0022298329229975987f0
-    @test row.Q_6136151 ≈ 0.0031045027476524524f0
-    @test row.Q_6136160 ≈ 3.3423894540713786f0
-    @test row.Q_6136200 ≈ 1.358270076420503f0
-    @test row.Q_6136201 ≈ 5.942330218662147f0
-    @test row.Q_6136202 ≈ 1.680997341533662f0
+    @test row.Q_6336050 ≈ 0.02314152846188506f0
+    @test row.Q_6336510 ≈ 0.011829340015725808f0
+    @test row.Q_6836100 ≈ 0.004285433507347682f0
+    @test row.Q_6336500 ≈ 0.011434655691502343f0
+    @test row.Q_6836190 ≈ 0.0004903061800226998f0
+    @test row.Q_6336800 ≈ 0.013376156569068251f0
+    @test row.Q_6336900 ≈ 0.0033244344482295423f0
+    @test row.Q_6336930 ≈ 0.08966505345584352f0
+    @test row.Q_6336910 ≈ 0.0020127260170180474f0
+    @test row.Q_6336920 ≈ 0.002580440335740291f0
+    @test row.Q_6136100 ≈ 0.0008485772628065181f0
+    @test row.Q_6136500 ≈ 0.0006749692699499864f0
+    @test row.Q_6136520 ≈ 0.0019351916317406491f0
+    @test row.Q_6136150 ≈ 0.002126215608742851f0
+    @test row.Q_6136151 ≈ 0.0028804236661004205f0
+    @test row.Q_6136160 ≈ 3.279985818360295f0
+    @test row.Q_6136200 ≈ 1.259358422161174f0
+    @test row.Q_6136201 ≈ 5.803861903796768f0
+    @test row.Q_6136202 ≈ 1.6624100470042156f0
     @test row.recharge_1 ≈ -0.027398093386017383f0
 end
 
@@ -44,25 +44,25 @@ end
     ds = model.writer.dataset_scalar
     @test ds["time"][1] == DateTime("2000-01-01T00:00:00")
     @test ds["Q"][:] ≈ [
-        1.6809974f0,
-        5.9423304f0,
-        1.35827f0,
-        3.3423896f0,
-        0.0031045028f0,
-        0.0022298328f0,
-        0.0021553952f0,
-        0.0007291489f0,
-        0.00087081286f0,
-        0.0026493934f0,
-        0.0021476103f0,
-        0.09773275f0,
-        0.0034082807f0,
-        0.013467698f0,
-        0.00052625296f0,
-        0.011474802f0,
-        0.004848609f0,
-        0.01241107f0,
-        0.023884906f0,
+        1.66241f0,
+        5.803862f0,
+        1.2593584f0,
+        3.279986f0,
+        0.0028804236f0,
+        0.0021262157f0,
+        0.0019351917f0,
+        0.0006749693f0,
+        0.00084857724f0,
+        0.0025804404f0,
+        0.002012726f0,
+        0.089665055f0,
+        0.0033244344f0,
+        0.013376157f0,
+        0.0004903062f0,
+        0.011434656f0,
+        0.0042854333f0,
+        0.01182934f0,
+        0.023141528f0,
     ]
     @test ds["Q_gauges"].attrib["cf_role"] == "timeseries_id"
     @test ds["temp_index"][:] ≈ [2.3279827f0]
@@ -112,16 +112,16 @@ end
 
 @testset "river flow" begin
     q = model.lateral.river.q_av
-    @test sum(q) ≈ 2807.884971209105f0
-    @test q[1622] ≈ 0.0016288040314320486f0
-    @test q[43] ≈ 7.338169165884175f0
-    @test q[network.river.order[end]] ≈ 0.00610520650626283f0
+    @test sum(q) ≈ 2805.266510229795f0
+    @test q[1622] ≈ 0.0015498389046670307f0
+    @test q[43] ≈ 7.335279907301223f0
+    @test q[network.river.order[end]] ≈ 0.006068754125930134f0
 end
 
 @testset "reservoir simple" begin
     res = model.lateral.river.reservoir
     @test res.outflow[1] ≈ 0.2174998592483153f0
-    @test res.inflow[1] ≈ 50.170880189190626f0
+    @test res.inflow[1] ≈ 49.4653315798391f0
     @test res.volume[1] ≈ 2.776162917050312f7
     @test res.precipitation[1] ≈ 0.1765228509902954f0
     @test res.evaporation[1] ≈ 0.5372688174247742f0
@@ -154,10 +154,10 @@ end
 
 @testset "river flow at basin outlets and downstream of one pit" begin
     q = model.lateral.river.q_av
-    @test q[3908] ≈ 8.133439919732997f0 # pit/ outlet
-    @test q[3920] ≈ 0.008996073270597723f0 # downstream of pit 3908
-    @test q[2474] ≈ 156.84174051203257f0 # pit/ outlet
-    @test q[5650] ≈ 0.10882099888755865f0 # pit/ outlet
+    @test q[3908] ≈ 8.107901948181988f0 # pit/ outlet
+    @test q[3920] ≈ 0.008992215117496462f0 # downstream of pit 3908
+    @test q[2474] ≈ 156.71758046363857f0 # pit/ outlet
+    @test q[5650] ≈ 0.10849551740603759f0 # pit/ outlet
 end
 
 # test changing forcing and cyclic LAI parameter

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -13,7 +13,7 @@ flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
     row = csv_first_row(model.writer.csv_path)
 
     @test row.time == DateTime("2000-06-01T00:00:00")
-    @test row.Q_av ≈ 0.016260519762890745f0
+    @test row.Q_av ≈ 0.01620324716944374f0
     @test row.head ≈ 1.8416896245327632f0
 end
 
@@ -46,19 +46,19 @@ end
 @testset "river domain" begin
     q = model.lateral.river.q_av
     river = model.lateral.river
-    @test sum(q) ≈ 0.03515257228971982f0
-    @test q[6] ≈ 0.007952670041402076f0
-    @test river.volume[6] ≈ 3.8923529548071025f0
-    @test river.inwater[6] ≈ 0.0003950369148075657f0
-    @test q[13] ≈ 0.0005980549969548235f0
-    @test q[network.river.order[end]] ≈ 0.008482648782941154f0
+    @test sum(q) ≈ 0.034846861707851576f0
+    @test q[6] ≈ 0.007866587223009643f0
+    @test river.volume[6] ≈ 4.474556355925399f0
+    @test river.inwater[6] ≈ 0.00036392604840276924f0
+    @test q[13] ≈ 0.0005952292000597283f0
+    @test q[network.river.order[end]] ≈ 0.008387430132453135f0
 end
 
 @testset "groundwater" begin
     gw = model.lateral.subsurface
-    @test gw.river.stage[1] ≈ 1.21057153442702f0
+    @test gw.river.stage[1] ≈ 1.2123636929067039f0
     @test gw.flow.aquifer.head[19] ≈ 1.7999999523162842f0
-    @test gw.river.flux[1] ≈ -50.751898489778426f0
+    @test gw.river.flux[1] ≈ -50.46515313302901f0
     @test gw.drain.flux[1] ≈ 0.0
     @test gw.recharge.rate[19] ≈ -0.0014241196552847502f0
 end


### PR DESCRIPTION
When alpha is updated in the kinematic wave with the new h value (wetted perimeter), this creates water balance errors.
To avoid these errors and have a more closed water balance the alpha value is now fixed. A bankfull height map can be provided for the river part to calculate the fixed alpha value (based on half bankfull height). For the land part the wetted perimeter is based on the flow width only.