### PR TITLE
Fix issues #181 and #191

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed how number of iterations `its` for kinematic wave river flow are calculated during
   initialization when using a fixed sub-timestep (specified in the TOML file). For a model
   timestep smaller than the fixed sub-timestep an InexactError was thrown.
+- Fixed providing a cyclic parameter when the NetCDF variable is read during model
+  initialization with `ncread`, this gave an error about the size of the NetCDF `time`
+  dimension.
 
 ## v0.5.1 - 2021-11-24
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kinematic wave should not be calculated, otherwise this results in `NaN` values. When the
   model is initialized from state files, `q` and `h` are set to zero for indices with a zero
   surface flow width.
+- Fixed how number of iterations `its` for kinematic wave river flow are calculated during
+  initialization when using a fixed sub-timestep (specified in the TOML file). For a model
+  timestep smaller than the fixed sub-timestep an InexactError was thrown.
 
 ## v0.5.1 - 2021-11-24
 

--- a/src/flow.jl
+++ b/src/flow.jl
@@ -163,7 +163,7 @@ function initialize_surfaceflow_river(
         h_av = zeros(Float, n),
         h_bankfull = h_bankfull,
         Δt = Float(tosecond(Δt)),
-        its = tstep > 0 ? ceil(Int(tosecond(Δt) / tstep)) : tstep,
+        its = tstep > 0 ? Int(cld(tosecond(Δt), tstep)) : tstep,
         width = width,
         wb_pit = wb_pit,
         alpha_pow = Float((2.0 / 3.0) * 0.6),


### PR DESCRIPTION
Fixing issues https://github.com/Deltares/Wflow.jl/issues/191 and https://github.com/Deltares/Wflow.jl/issues/181.

Issue https://github.com/Deltares/Wflow.jl/issues/181 is fixed by checking if the NetCDF variable `var` has dimension `time` in the `ncread` function. If this is the case, it is a cyclic parameter that is handled by the `update_cyclic!` function.