### PR TITLE
Add SQ functionality to reservoirs

### DIFF
--- a/src/io.jl
+++ b/src/io.jl
@@ -1374,9 +1374,17 @@ function read_hq_csv(path)
     return (H = data[:, 1], Q = data[:, 2:end])
 end
 
+"Read a storage-rating curve from CSV into a NamedTuple of vectors"
+function read_sq_csv(path)
+    data = readdlm(path, ',', Float, skipstart = 1)
+    # Q is a matrix with 365 columns, one for each day in the year
+    return (S = data[:, 1], Q = data[:, 2:end])
+end
+
 # these represent the type of the rating curve and specific storage data
 const SH = NamedTuple{(:H, :S),Tuple{Vector{Float},Vector{Float}}}
 const HQ = NamedTuple{(:H, :Q),Tuple{Vector{Float},Matrix{Float}}}
+const SQ = NamedTuple{(:S, :Q),Tuple{Vector{Float},Matrix{Float}}}
 
 is_increasing(v) = last(v) > first(v)
 

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -404,9 +404,13 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
         e = lake_e,
         waterlevel = lake_waterlevel,
 <<<<<<< HEAD
+<<<<<<< HEAD
         maxvolume = lake_maxvolume,
 =======
 >>>>>>> parent of 333f0436 (Added SQ functionality)
+=======
+        maxvolume = lake_maxvolume
+>>>>>>> parent of acd2ca27 (Update reservoir_lake.jl)
         sh = sh,
         hq = hq,
         inflow = fill(mv, n),

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -422,7 +422,7 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
         b = lake_b,
         e = lake_e,
         waterlevel = lake_waterlevel,
-        maxvolume = lake_maxvolume
+        maxvolume = lake_maxvolume,
         sh = sh,
         hq = hq,
         sq = sq,

--- a/src/reservoir_lake.jl
+++ b/src/reservoir_lake.jl
@@ -214,6 +214,8 @@ end
     e::Vector{T} | "-"                      # rating curve exponent
     sh::Vector{Union{SH,Missing}}           # data for storage curve
     hq::Vector{Union{HQ,Missing}}           # data for rating curve
+    sq::Vector{Union{SQ,Missing}}           # data for storage-based rating curve
+    maxvolume::Vector{T} | "m3"             # maximum volume lake [m³]
     waterlevel::Vector{T} | "m"             # waterlevel H [m] of lake
     inflow::Vector{T} | "m3"                # inflow to the lake [m³]
     storage::Vector{T} | "m3"               # storage lake [m³]
@@ -349,6 +351,16 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
         fill = 0,
     )
 
+    lake_maxvolume = ncread(
+        nc,
+        config,
+        "lateral.river.lake.maxvolume";
+        optional = false,
+        sel = inds_lake,
+        type = Float,
+        fill = 0,
+    )
+
     # for surface water routing lake locations are considered pits in the flow network
     # all upstream flow goes to the river and flows into the lake
     pits[inds_lake] .= true
@@ -362,6 +374,7 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
 
     sh = Vector{Union{SH,Missing}}(missing, n_lakes)
     hq = Vector{Union{HQ,Missing}}(missing, n_lakes)
+    sq = Vector{Union{SQ,Missing}}(missing, n_lakes)
     lowerlake_ind = fill(0, n_lakes)
     # lake CSV parameter files are expected in the same directory as path_static
     path = dirname(input_path(config, config.input.path_static))
@@ -391,6 +404,12 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
                 "For the modified pulse approach (LakeOutflowFunc = 3) the LakeStorFunc should be 1"
             )
         end
+
+        if lake_outflowfunc[i] == 4
+            csv_path = joinpath(path, "lake_sq_$lakeloc.csv")
+            @info("read a volume-based rating curve from CSV file $csv_path, for lake location $lakeloc")
+            sq[i] = read_sq_csv(csv_path)
+        end
     end
     n = length(lakearea)
     lakes = NaturalLake{Float}(
@@ -403,8 +422,10 @@ function initialize_natural_lake(config, nc, inds_riv, nriv, pits, Δt)
         b = lake_b,
         e = lake_e,
         waterlevel = lake_waterlevel,
+        maxvolume = lake_maxvolume
         sh = sh,
         hq = hq,
+        sq = sq,
         inflow = fill(mv, n),
         storage = initialize_storage(lake_storfunc, lakearea, lake_waterlevel, sh),
         outflow = fill(mv, n),
@@ -504,13 +525,17 @@ function update(lake::NaturalLake, i, inflow, doy, timestepsecs)
     end
 
     ### Linearisation for specific storage/rating curves ###
-    if lake.outflowfunc[i] == 1 || lake.outflowfunc[i] == 2
+    if lake.outflowfunc[i] == 1 || lake.outflowfunc[i] == 2 || lake.outflowfunc[i] == 4
 
         diff_wl = has_lowerlake ? lake.waterlevel[i] - lake.waterlevel[lo] : 0.0
 
         if lake.outflowfunc[i] == 1
             outflow =
                 interpolate_linear(lake.waterlevel[i], lake.hq[i].H, lake.hq[i].Q[:, doy])
+        elseif lake.outflowfunc[i] == 4
+            outflow =
+                interpolate_linear(lake.storage[i], lake.sq[i].S, lake.sq[i].Q[:, doy])
+        
         else
             if diff_wl >= 0.0
                 if lake.waterlevel[i] > lake.threshold[i]
@@ -537,6 +562,11 @@ function update(lake::NaturalLake, i, inflow, doy, timestepsecs)
             (lake.precipitation[i] / 1000.0) * (timestepsecs / lake.Δt) * lake.area[i] -
             (lake.evaporation[i] / 1000.0) * (timestepsecs / lake.Δt) * lake.area[i] -
             outflow * timestepsecs
+
+        if lake.maxvolume[i] > 0 && storage > lake.maxvolume[i]
+            outflow = outflow + (storage - lake.maxvolume[i])/timestepsecs
+            storage = lake.maxvolume[i]
+        end
 
         waterlevel = if lake.storfunc[i] == 1
             lake.waterlevel[i] + (storage - lake.storage[i]) / lake.area[i]

--- a/test/reservoir_lake.jl
+++ b/test/reservoir_lake.jl
@@ -8,6 +8,7 @@
         totaloutflow = [0.0],
         inflow = [0.0],
         area = [1885665.353626924],
+        outflowfunc = [1],
         targetfullfrac = [0.8],
         targetminfrac = [0.2425554726620697],
         precipitation = [4.2],
@@ -15,9 +16,11 @@
         outflow = [NaN],
         percfull = [NaN],
         demandrelease = [NaN],
+        sq = [missing],
+        overflow = [NaN],
     )
 
-    Wflow.update(res, 1, 100.0, 86400.0)
+    Wflow.update(res, 1, 100.0, 1, 86400.0)
     @test res.outflow[1] ≈ 91.3783714867453
     @test res.totaloutflow[1] ≈ 7.895091296454794e6
     @test res.volume[1] ≈ 2.0e7
@@ -25,6 +28,71 @@
     @test res.demandrelease[1] ≈ 52.5229994727611
     @test res.precipitation[1] ≈ 4.2
     @test res.evaporation[1] ≈ 1.5
+end
+
+datadir = joinpath(@__DIR__, "data")
+@testset "reservoir SQ normal" begin
+    res = Wflow.SimpleReservoir{Float64}(
+        Δt = 86400,
+        demand = [NaN],
+        maxrelease = [NaN],
+        maxvolume = [2.5e7],
+        volume = [2.0e7],
+        totaloutflow = [0.0],
+        inflow = [0.0],
+        area = [2_000_000],
+        outflowfunc = [2],
+        targetfullfrac = [NaN],
+        targetminfrac = [NaN],
+        precipitation = [4.2],
+        evaporation = [1.5],
+        outflow = [NaN],
+        percfull = [NaN],
+        demandrelease = [NaN],
+        overflow = [NaN],
+        sq = [Wflow.read_sq_csv(joinpath(datadir, "input", "res_sq_1.csv"))],
+    )
+
+    Wflow.update(res, 1, 20.0, 1, 86400)
+    @test res.precipitation[1] ≈ 4.2
+    @test res.evaporation[1] ≈ 1.5
+    @test res.demandrelease[1] ≈ 40
+    @test res.outflow[1] ≈ 40
+    @test res.totaloutflow[1] ≈ 3.456e6
+    @test res.volume[1] ≈ 1.82774e7
+    @test res.overflow[1] ≈ 0
+end
+
+@testset "reservoir SQ overflow" begin
+        res = Wflow.SimpleReservoir{Float64}(
+            Δt = 86400,
+            demand = [NaN],
+            maxrelease = [NaN],
+            maxvolume = [2.5e7],
+            volume = [2.0e7],
+            totaloutflow = [0.0],
+            inflow = [0.0],
+            area = [2_000_000],
+            outflowfunc = [2],
+            targetfullfrac = [NaN],
+            targetminfrac = [NaN],
+            precipitation = [4.2],
+            evaporation = [1.5],
+            outflow = [NaN],
+            percfull = [NaN],
+            demandrelease = [NaN],
+            overflow = [NaN],
+            sq = [Wflow.read_sq_csv(joinpath(datadir, "input", "res_sq_1.csv"))],
+        )
+
+    Wflow.update(res, 1, 150.0, 2, 86400)
+    @test res.precipitation[1] ≈ 4.2
+    @test res.evaporation[1] ≈ 1.5
+    @test res.demandrelease[1] ≈ 50
+    @test res.outflow[1] ≈ 92.19213
+    @test res.totaloutflow[1] ≈ 7.9654e6
+    @test res.volume[1] ≈ 2.5e7
+    @test res.overflow[1] ≈ 3.6454e6
 end
 
 @testset "natural lake" begin


### PR DESCRIPTION
See also issue #242

We first discussed this implementation through modelling the reservoirs as lakes, and adding a new LakeOutflowFunc for the SQ-approach. However, it is also possible by adding the functionality to the reservoirs

ResOutflowFunc is determined by checking if .csv file corresponding to reservoir exists. If it exists, the reservoir will use the SQ-approach. If not, then it is modelled using the old approach. It is a 'quick fix', but I would say it is a good alternative until lakes and reservoirs are merged into 'waterbody'. Advantage of this fix is that it uses parameters such as ResMaxVolume which are generated by hydromt_wflow, and that it will work with previous Wflow models (no breaking).

Code passed tests and 2 new tests are added, for normal flow and for a overflowing reservoir. Results correspond with hand calculations. Attached the csv file used in the test, maybe nice to upload to artifact repo if this will be implemented

[res_sq_1.csv](https://github.com/Deltares/Wflow.jl/files/10849467/res_sq_1.csv)
