### PR TITLE
Support compression of NetCDF file

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
-- Added support for NetCDF compression, through the option `compressionlevel` in the
-  `[output]` section in the TOML file. The setting defaults to 0 (no compression), but all
-  levels between 0 and 9 can be used.
+- Added support for NetCDF compression for gridded model output, through the option
+  `compressionlevel` in the `[output]` section in the TOML file. The setting defaults to 0
+  (no compression), but all levels between 0 and 9 can be used.
 
 ### Changed
 - Re-organized the documentation: moved explanation of different model concepts to a model

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Added support for NetCDF compression, through the option `compressionlevel` in the
+  `[output]` section in the TOML file. The setting defaults to 0 (no compression), but all
+  levels between 0 and 9 can be used.
+
 ### Changed
 - Re-organized the documentation: moved explanation of different model concepts to a model
   documentation section, added a user guide to explain setting up the model, added new 

--- a/docs/src/user_guide/step2_settings_file.md
+++ b/docs/src/user_guide/step2_settings_file.md
@@ -186,14 +186,14 @@ This optional section of the TOML file contains the output netCDF file for writi
 model output, including a mapping between internal model parameter components and external
 netCDF variables. 
 
-To limit the size of the resulting NetCDF file, file compression can be enabled. This does
-come with an increase in computational speed, but can significantly reduce the file size of
-the NetCDF file. This can be enabled by setting the `compressionlevel` variable to any value
-between `0` and `9`. A setting of `0` indicates that compression is not enabled, and values
-between 1 and 9 indicate different levels of compression (1: least compression, smallest
-impact on run time, 9: highest compression level, biggest impact on run times). If file size
-becomes an issue, we recommend using a value of `1`, as higher compression levels generally
-have only a limited effect on the file size.
+To limit the size of the resulting NetCDF file, file compression can be enabled. This causes
+an increase in computational time, but can significantly reduce the file size of the NetCDF
+file. This can be enabled by setting the `compressionlevel` variable to any value between
+`0` and `9`. A setting of `0` indicates that compression is not enabled, and values between
+1 and 9 indicate different levels of compression (1: least compression, smallest impact on
+run time, 9: highest compression level, biggest impact on run times). If file size becomes
+an issue, we recommend using a value of `1`, as higher compression levels generally have
+only a limited effect on the file size.
 
 ```toml
 [output]    

--- a/docs/src/user_guide/step2_settings_file.md
+++ b/docs/src/user_guide/step2_settings_file.md
@@ -184,11 +184,21 @@ slope = "Slope"
 ### Grid data
 This optional section of the TOML file contains the output netCDF file for writing gridded
 model output, including a mapping between internal model parameter components and external
-netCDF variables.
+netCDF variables. 
+
+To limit the size of the resulting NetCDF file, file compression can be enabled. This does
+come with an increase in computational speed, but can significantly reduce the file size of
+the NetCDF file. This can be enabled by setting the `compressionlevel` variable to any value
+between `0` and `9`. A setting of `0` indicates that compression is not enabled, and values
+between 1 and 9 indicate different levels of compression (1: least compression, smallest
+impact on run time, 9: highest compression level, biggest impact on run times). If file size
+becomes an issue, we recommend using a value of `1`, as higher compression levels generally
+have only a limited effect on the file size.
 
 ```toml
 [output]    
 path = "output_moselle.nc"         # Location of the output file
+compressionlevel = 1               # Amount of compression (default 0)
 
 [output.vertical]   # Mapping of names between internal model components and external netCDF variables
 satwaterdepth = "satwaterdepth"

--- a/src/io.jl
+++ b/src/io.jl
@@ -454,6 +454,7 @@ function setup_grid_netcdf(
     extra_dim,
     sizeinmetres;
     float_type = Float32,
+    deflatelevel = 0,
 )
 
     ds = create_tracked_netcdf(path)
@@ -471,6 +472,7 @@ function setup_grid_netcdf(
                 "axis" => "X",
                 "units" => "m",
             ],
+            deflatelevel = deflatelevel,
         )
         defVar(
             ds,
@@ -484,6 +486,7 @@ function setup_grid_netcdf(
                 "axis" => "Y",
                 "units" => "m",
             ],
+            deflatelevel = deflatelevel,
         )
 
     else
@@ -512,6 +515,7 @@ function setup_grid_netcdf(
                 "axis" => "Y",
                 "units" => "degrees_north",
             ],
+            deflatelevel = deflatelevel,
         )
     end
     set_extradim_netcdf(ds, extra_dim)
@@ -521,6 +525,7 @@ function setup_grid_netcdf(
         Float64,
         ("time",),
         attrib = ["units" => time_units, "calendar" => calendar],
+        deflatelevel = deflatelevel,
     )
     if sizeinmetres
         for (key, val) in pairs(parameters)
@@ -532,6 +537,7 @@ function setup_grid_netcdf(
                     float_type,
                     ("x", "y", "time"),
                     attrib = ["_FillValue" => float_type(NaN)],
+                    deflatelevel = deflatelevel,
                 )
             elseif eltype(val.vector) <: SVector
                 # for SVectors an additional dimension (`extra_dim`) is required
@@ -541,6 +547,7 @@ function setup_grid_netcdf(
                     float_type,
                     ("x", "y", extra_dim.name, "time"),
                     attrib = ["_FillValue" => float_type(NaN)],
+                    deflatelevel = deflatelevel,
                 )
             else
                 error("Unsupported output type: ", typeof(val.vector))
@@ -556,6 +563,7 @@ function setup_grid_netcdf(
                     float_type,
                     ("lon", "lat", "time"),
                     attrib = ["_FillValue" => float_type(NaN)],
+                    deflatelevel = deflatelevel,
                 )
             elseif eltype(val.vector) <: SVector
                 # for SVectors an additional dimension (`extra_dim`) is required
@@ -565,6 +573,7 @@ function setup_grid_netcdf(
                     float_type,
                     ("lon", "lat", extra_dim.name, "time"),
                     attrib = ["_FillValue" => float_type(NaN)],
+                    deflatelevel = deflatelevel,
                 )
             else
                 error("Unsupported output type: ", typeof(val.vector))
@@ -871,7 +880,8 @@ function prepare_writer(
     # data but only if config.output.path has been set
     if haskey(config, "output") && haskey(config.output, "path")
         nc_path = output_path(config, config.output.path)
-        @info "Create an output NetCDF file `$nc_path` for grid data."
+        deflatelevel = get(config.output, "compressionlevel", 0)::Int
+        @info "Create an output NetCDF file `$nc_path` for grid data, using compression level `$deflatelevel`."
         # create a flat mapping from internal parameter locations to NetCDF variable names
         output_ncnames = ncnames(config.output)
         # fill the output_map by mapping parameter NetCDF names to arrays
@@ -885,6 +895,7 @@ function prepare_writer(
             time_units,
             extra_dim,
             sizeinmetres,
+            deflatelevel = deflatelevel
         )
     else
         nc_path = nothing


### PR DESCRIPTION
Support using the deflatelevel option when writing the netcdf output data. This option is currently only available for the gridded NetCDF data (so not for the states and scalar output), as this file can become very large. 

The option can be specified in the `[output]` section of the TOML file, via the `compressionlevel` keyword. A value of 0 (default) indicates no compression, and values between 1 and 9 indicate increasing levels of compression, but at the cost of increased computation times. 

Some tests for the Moselle and the Rhine showed that file size reduction is already substantial when using `compressionlevel = 1` (file sizes are reduced by a factor of 4-5), while the total computation time has increased by 5-25%, depending on the basin. Using `compressionlevel = 9`, files are only slightly smaller, but runtimes increased by roughly 40%.