### PR TITLE
define BMI.get_time_units on model instance

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- `BMI.get_time_units` now gets called on the model rather than the type, like all other BMI
+  functions, except `BMI.initialize`.
+
+### Changed
+
+### Added
+
 ## v0.6.3 - 2023-03-01
 
 ### Fixed

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -180,7 +180,7 @@ function BMI.get_end_time(model::Model)
     datetime2unix(DateTime(model.config.endtime))
 end
 
-function BMI.get_time_units(::Type{<:Model})
+function BMI.get_time_units(model::Model)
     string("seconds since ", unix2datetime(0))
 end
 

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -9,7 +9,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         model = BMI.initialize(Wflow.Model, tomlpath)
 
         @testset "initialization and time functions" begin
-            @test BMI.get_time_units(Wflow.Model) == "seconds since 1970-01-01T00:00:00"
+            @test BMI.get_time_units(model) == "seconds since 1970-01-01T00:00:00"
             @test BMI.get_time_step(model) == 86400.0
             @test BMI.get_start_time(model) == 9.467712e8
             @test BMI.get_current_time(model) == 9.467712e8


### PR DESCRIPTION
Perhaps this was originally done since it doesn't need any information from the model instance, but since this is the only one, this looks more like a bug to me.