### PR TITLE
remove _FillValue from coordinate variables

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   location in update river flow.
 - Limit flow (`qx`, `qy` and `q`) in local inertial model when water is not available (set
   to zero).
+- In the grid output netCDFs, don't set the `_FillValue` attribute, since the CF conventions
+  don't allow it.
 
 ### Changed
 - Changed depth `h` for reservoir and lake locations as part of the river local inertial

--- a/src/io.jl
+++ b/src/io.jl
@@ -501,7 +501,6 @@ function setup_grid_netcdf(
             ncx,
             ("x",),
             attrib = [
-                "_FillValue" => NaN,
                 "long_name" => "x coordinate of projection",
                 "standard_name" => "projection_x_coordinate",
                 "axis" => "X",
@@ -515,7 +514,6 @@ function setup_grid_netcdf(
             ncy,
             ("y",),
             attrib = [
-                "_FillValue" => NaN,
                 "long_name" => "y coordinate of projection",
                 "standard_name" => "projection_y_coordinate",
                 "axis" => "Y",
@@ -531,7 +529,6 @@ function setup_grid_netcdf(
             ncx,
             ("lon",),
             attrib = [
-                "_FillValue" => NaN,
                 "long_name" => "longitude",
                 "standard_name" => "longitude",
                 "axis" => "X",
@@ -544,7 +541,6 @@ function setup_grid_netcdf(
             ncy,
             ("lat",),
             attrib = [
-                "_FillValue" => NaN,
                 "long_name" => "latitude",
                 "standard_name" => "latitude",
                 "axis" => "Y",


### PR DESCRIPTION
There were no actual missing values, but setting the attribute itself is also not allowed.

Quoting https://cfconventions.org/cf-conventions/cf-conventions.html#attribute-appendix

> `_FillValue`: Allowed for auxiliary coordinate variables but not allowed for coordinate variables.