### PR TITLE
Fix subdaily sbm gwf

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Scaling of potential capillary rise is replaced by a common approach found in literature,
-  based on the water table depth `zi` and a maximum water depth `cap_hmax` beyond which
-  capillary rise ceases. See also [Transpiration and soil evaporation](@ref). Multiplying
-  the scaling factor with the ratio of model time step and `basetimestep` in the original
-  approach resulted in (much) smaller capillary fluxes at sub-daily model time steps
-  compared to daily model time steps, and is not used in the new approach. The parameter
-  `capscale` has been replaced by `cap_hmax`, references to `capscale` in a TOML file of
-  previous versions should replaced by `cap_hmax`.
+  based on the water table depth `zi`, a maximum water depth `cap_hmax` beyond which
+  capillary rise ceases, and a coefficient `cap_n`. See also [Transpiration and soil
+  evaporation](@ref). Multiplying the scaling factor with the ratio of model time step and
+  `basetimestep` in the original approach resulted in (much) smaller capillary fluxes at
+  sub-daily model time steps compared to daily model time steps, and is not used in the new
+  approach. Parameters `cap_hmax` and `cap_n` can be set through the TOML file, parameter
+  `capscale` of the previous approach is not used anymore.
 
 ### Fixed
 - Conversion of `GroundwaterFlow` boundaries [``m^3 d^{-1}``] as part of model concept

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Scaling of potential capillary rise is replaced by a common approach found in literature,
+  based on the water table depth `zi` and a maximum water depth `cap_hmax` beyond which
+  capillary rise ceases. See also [Transpiration and soil evaporation](@ref). Multiplying
+  the scaling factor with the ratio of model time step and `basetimestep` in the original
+  approach resulted in (much) smaller capillary fluxes at sub-daily model time steps
+  compared to daily model time steps, and is not used in the new approach. The parameter
+  `capscale` has been replaced by `cap_hmax`, references to `capscale` in a TOML file of
+  previous versions should replaced by `cap_hmax`.
+
+### Fixed
+- Conversion of `GroundwaterFlow` boundaries [``m^3 d^{-1}``] as part of model concept
+  `sbm_gwf` to ``m^3 s^{-1}`` for sub-daily model time steps. For the conversion the
+  `basetimestep` (86400 s) should be used (and not the model time step).
+
 ## v0.4.1 - 2021-11-04
 
 ### Changed

--- a/docs/src/vertical/parameters.md
+++ b/docs/src/vertical/parameters.md
@@ -43,7 +43,7 @@ specific_leaf = "Sl"
 | **`pathfrac`** | fraction of compacted area | - | 0.01  |
 | **`rootingdepth`** | rooting depth  | mm | 750.0  |
 | **`rootdistpar`** | controls how roots are linked to water table | - | -500.0  |
-| **`capscale`** | controlling capillary rise | mm | 100.0  |
+| **`cap_hmax`** | controlling capillary rise | mm | 2000.0  |
 | **`et_reftopot`** | multiplication factor to correct reference evaporation | - | 1.0  |
 | **`sl`** (`specific_leaf`) | specific leaf storage  | mm | - |
 | **`swood`** (`storage_wood`) | storage woody part of vegetation | mm | - |

--- a/docs/src/vertical/parameters.md
+++ b/docs/src/vertical/parameters.md
@@ -43,7 +43,8 @@ specific_leaf = "Sl"
 | **`pathfrac`** | fraction of compacted area | - | 0.01  |
 | **`rootingdepth`** | rooting depth  | mm | 750.0  |
 | **`rootdistpar`** | controls how roots are linked to water table | - | -500.0  |
-| **`cap_hmax`** | controlling capillary rise | mm | 2000.0  |
+| **`cap_hmax`** | water depth beyond which capillary flux ceases | mm | 2000.0  |
+| **`cap_n`** | coefficient controlling capillary rise | - | 2.0  |
 | **`et_reftopot`** | multiplication factor to correct reference evaporation | - | 1.0  |
 | **`sl`** (`specific_leaf`) | specific leaf storage  | mm | - |
 | **`swood`** (`storage_wood`) | storage woody part of vegetation | mm | - |
@@ -125,7 +126,7 @@ internal model parameter to the external netCDF variable.
 |  parameter | description    | unit | default |
 |:---------------| --------------- | ---------------------- | ----- |
 | **`cfmax`**  | degree-day factor | mm ᵒC``^{-1}`` Δt``^{-1}`` | 3.75653 mm ᵒC``^{-1}`` day``^{-1}``  |
-| **``tt`**  | threshold temperature for snowfall| ᵒC | -1.41934  |
+| **`tt`**  | threshold temperature for snowfall| ᵒC | -1.41934  |
 | **`tti`**  | threshold temperature interval length | ᵒC | 1.0  |
 | **`ttm`**  | threshold temperature for snowmelt  | ᵒC | -1.41934  |
 | **`whc`**  | water holding capacity as fraction of current snow pack  | - | 0.1  |

--- a/docs/src/vertical/sbm.md
+++ b/docs/src/vertical/sbm.md
@@ -327,23 +327,25 @@ block:
     maxcapflux = max(0.0, min(ksat, actevapustore, ustorecapacity, satwaterdepth))
 ```
 
-Then the potential rise `maxcapflux` is scaled using the water table depth `zi` and a
-maximum water depth `cap_hmax` [mm] beyond which capillary rise ceases as follows in the
-code block below (`i` refers to the index of the vector that contains all active cells
-within the spatial model domain):
+Then the potential rise `maxcapflux` is scaled using the water table depth `zi`, a maximum
+water depth `cap_hmax` [mm] beyond which capillary rise ceases and a coefficient `cap_n`
+[-], as follows in the code block below (`i` refers to the index of the vector that contains
+all active cells within the spatial model domain):
 
 ```julia
     if sbm.zi[i] > rootingdepth
         capflux =
-            maxcapflux *
-            pow(1.0 - min(sbm.zi[i], sbm.cap_hmax[i]) / (sbm.cap_hmax[i]), 2.0)
+            maxcapflux * pow(
+                1.0 - min(sbm.zi[i], sbm.cap_hmax[i]) / (sbm.cap_hmax[i]),
+                sbm.cap_n[i],
+            )
     else
         capflux = 0.0
     end
 ```
 
 If the roots reach the water table (`rootingdepth` ``\ge`` `sbm.zi`), `capflux` is set to
-zero and thus setting the capillary rise `capflux` to zero.
+zero.
 
 Finally, the capillary rise `capflux` is limited by the unsaturated store deficit (one or
 multiple layers), calculated as follows in the code block below (`i` refers to the index of

--- a/docs/src/vertical/sbm.md
+++ b/docs/src/vertical/sbm.md
@@ -327,25 +327,23 @@ block:
     maxcapflux = max(0.0, min(ksat, actevapustore, ustorecapacity, satwaterdepth))
 ```
 
-Then the potential rise `maxcapflux` is scaled using the distance between the roots and the
-water table as follows in the code block below (`i` refers to the index of the vector that
-contains all active cells within the spatial model domain):
+Then the potential rise `maxcapflux` is scaled using the water table depth `zi` and a
+maximum water depth `cap_hmax` [mm] beyond which capillary rise ceases as follows in the
+code block below (`i` refers to the index of the vector that contains all active cells
+within the spatial model domain):
 
 ```julia
     if sbm.zi[i] > rootingdepth
-        capfluxscale =
-            sbm.capscale[i] / (sbm.capscale[i] + sbm.zi[i] - rootingdepth) *
-            (sbm.Δt / tosecond(basetimestep))
+        capflux =
+            maxcapflux *
+            pow(1.0 - min(sbm.zi[i], sbm.cap_hmax[i]) / (sbm.cap_hmax[i]), 2.0)
     else
-        capfluxscale = 0.0
+        capflux = 0.0
     end
-    capflux = maxcapflux * capfluxscale
 ```
 
-where `capfluxscale` [-] is the scaling factor to multiply the potential rise `maxcapflux`
-with, `sbm.capscale` [mm] is a model parameter (default = 100) and `rootingdepth` [mm] the
-rooting depth. If the roots reach the water table (`rootingdepth` ``\ge`` `sbm.zi`),
-`capfluxscale` is set to zero and thus setting the capillary rise `capflux` to zero.
+If the roots reach the water table (`rootingdepth` ``\ge`` `sbm.zi`), `capflux` is set to
+zero and thus setting the capillary rise `capflux` to zero.
 
 Finally, the capillary rise `capflux` is limited by the unsaturated store deficit (one or
 multiple layers), calculated as follows in the code block below (`i` refers to the index of

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -411,14 +411,14 @@ function initialize_sbm(nc, config, riverfrac, inds)
         sel = inds,
         defaults = 10.0,
         type = Float,
-    ) #.* (Δt / basetimestep)
+    ) .* (Δt / basetimestep)
     infiltcapsoil = ncread(
         nc,
         param(config, "input.vertical.infiltcapsoil", nothing);
         sel = inds,
         defaults = 100.0,
         type = Float,
-    ) #.* (Δt / basetimestep)
+    ) .* (Δt / basetimestep)
     maxleakage =
         ncread(
             nc,

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -42,7 +42,7 @@
     # Controls how roots are linked to water table [-]
     rootdistpar::Vector{T} | "-"
     # Parameter [mm] controlling capillary rise
-    capscale::Vector{T} | "mm"
+    cap_hmax::Vector{T} | "mm"
     # Multiplication factor [-] to correct
     et_reftopot::Vector{T} | "-"
     # Brooks-Corey power coefﬁcient [-] for each soil layer
@@ -405,22 +405,20 @@ function initialize_sbm(nc, config, riverfrac, inds)
         defaults = 2000.0,
         type = Float,
     )
-    infiltcappath =
-        ncread(
-            nc,
-            param(config, "input.vertical.infiltcappath", nothing);
-            sel = inds,
-            defaults = 10.0,
-            type = Float,
-        ) .* (Δt / basetimestep)
-    infiltcapsoil =
-        ncread(
-            nc,
-            param(config, "input.vertical.infiltcapsoil", nothing);
-            sel = inds,
-            defaults = 100.0,
-            type = Float,
-        ) .* (Δt / basetimestep)
+    infiltcappath = ncread(
+        nc,
+        param(config, "input.vertical.infiltcappath", nothing);
+        sel = inds,
+        defaults = 10.0,
+        type = Float,
+    ) #.* (Δt / basetimestep)
+    infiltcapsoil = ncread(
+        nc,
+        param(config, "input.vertical.infiltcapsoil", nothing);
+        sel = inds,
+        defaults = 100.0,
+        type = Float,
+    ) #.* (Δt / basetimestep)
     maxleakage =
         ncread(
             nc,
@@ -488,11 +486,11 @@ function initialize_sbm(nc, config, riverfrac, inds)
         defaults = -500.0,
         type = Float,
     )
-    capscale = ncread(
+    cap_hmax = ncread(
         nc,
-        param(config, "input.vertical.capscale", nothing);
+        param(config, "input.vertical.cap_hmax", nothing);
         sel = inds,
-        defaults = 100.0,
+        defaults = 2000.0,
         type = Float,
     )
     et_reftopot = ncread(
@@ -560,7 +558,7 @@ function initialize_sbm(nc, config, riverfrac, inds)
         pathfrac = pathfrac,
         rootingdepth = rootingdepth,
         rootdistpar = rootdistpar,
-        capscale = capscale,
+        cap_hmax = cap_hmax,
         et_reftopot = et_reftopot,
         c = svectorscopy(c, Val{maxlayers}()),
         stemflow = fill(mv, n),
@@ -948,13 +946,12 @@ function update_until_recharge(sbm::SBM, config)
             maxcapflux = max(0.0, min(ksat, actevapustore, ustorecapacity, satwaterdepth))
 
             if sbm.zi[i] > rootingdepth
-                capfluxscale =
-                    sbm.capscale[i] / (sbm.capscale[i] + sbm.zi[i] - rootingdepth) *
-                    (sbm.Δt / tosecond(basetimestep))
+                capflux =
+                    maxcapflux *
+                    pow(1.0 - min(sbm.zi[i], sbm.cap_hmax[i]) / (sbm.cap_hmax[i]), 2.0)
             else
-                capfluxscale = 0.0
+                capflux = 0.0
             end
-            capflux = maxcapflux * capfluxscale
 
             netcapflux = capflux
             for k = n_usl:-1:1

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -18,12 +18,12 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
         @testset "model information functions" begin
             @test BMI.get_component_name(model) == "sbm"
-            @test BMI.get_input_item_count(model) == 186
-            @test BMI.get_output_item_count(model) == 186
-            @test BMI.get_input_var_names(model)[[1, 5, 120, 186]] == [
+            @test BMI.get_input_item_count(model) == 187
+            @test BMI.get_output_item_count(model) == 187
+            @test BMI.get_input_var_names(model)[[1, 5, 120, 187]] == [
                 "vertical.Δt",
                 "vertical.n_unsatlayers",
-                "lateral.land.q_av",
+                "lateral.land.qin",
                 "lateral.river.reservoir.evaporation",
             ]
         end


### PR DESCRIPTION
- Changed the scaling of capillary rise, now based on a common approach found in literature.
- Fixed conversion of boundaries of `GroundwaterFlow` [m3/d] to m3/s in `sbm_gwf` model concept (conversion was based on model time step and should be based on basetimestep (86400 s).