### PR TITLE
Create dir before creating log file

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fixed an error with the log file, when writing to a folder that does not (yet) exists.
+  Now, the folder is created prior to writing the log file.
+
 ## v0.6.0 - 2022-04-14 
 
 ### Added

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -49,6 +49,7 @@ end
 function init_logger(config::Config; silent = false)::Tuple{TeeLogger,IOStream}
     loglevel = parse_loglevel(get(config, "loglevel", "info"))
     path_log = output_path(config, get(config, "path_log", "log.txt"))
+    mkpath(dirname(path_log))
     log_handle = open(path_log, "w")
     fews_run = get(config, "fews_run", false)::Bool
 


### PR DESCRIPTION
Fix the `No such file or directory` error when Wflow tries to write a log file in a (not yet) existing directory (see https://github.com/Deltares/Wflow.jl/issues/209). Now, the directory is created before trying to create the log file.