### PR TITLE
Allow for _FillValue in time dimension

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Fixed
+- Removed error when `_FillValue` is present in the time dimension of the forcing NetCDF file.
+  The simulation is allowed to continue with the attribute present, given that there are no
+  missing values in the time dimension. This is checked by the code, and an error is thrown if
+  this is the case.
 
 ### Changed
 

--- a/src/io.jl
+++ b/src/io.jl
@@ -245,6 +245,18 @@ function update_forcing!(model)
     @unpack dataset, forcing_parameters = reader
     nctimes = dataset["time"][:]
 
+    # Check if the time dimension contains a _FillValue attribute
+    if haskey(dataset["time"].attrib, "_FillValue")
+        # Remove missings, and check if lenght has changed (missings in time dimension are not
+        # allowed), and throw an error is the lenghts are different
+        times_dropped = collect(skipmissing(nctimes))
+        if length(times_dropped) == length(nctimes)
+            nctimes = times_dropped
+        else
+            error("Time dimension contains missing values")
+        end
+    end
+
     do_reservoirs = get(config.model, "reservoirs", false)::Bool
     do_lakes = get(config.model, "lakes", false)::Bool
 


### PR DESCRIPTION
Fixed an issue where the `_FillValue` attribute in the time dimension of the forcing file causes an error, as the `get_at` function was unable to dispatch due to unexpected types. This addition checks (if the `_FillValue`  is present) whether there are actual missing values in the time dimension. If this is the case, an error is thrown, otherwise the dates are converted to the correct type for the `get_at` function.