### PR TITLE
add support for dir_input and dir_output

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Optional `dir_input` and `dir_output` keys in the TOML, which can be used to quickly
+  change the path for all input or output files that are given as a relative path.
+
 ## v0.5.0 - 2021-11-12
 
 ### Changed

--- a/docs/src/config.md
+++ b/docs/src/config.md
@@ -2,7 +2,7 @@
 
 [TOML](https://github.com/toml-lang/toml) is used as the configuration format for models
 available in wflow. File paths included in the configuration TOML file are relative to the
-TOML file location.
+TOML file location, or to `dir_input` and `dir_output` if they are given.
 
 ## General time info
 Time information is optional. When left out, each time step in the forcing NetCDF will be
@@ -21,6 +21,8 @@ endtime = 2000-02-01T00:00:00                   # optional, default from forcing
 starttime = 2000-01-01T00:00:00                 # optional, default from forcing NetCDF
 time_units = "days since 1900-01-01 00:00:00"   # optional, this is default value
 timestepsecs = 86400                            # optional, default from forcing NetCDF
+dir_input = "data/input"                        # optional, default is the path of the TOML
+dir_output = "data/output"                      # optional, default is the path of the TOML
 ```
 
 ## Model section
@@ -53,8 +55,8 @@ the entire `state` section can be left out.
 
 ```toml
 [state]
-path_input = "data/instates-moselle.nc" 
-path_output = "data/outstates-moselle.nc"
+path_input = "instates-moselle.nc" 
+path_output = "outstates-moselle.nc"
 
 [state.vertical]
 satwaterdepth = "satwaterdepth"
@@ -95,9 +97,9 @@ mapped a default value will be used if available.
 
 ```toml
 [input]
-# use "data/forcing-year-*.nc" if forcing files are split in time
-path_forcing = "data/forcing-moselle.nc"
-path_static = "data/staticmaps-moselle.nc"
+# use "forcing-year-*.nc" if forcing files are split in time
+path_forcing = "forcing-moselle.nc"
+path_static = "staticmaps-moselle.nc"
 
 # these are not directly part of the model
 gauges = "wflow_gauges"
@@ -180,7 +182,7 @@ netCDF variables.
 
 ```toml
 [output]
-path = "data/output_moselle.nc"
+path = "output_moselle.nc"
 
 [output.vertical]
 satwaterdepth = "satwaterdepth"
@@ -220,7 +222,7 @@ Delft-FEWS can ingest this data format directly.
 
 ```toml
 [netcdf]
-path = "data/output_scalar_moselle.nc"
+path = "output_scalar_moselle.nc"
 
 [[netcdf.variable]]
 name = "Q"
@@ -268,7 +270,7 @@ list. You may specify as many entries as you wish.
 
 ```toml
 [csv]
-path = "data/output_moselle.csv"
+path = "output_moselle.csv"
 
 [[csv.column]]
 header = "Q"

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -6,8 +6,7 @@ Config object. Will return a Model that is ready to run.
 """
 function initialize_hbv_model(config::Config)
     # unpack the paths to the NetCDF files
-    tomldir = dirname(config)
-    static_path = joinpath(tomldir, config.input.path_static)
+    static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)
     clock = Clock(config, reader)
@@ -357,7 +356,6 @@ function initialize_hbv_model(config::Config)
     if do_lakes
         lakes, lakeindex, lake, pits = initialize_natural_lake(
             config,
-            static_path,
             nc,
             inds_riv,
             nriv,
@@ -560,7 +558,7 @@ function initialize_hbv_model(config::Config)
 
     # read and set states in model object if reinit=true
     if reinit == false
-        instate_path = joinpath(tomldir, config.state.path_input)
+        instate_path = input_path(config, config.state.path_input)
         state_ncnames = ncnames(config.state)
         set_states(instate_path, model, state_ncnames; type = Float)
         # update kinematic wave volume for river and land domain

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -211,7 +211,7 @@ end
     end
 end
 
-function initialize_natural_lake(config, path, nc, inds_riv, nriv, pits, Δt)
+function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
     # read only lake data if lakes true
     # allow lakes only in river cells
     # note that these locations are only the lake outlet pixels
@@ -318,6 +318,9 @@ function initialize_natural_lake(config, path, nc, inds_riv, nriv, pits, Δt)
     sh = Vector{Union{SH,Missing}}(missing, n_lakes)
     hq = Vector{Union{HQ,Missing}}(missing, n_lakes)
     lowerlake_ind = fill(0, n_lakes)
+    # lake CSV parameter files are expected in the same directory as path_static
+    path = dirname(input_path(config, config.input.path_static))
+
     for i = 1:n_lakes
         lakeloc = lakelocs[i]
         if linked_lakelocs[i] > 0

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -16,8 +16,7 @@ Will return a Model that is ready to run.
 function initialize_sbm_gwf_model(config::Config)
 
     # unpack the paths to the NetCDF files
-    tomldir = dirname(config)
-    static_path = joinpath(tomldir, config.input.path_static)
+    static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)
     clock = Clock(config, reader)
@@ -80,7 +79,6 @@ function initialize_sbm_gwf_model(config::Config)
     if do_lakes
         lakes, lakeindex, lake, pits = initialize_natural_lake(
             config,
-            dirname(static_path),
             nc,
             inds_riv,
             nriv,
@@ -443,7 +441,7 @@ function initialize_sbm_gwf_model(config::Config)
 
     # read and set states in model object if reinit=false
     if reinit == false
-        instate_path = joinpath(tomldir, config.state.path_input)
+        instate_path = input_path(config, config.state.path_input)
         state_ncnames = ncnames(config.state)
         set_states(instate_path, model, state_ncnames, type = Float)
         # update kinematic wave volume for river and land domain

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -7,8 +7,7 @@ Config object. Will return a Model that is ready to run.
 function initialize_sbm_model(config::Config)
 
     # unpack the paths to the NetCDF files
-    tomldir = dirname(config)
-    static_path = joinpath(tomldir, config.input.path_static)
+    static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)
     clock = Clock(config, reader)
@@ -68,7 +67,6 @@ function initialize_sbm_model(config::Config)
     if do_lakes
         lakes, lakeindex, lake, pits = initialize_natural_lake(
             config,
-            dirname(static_path),
             nc,
             inds_riv,
             nriv,
@@ -332,7 +330,7 @@ function initialize_sbm_model(config::Config)
 
     # read and set states in model object if reinit=false
     if reinit == false
-        instate_path = joinpath(tomldir, config.state.path_input)
+        instate_path = input_path(config, config.state.path_input)
         state_ncnames = ncnames(config.state)
         set_states(instate_path, model, state_ncnames; type = Float)
         @unpack lateral, vertical = model

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -7,8 +7,7 @@ Config object. Will return a Model that is ready to run.
 function initialize_sediment_model(config::Config)
 
     # unpack the paths to the NetCDF files
-    tomldir = dirname(config)
-    static_path = joinpath(tomldir, config.input.path_static)
+    static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)
     clock = Clock(config, reader)
@@ -143,7 +142,7 @@ function initialize_sediment_model(config::Config)
 
     # read and set states in model object if reinit=false
     if reinit == false
-        instate_path = joinpath(tomldir, config.state.path_input)
+        instate_path = input_path(config, config.state.path_input)
         state_ncnames = ncnames(config.state)
         set_states(instate_path, model, state_ncnames; type = Float)
     end

--- a/test/hbv_config.toml
+++ b/test/hbv_config.toml
@@ -10,8 +10,8 @@ time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 
 [state]
-path_input = "data/instates-lahn.nc"
-path_output = "data/outstates-lahn.nc"
+path_input = "data/input/instates-lahn.nc"
+path_output = "data/output/outstates-lahn.nc"
 
 # if listed, the variable must be present in the NetCDF or error
 # if not listed, the variable can get a default value if it has one
@@ -33,8 +33,8 @@ h = "h_land"
 q = "q_land"
 
 [input]
-path_forcing = "data/forcing-lahn.nc"
-path_static = "data/staticmaps-lahn.nc"
+path_forcing = "data/input/forcing-lahn.nc"
+path_static = "data/input/staticmaps-lahn.nc"
 
 # these are not directly part of the model
 gauges = "wflow_gauges"
@@ -93,7 +93,7 @@ snow = true
 type = "hbv"
 
 [output]
-path = "data/output_lahn.nc"
+path = "data/output/output_lahn.nc"
 
 [output.vertical]
 lowerzonestorage = "lowerzonestorage"
@@ -106,7 +106,7 @@ upperzonestorage = "upperzonestorage"
 q = "q"
 
 [csv]
-path = "data/output_lahn.csv"
+path = "data/output/output_lahn.csv"
 
 [[csv.column]]
 header = "Q"

--- a/test/io.jl
+++ b/test/io.jl
@@ -19,7 +19,7 @@ config = Wflow.Config(tomlpath)
     # test if the values are parsed as expected
     @test config.starttime === DateTime(2000)
     @test config.endtime === DateTime(2000, 2)
-    @test config.output.path == "data/output_moselle.nc"
+    @test config.output.path == "output_moselle.nc"
     @test config.output isa Wflow.Config
     @test collect(keys(config.output)) == ["lateral", "vertical", "path"]
 
@@ -37,13 +37,25 @@ config = Wflow.Config(tomlpath)
     @test modifier.scale == 1.0
     @test modifier.offset == 0.0
     @test modifier.value === nothing
+
+    # test the optional "dir_input" and "dir_output" keys
+    @test haskey(config, "dir_input")
+    @test haskey(config, "dir_output")
+    @test Wflow.input_path(config, config.state.path_input) == joinpath(@__DIR__, "data", "input", "instates-moselle.nc")
+    @test Wflow.output_path(config, config.state.path_output) == joinpath(@__DIR__, "data", "output", "outstates-moselle.nc")
+    # hbv_config doesn't use dir_input and dir_output
+    hbv_config = Wflow.Config(joinpath(@__DIR__, "hbv_config.toml"))
+    @test !haskey(hbv_config, "dir_input")
+    @test !haskey(hbv_config, "dir_output")
+    @test Wflow.input_path(hbv_config, hbv_config.state.path_input) == joinpath(@__DIR__, "data", "input", "instates-lahn.nc")
+    @test Wflow.output_path(hbv_config, hbv_config.state.path_output) == joinpath(@__DIR__, "data", "output", "outstates-lahn.nc")
 end
 
 @testset "Clock constructor" begin
     config = Wflow.Config(tomlpath)
 
     # mock a NCReader object
-    ncpath = joinpath(dirname(pathof(config)), config.input.path_forcing)
+    ncpath = Wflow.input_path(config, config.input.path_forcing)
     ds = NCDataset(ncpath)
     reader = (; dataset = ds)
 

--- a/test/reservoir_lake.jl
+++ b/test/reservoir_lake.jl
@@ -59,8 +59,8 @@ end
 
 datadir = joinpath(@__DIR__, "data")
 sh = [
-    Wflow.read_sh_csv(joinpath(datadir, "lake_sh_1.csv")),
-    Wflow.read_sh_csv(joinpath(datadir, "lake_sh_2.csv")),
+    Wflow.read_sh_csv(joinpath(datadir, "input", "lake_sh_1.csv")),
+    Wflow.read_sh_csv(joinpath(datadir, "input", "lake_sh_2.csv")),
 ]
 @testset "linked lakes (HBV)" begin
     @test keys(sh[1]) == (:H, :S)
@@ -78,7 +78,7 @@ sh = [
         b = [140.0, 0.0],
         e = [1.5, 1.5],
         sh = sh,
-        hq = [missing, Wflow.read_hq_csv(joinpath(datadir, "lake_hq_2.csv"))],
+        hq = [missing, Wflow.read_hq_csv(joinpath(datadir, "input", "lake_hq_2.csv"))],
         waterlevel = [395.03027, 394.87833],
         precipitation = [10.0, 10.0],
         evaporation = [2.0, 2.0],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,11 +21,12 @@ const Float = Wflow.Float
 # ensure test data is present
 testdir = @__DIR__
 datadir = joinpath(testdir, "data")
-isdir(datadir) || mkdir(datadir)
+inputdir = joinpath(datadir, "input")
+isdir(inputdir) || mkpath(inputdir)
 
 "Download a test data file if it does not already exist"
 function testdata(version, source_filename, target_filename)
-    target_path = joinpath(datadir, target_filename)
+    target_path = joinpath(inputdir, target_filename)
     base_url = "https://github.com/visr/wflow-artifacts/releases/download"
     url = string(base_url, '/', string('v', version), '/', source_filename)
     isfile(target_path) || Downloads.download(url, target_path)

--- a/test/sbm_config.toml
+++ b/test/sbm_config.toml
@@ -8,10 +8,12 @@ endtime = 2000-02-01T00:00:00
 starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
+dir_input = "data/input"
+dir_output = "data/output"
 
 [state]
-path_input = "data/instates-moselle.nc"
-path_output = "data/outstates-moselle.nc"
+path_input = "instates-moselle.nc"
+path_output = "outstates-moselle.nc"
 
 # if listed, the variable must be present in the NetCDF or error
 # if not listed, the variable can get a default value if it has one
@@ -41,8 +43,8 @@ h_av = "h_av_land"
 q = "q_land"
 
 [input]
-path_forcing = "data/forcing-moselle.nc"
-path_static = "data/staticmaps-moselle.nc"
+path_forcing = "forcing-moselle.nc"
+path_static = "staticmaps-moselle.nc"
 
 # these are not directly part of the model
 gauges = "wflow_gauges"
@@ -127,7 +129,7 @@ type = "sbm"
 min_streamorder = 3
 
 [output]
-path = "data/output_moselle.nc"
+path = "output_moselle.nc"
 
 [output.vertical]
 canopystorage = "canopystorage"
@@ -152,7 +154,7 @@ h = "h_land"
 q = "q_land"
 
 [netcdf]
-path = "data/output_scalar_moselle.nc"
+path = "output_scalar_moselle.nc"
 
 [[netcdf.variable]]
 name = "Q"
@@ -174,7 +176,7 @@ index.y = 264
 parameter = "vertical.temperature"
 
 [csv]
-path = "data/output_moselle.csv"
+path = "output_moselle.csv"
 
 [[csv.column]]
 header = "Q"

--- a/test/sbm_gw.toml
+++ b/test/sbm_gw.toml
@@ -8,10 +8,12 @@ endtime = 2000-02-01T00:00:00
 starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
+dir_input = "data/input"
+dir_output = "data/output"
 
 [state]
-path_input = "data/instates-moselle.nc"
-path_output = "data/outstates-moselle.nc"
+path_input = "instates-moselle.nc"
+path_output = "outstates-moselle.nc"
 
 # if listed, the variable must be present in the NetCDF or error
 # if not listed, the variable can get a default value if it has one
@@ -38,8 +40,8 @@ h_av = "h_av_land"
 q = "q_land"
 
 [input]
-path_forcing = "data/forcing-moselle.nc"
-path_static = "data/staticmaps-moselle.nc"
+path_forcing = "forcing-moselle.nc"
+path_static = "staticmaps-moselle.nc"
 
 # these are not directly part of the model
 gauges = "wflow_gauges"
@@ -116,7 +118,7 @@ thicknesslayers = [100, 300, 800]
 type = "sbm"
 
 [output]
-path = "data/output_moselle.nc"
+path = "output_moselle.nc"
 
 [output.vertical]
 canopystorage = "canopystorage"
@@ -138,7 +140,7 @@ h = "h_land"
 q = "q_land"
 
 [netcdf]
-path = "data/output_scalar_moselle.nc"
+path = "output_scalar_moselle.nc"
 
 [[netcdf.variable]]
 name = "Q"
@@ -160,7 +162,7 @@ index.y = 264
 parameter = "vertical.temperature"
 
 [csv]
-path = "data/output_moselle.csv"
+path = "output_moselle.csv"
 
 [[csv.column]]
 header = "Q"

--- a/test/sbm_gwf_config.toml
+++ b/test/sbm_gwf_config.toml
@@ -8,10 +8,12 @@ endtime = 2000-06-30T00:00:00
 starttime = 2000-06-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
+dir_input = "data/input"
+dir_output = "data/output"
 
 [state]
-path_input = "data/instates-example-sbm-gwf.nc"
-path_output = "data/outstates-example-sbm-gwf.nc"
+path_input = "instates-example-sbm-gwf.nc"
+path_output = "outstates-example-sbm-gwf.nc"
 
 # if listed, the variable must be present in the NetCDF or error
 # if not listed, the variable can get a default value if it has one
@@ -33,8 +35,8 @@ q = "q_land"
 head = "head"
 
 [input]
-path_forcing = "data/forcing-sbm-groundwater-part*.nc"
-path_static = "data/staticmaps-sbm-groundwater.nc"
+path_forcing = "forcing-sbm-groundwater-part*.nc"
+path_static = "staticmaps-sbm-groundwater.nc"
 
 # these are not directly part of the model
 ldd = "wflow_ldd"
@@ -96,7 +98,7 @@ thicknesslayers = [100, 300, 800]
 type = "sbm_gwf"
 
 [output]
-path = "data/output_example-sbm-gwf.nc"
+path = "output_example-sbm-gwf.nc"
 
 [output.vertical]
 canopystorage = "canopystorage"
@@ -120,7 +122,7 @@ flux = "drain_flux"
 flux = "flux"
 
 [csv]
-path = "data/output_example-sbm-gwf.csv"
+path = "output_example-sbm-gwf.csv"
 
 [[csv.column]]
 header = "Q_av"

--- a/test/sbm_simple.toml
+++ b/test/sbm_simple.toml
@@ -4,10 +4,12 @@
 # TOML documentation: https://github.com/toml-lang/toml
 
 endtime = 2000-01-10T00:00:00
+dir_input = "data/input"
+dir_output = "data/output"
 
 [input]
-path_forcing = "data/forcing-moselle.nc"
-path_static = "data/staticmaps-moselle.nc"
+path_forcing = "forcing-moselle.nc"
+path_static = "staticmaps-moselle.nc"
 
 # these are not directly part of the model
 ldd = "wflow_ldd"
@@ -84,7 +86,7 @@ thicknesslayers = [100, 300, 800]
 type = "sbm"
 
 [csv]
-path = "data/output_moselle_simple.csv"
+path = "output_moselle_simple.csv"
 
 [[csv.column]]
 coordinate.x = 7.378

--- a/test/sediment_config.toml
+++ b/test/sediment_config.toml
@@ -8,10 +8,12 @@ endtime = 2000-01-03T00:00:00
 starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
+dir_input = "data/input"
+dir_output = "data/output"
 
 [state]
-path_input = "data/instates-moselle-sed.nc"
-path_output = "data/outstates-moselle-sed.nc"
+path_input = "instates-moselle-sed.nc"
+path_output = "outstates-moselle-sed.nc"
 
 # if listed, the variable must be present in the NetCDF or error
 # if not listed, the variable can get a default value if it has one
@@ -37,8 +39,8 @@ siltload = "siltload"
 siltstore = "siltstore"
 
 [input]
-path_forcing = "data/forcing-moselle-sed.nc"
-path_static = "data/staticmaps-moselle-sed.nc"
+path_forcing = "forcing-moselle-sed.nc"
+path_static = "staticmaps-moselle-sed.nc"
 
 # these are not directly part of the model
 gauges = "wflow_gauges"
@@ -123,7 +125,7 @@ runrivermodel = true
 type = "sediment" 
 
 [output]
-path = "data/output-moselle-sed.nc"
+path = "output-moselle-sed.nc"
 
 [output.vertical]
 TCclay = "TCclay"
@@ -152,7 +154,7 @@ outclay = "outclay"
 width = "widthriv"
 
 [csv]
-path = "data/output-moselle-sediment.csv"
+path = "output-moselle-sediment.csv"
 
 [[csv.column]]
 coordinate.x = 6.931


### PR DESCRIPTION
Until now, the paths to the files were all either absolute or relative to the TOML. This makes is flexible because you can point to wherever you want. One downside, compared to the more rigid approach used before, is that it makes it hard to try quickly send all output to a new directory when trying things out, as you have to change all the output paths in the TOML.

This should relieve that, as you can now just add a `dir_input` and `dir_output` key in the TOML. If they are not added, nothing changes, so this is not breaking. These folders are only used for paths that are not absolute. `dir_input` and `dir_output` can also be absolute if needed.
