### PR TITLE
fix surface flow width

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   width.
 - Fixed use of absolute path for `path_forcing` in TOML file, which gave an error in Wflow
   v0.5.1.
+- When the surface flow width for overland flow is zero, the water level `h` of the
+  kinematic wave should not be calculated, otherwise this results in `NaN` values. When the
+  model is initialized from state files, `q` and `h` are set to zero for indices with a zero
+  surface flow width.
 
 ## v0.5.1 - 2021-11-24
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -321,9 +321,11 @@ function update(
                         end
                     end
 
-                    # update h
-                    crossarea = sf.α[v] * pow(sf.q[v], sf.β)
-                    sf.h[v] = crossarea / sf.width[v]
+                    # update h, only if surface width (overland flow) > 0.0
+                    if sf.width[v] > 0.0
+                        crossarea = sf.α[v] * pow(sf.q[v], sf.β)
+                        sf.h[v] = crossarea / sf.width[v]
+                    end
 
                     sf.q_av[v] += sf.q[v]
                     sf.h_av[v] += sf.h[v]

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -503,9 +503,12 @@ function initialize_hbv_model(config::Config)
         # update kinematic wave volume for river and land domain
         @unpack lateral = model
         # makes sure land cells with zero flow width are set to zero q and h
-        i = findall(==(0.0), lateral.land.width)
-        lateral.land.q[i] .= 0.0
-        lateral.land.h[i] .= 0.0
+        for i in eachindex(lateral.land.width)
+            if lateral.land.width[i] <= 0.0
+                lateral.land.q[i] = 0.0
+                lateral.land.h[i] = 0.0
+            end
+        end
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         lateral.river.volume .= lateral.river.h .* lateral.river.width .* lateral.river.dl
 

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -502,6 +502,10 @@ function initialize_hbv_model(config::Config)
         set_states(instate_path, model, state_ncnames; type = Float)
         # update kinematic wave volume for river and land domain
         @unpack lateral = model
+        # makes sure land cells with zero flow width are set to zero q and h
+        i = findall(==(0.0), lateral.land.width)
+        lateral.land.q[i] .= 0.0
+        lateral.land.h[i] .= 0.0
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         lateral.river.volume .= lateral.river.h .* lateral.river.width .* lateral.river.dl
 

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -386,9 +386,12 @@ function initialize_sbm_gwf_model(config::Config)
         # update kinematic wave volume for river and land domain
         @unpack lateral = model
         # makes sure land cells with zero flow width are set to zero q and h
-        i = findall(==(0.0), lateral.land.width)
-        lateral.land.q[i] .= 0.0
-        lateral.land.h[i] .= 0.0
+        for i in eachindex(lateral.land.width)
+            if lateral.land.width[i] <= 0.0
+                lateral.land.q[i] = 0.0
+                lateral.land.h[i] = 0.0
+            end
+        end
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         lateral.river.volume .= lateral.river.h .* lateral.river.width .* lateral.river.dl
 

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -385,6 +385,10 @@ function initialize_sbm_gwf_model(config::Config)
         set_states(instate_path, model, state_ncnames, type = Float)
         # update kinematic wave volume for river and land domain
         @unpack lateral = model
+        # makes sure land cells with zero flow width are set to zero q and h
+        i = findall(==(0.0), lateral.land.width)
+        lateral.land.q[i] .= 0.0
+        lateral.land.h[i] .= 0.0
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         lateral.river.volume .= lateral.river.h .* lateral.river.width .* lateral.river.dl
 

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -316,9 +316,12 @@ function initialize_sbm_model(config::Config)
             )
         vertical.zi .= zi
         # makes sure land cells with zero flow width are set to zero q and h
-        i = findall(==(0.0), lateral.land.width)
-        lateral.land.q[i] .= 0.0
-        lateral.land.h[i] .= 0.0
+        for i in eachindex(lateral.land.width)
+            if lateral.land.width[i] <= 0.0
+                lateral.land.q[i] = 0.0
+                lateral.land.h[i] = 0.0
+            end
+        end
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         # only set active cells for river (ignore boundary conditions/ghost points)
         lateral.river.volume[1:nriv] .=

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -315,6 +315,10 @@ function initialize_sbm_model(config::Config)
                 vertical.satwaterdepth ./ (vertical.θₛ .- vertical.θᵣ),
             )
         vertical.zi .= zi
+        # makes sure land cells with zero flow width are set to zero q and h
+        i = findall(==(0.0), lateral.land.width)
+        lateral.land.q[i] .= 0.0
+        lateral.land.h[i] .= 0.0
         lateral.land.volume .= lateral.land.h .* lateral.land.width .* lateral.land.dl
         # only set active cells for river (ignore boundary conditions/ghost points)
         lateral.river.volume[1:nriv] .=


### PR DESCRIPTION
When the surface flow width for overland flow is zero, h of the kinematic wave should not be calculated, otherwise this results in NaN values.