### PR TITLE
Change unit of lateral subsurface flow (ssf)

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Re-organized the documentation: moved explanation of different model concepts to a model
   documentation section, added a user guide to explain setting up the model, added new 
   figures to the description of wflow\_sbm.
+- The unit of lateral subsurface flow `ssf` of `LateralSSF` is now ``m^3 d^{-1}``. The unit
+  was ``m^3 t^{-1}``, where ``t`` is the model timestep. Other flow variables are already
+  stored independently from ``t``, this allows for easier interpretation and to use states
+  independently of ``t``.
 
 ## v0.5.2 - 2022-02-03 
 

--- a/docs/src/model_docs/params_lateral.md
+++ b/docs/src/model_docs/params_lateral.md
@@ -130,23 +130,22 @@ description of these parameters, the unit, and default value if applicable.
 
 | parameter | description  	        | unit | default |
 |:---------------| --------------- | ---------------------- | ----- |    
-| `kh₀`          | horizontal hydraulic conductivity at soil surface  | m Δt``^{-1}`` |  - |
+| `kh₀`          | horizontal hydraulic conductivity at soil surface  | m d``^{-1}`` |  - |
 | `f` | a scaling parameter (controls exponential decline of kh₀) | m``^{-1}``  | - |
 | `soilthickness` | soil thickness | m  | - |
 | `θₛ` | saturated water content (porosity) | -  | - |
 | `θᵣ` | residual water content  | -  | - |
-| `t` | time step | Δt s  | - |
-| `Δt` | model time step | s  | - |
+| `Δt` | model time step | d  | - |
 | `βₗ` | slope | -  | - |
 | `dl` | drain length | m | - |
 | `dw` | drain width | m | - |
 | `zi` | pseudo-water table depth (top of the saturated zone) | m | - |
-| `exfiltwater` | exfiltration (groundwater above surface level, saturated excess conditions) | m | - |
-| `recharge` | net recharge to saturated store  | m | - |
-| `ssf` | subsurface flow  | m``^3`` Δt``{-1}``  | - |
-| `ssfin` | inflow from upstream cells | m``^3`` Δt``{-1}``  | - |
-| `ssfmax` | maximum subsurface flow | m``^2`` Δt``{-1}``  | - |
-| `to_river` | part of subsurface flow that flows to the river | m``^3`` Δt``{-1}``  | - |
+| `exfiltwater` | exfiltration (groundwater above surface level, saturated excess conditions) | m Δt⁻¹ | - |
+| `recharge` | net recharge to saturated store  | m Δt⁻¹ | - |
+| `ssf` | subsurface flow  | m``^3`` d``{-1}``  | - |
+| `ssfin` | inflow from upstream cells | m``^3`` d``{-1}``  | - |
+| `ssfmax` | maximum subsurface flow | m``^2`` d``{-1}``  | - |
+| `to_river` | part of subsurface flow that flows to the river | m``^3`` d``{-1}``  | - |
 | `wb_pit` | boolean location (0 or 1) of a waterbody (wb, reservoir or lake) | -  | - |
 
 ## Local inertial

--- a/src/horizontal_process.jl
+++ b/src/horizontal_process.jl
@@ -88,7 +88,7 @@ function kinematic_wave_ssf(ssfin, ssfₜ₋₁, ziₜ₋₁, r, kh₀, β, θ�
         # Term of the continuity equation for Newton-Raphson iteration for iteration 1
         # because celerity Cn is depending on zi, the increase or decrease of zi is moved to the recharge term of the continuity equation
         # then (1./Cn)*ssfₜ₋₁ can be replaced with (1./Cn)*ssf, and thus celerity and lateral flow rate ssf are then in line
-        c = (Δt / Δx) * ssfin + (1.0 / Cn) * ssf + Δt * (r - (ziₜ₋₁ - zi) * θₑ * dw)
+        c = (Δt / Δx) * ssfin + (1.0 / Cn) * ssf + (r - (ziₜ₋₁ - zi) * θₑ * dw)
 
         # Continuity equation of which solution should be zero
         fQ = (Δt / Δx) * ssf + (1.0 / Cn) * ssf - c
@@ -111,7 +111,7 @@ function kinematic_wave_ssf(ssfin, ssfₜ₋₁, ziₜ₋₁, r, kh₀, β, θ�
             # Term of the continuity equation for given Newton-Raphson iteration m
             # because celerity Cn is depending on zi, the increase or decrease of zi is moved to the recharge term of the continuity equation
             # then (1./Cn)*ssfₜ₋₁ can be replaced with (1./Cn)*ssf, and thus celerity and lateral flow rate ssf are then in line
-            c = (Δt / Δx) * ssfin + (1.0 / Cn) * ssf + Δt * (r - (ziₜ₋₁ - zi) * θₑ * dw)
+            c = (Δt / Δx) * ssfin + (1.0 / Cn) * ssf + (r - (ziₜ₋₁ - zi) * θₑ * dw)
 
             # Continuity equation of which solution should be zero
             fQ = (Δt / Δx) * ssf + (1.0 / Cn) * ssf - c
@@ -132,7 +132,7 @@ function kinematic_wave_ssf(ssfin, ssfₜ₋₁, ziₜ₋₁, r, kh₀, β, θ�
         # Constrain the lateral flow rate ssf
         ssf = min(ssf, (ssfmax * dw))
         # On the basis of the lateral flow rate, estimate the amount of groundwater level above surface (saturation excess conditions), then rest = negative
-        rest = ziₜ₋₁ - (ssfin + r * Δx - ssf) / (dw * Δx) / θₑ
+        rest = ziₜ₋₁ - (ssfin * Δt + r * Δx - ssf * Δt) / (dw * Δx) / θₑ
         # In case the groundwater level lies above surface (saturation excess conditions, rest = negative), calculate the exfiltration rate and set groundwater back to zero.
         exfilt = min(rest, 0.0) * -θₑ
         zi = clamp(zi, 0.0, d)

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -147,8 +147,8 @@ function initialize_sbm_model(config::Config)
             type = Float,
         )
 
-        # unit for lateral subsurface flow component is [m]
-        kh₀ = khfrac .* sbm.kv₀ .* 0.001
+        # unit for lateral subsurface flow component is [m³ d⁻¹], sbm.kv₀ [mm Δt⁻¹]
+        kh₀ = khfrac .* sbm.kv₀ .* 0.001 .* (basetimestep / Δt)
         f = sbm.f .* 1000.0
         zi = sbm.zi .* 0.001
         soilthickness = sbm.soilthickness .* 0.001
@@ -160,8 +160,7 @@ function initialize_sbm_model(config::Config)
             soilthickness = soilthickness,
             θₛ = sbm.θₛ,
             θᵣ = sbm.θᵣ,
-            Δt = tosecond(Δt),
-            t = 1.0,
+            Δt = Δt / basetimestep,
             βₗ = βₗ,
             dl = dl,
             dw = dw,
@@ -177,7 +176,7 @@ function initialize_sbm_model(config::Config)
         # when the SBM model is coupled (BMI) to a groundwater model, the following
         # variables are expected to be exchanged from the groundwater model.
         ssf = GroundwaterExchange{Float}(
-            Δt = tosecond(Δt),
+            Δt = Δt / basetimestep,
             exfiltwater = fill(mv, n),
             zi = fill(mv, n),
             to_river = fill(mv, n),
@@ -502,7 +501,7 @@ function update_after_subsurfaceflow(
         lateral.subsurface.exfiltwater * 1000.0,
     )
 
-    ssf_toriver = lateral.subsurface.to_river ./ lateral.subsurface.Δt
+    ssf_toriver = lateral.subsurface.to_river ./ tosecond(basetimestep)
     surface_routing(model, ssf_toriver = ssf_toriver)
 
     write_output(model)

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -375,6 +375,10 @@ function initialize_sbm_model(config::Config)
         instate_path = input_path(config, config.state.path_input)
         @info "Set initial conditions from state file `$instate_path`."
         state_ncnames = ncnames(config.state)
+        @warn string(
+            "The unit of `ssf` (lateral subsurface flow) is now m3 d-1. Please update your", 
+            " input state file if it was produced with a Wflow version up to v0.5.2."
+        )
         set_states(instate_path, model, state_ncnames; type = Float)
         @unpack lateral, vertical, network = model
         # update zi for vertical sbm and kinematic wave volume for river and land domain

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -18,12 +18,12 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
         @testset "model information functions" begin
             @test BMI.get_component_name(model) == "sbm"
-            @test BMI.get_input_item_count(model) == 187
-            @test BMI.get_output_item_count(model) == 187
-            @test BMI.get_input_var_names(model)[[1, 5, 120, 187]] == [
+            @test BMI.get_input_item_count(model) == 186
+            @test BMI.get_output_item_count(model) == 186
+            @test BMI.get_input_var_names(model)[[1, 5, 120, 186]] == [
                 "vertical.Δt",
                 "vertical.n_unsatlayers",
-                "lateral.land.qin",
+                "lateral.land.q_av",
                 "lateral.river.reservoir.evaporation",
             ]
         end


### PR DESCRIPTION
The unit of lateral subsurface flow (ssf) has been changed from m3/Δt to m3/day, where Δt is the model timestep. Other flow variables are already stored independently from Δt, this allows for easier interpretation and to use states independently of Δt.