### PR TITLE
add extra tests from Aqua

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -40,22 +40,10 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
-CFTime = "179af706-886a-5703-950a-314cd64e0468"
-Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 QuadGK = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [targets]
-test = ["Aqua", "BasicModelInterface", "CFTime", "Dates", "DelimitedFiles", "Downloads", "Graphs", "Logging", "NCDatasets", "Polynomials", "QuadGK", "Random", "StaticArrays", "Statistics", "TOML", "Test", "UnPack"]
+test = ["Aqua", "Downloads", "Polynomials", "QuadGK", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ UnPack = "1"
 julia = "1.6"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BasicModelInterface = "59605e27-edc0-445a-b93d-c09a3a50b330"
 CFTime = "179af706-886a-5703-950a-314cd64e0468"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -57,4 +58,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [targets]
-test = ["BasicModelInterface", "CFTime", "Dates", "DelimitedFiles", "Downloads", "Graphs", "Logging", "NCDatasets", "Polynomials", "QuadGK", "Random", "StaticArrays", "Statistics", "TOML", "Test", "UnPack"]
+test = ["Aqua", "BasicModelInterface", "CFTime", "Dates", "DelimitedFiles", "Downloads", "Graphs", "Logging", "NCDatasets", "Polynomials", "QuadGK", "Random", "StaticArrays", "Statistics", "TOML", "Test", "UnPack"]

--- a/test/io.jl
+++ b/test/io.jl
@@ -4,7 +4,7 @@ using TOML
 using CFTime
 using Random
 using UnPack
-using Logging
+using LoggingExtras
 
 tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 parsed_toml = TOML.parsefile(tomlpath)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using Base.Threads
 using BasicModelInterface
 import Polynomials
 using DelimitedFiles
-using Logging
+using LoggingExtras
 using QuadGK
 import Aqua
 
@@ -89,7 +89,7 @@ with_logger(NullLogger()) do
         include("run_sediment.jl")
         include("subdomains.jl")
         include("run_flextopo.jl")
+
+        Aqua.test_all(Wflow; ambiguities=false)
     end
 end
-
-Aqua.test_all(Wflow; ambiguities=false)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ import Polynomials
 using DelimitedFiles
 using Logging
 using QuadGK
+import Aqua
 
 const BMI = BasicModelInterface
 const Float = Wflow.Float
@@ -90,3 +91,5 @@ with_logger(NullLogger()) do
         include("run_flextopo.jl")
     end
 end
+
+Aqua.test_all(Wflow; ambiguities=false)


### PR DESCRIPTION
This enables some extra tests that can be very useful: 
https://juliatesting.github.io/Aqua.jl/dev/

Also cleans up the testing dependencies a bit. There is no need to specify them separately under extras if they are also a regular dependency. And LoggingExtras re-exports the Logging stdlib.