### PR TITLE
disallow NaN in ncread if allow_missing=false

### DIFF
--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -399,6 +399,8 @@ function initialize_hbv_model(config::Config)
 
     riverlength = riverlength_2d[inds_riv]
     riverwidth = riverwidth_2d[inds_riv]
+    minimum(riverlength) > 0 || error("river length must be positive on river cells")
+    minimum(riverwidth) > 0 || error("river width must be positive on river cells")
 
     ldd_riv = ldd_2d[inds_riv]
     if do_pits

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -122,6 +122,8 @@ function initialize_sbm_gwf_model(config::Config)
     # river flow (kinematic wave)
     riverlength = riverlength_2d[inds_riv]
     riverwidth = riverwidth_2d[inds_riv]
+    minimum(riverlength) > 0 || error("river length must be positive on river cells")
+    minimum(riverwidth) > 0 || error("river width must be positive on river cells")
 
     ldd_riv = ldd_2d[inds_riv]
     graph_riv = flowgraph(ldd_riv, inds_riv, pcr_dir)

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -161,6 +161,8 @@ function initialize_sbm_model(config::Config)
 
     riverlength = riverlength_2d[inds_riv]
     riverwidth = riverwidth_2d[inds_riv]
+    minimum(riverlength) > 0 || error("river length must be positive on river cells")
+    minimum(riverwidth) > 0 || error("river width must be positive on river cells")
 
     ldd_riv = ldd_2d[inds_riv]
     if do_pits

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -95,8 +95,12 @@ function initialize_sediment_model(config::Config)
     # the indices of the river cells in the land(+river) cell vector
     βₗ = ncread(nc, param(config, "input.lateral.land.slope"); sel = inds, type = Float)
     clamp!(βₗ, 0.00001, Inf)
+
     riverlength = riverlength_2d[inds_riv]
     riverwidth = riverwidth_2d[inds_riv]
+    minimum(riverlength) > 0 || error("river length must be positive on river cells")
+    minimum(riverwidth) > 0 || error("river width must be positive on river cells")
+
     ldd_riv = ldd_2d[inds_riv]
     graph_riv = flowgraph(ldd_riv, inds_riv, pcr_dir)
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -260,9 +260,14 @@ function ncread(
         if isnothing(fill)
             # errors if missings are found
             A = nomissing(A)
+            if any(isnan, A)
+                error("NaN not allowed in $var")
+            end
         else
             # replaces missings with a fill value
             A = nomissing(A, fill)
+            # replace also NaN values with the fill value
+            replace!(x -> isnan(x) ? fill : x, A)
         end
     end
 


### PR DESCRIPTION
If the fill value of the netCDF is NaN, NCDatasets will make it a missing. But if that is not the case and we don't want missings, I cannot think of any case where we would want NaN.

This will work for instance to catch NaN values if they are present in the river width with the current call to ncread:

```julia
ncread(nc, param(config, "input.lateral.river.width"); type = Float, fill = 0)
```