### PR TITLE
BMI use simulation starttime as t = 0, not 1970

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `BMI.get_time_units` now gets called on the model rather than the type, like all other BMI
-  functions, except `BMI.initialize`.
+  functions, except `BMI.initialize`. Also it returns "s" instead of "seconds since
+  1970-01-01T00:00:00", in line with the BMI specification.
 
 ### Changed
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   1970-01-01T00:00:00", in line with the BMI specification.
 
 ### Changed
+- The time values returned in the BMI interface are no longer in seconds since 1970, but in
+  seconds since the model start time. This is more in line with standard BMI practices.
 
 ### Added
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- `BMI.get_time_units` now gets called on the model rather than the type, like all other BMI
+  functions, except `BMI.initialize`.
+
+### Changed
+
+### Added
+
 ## v0.6.3 - 2023-03-01
 
 ### Fixed

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -181,7 +181,7 @@ function BMI.get_end_time(model::Model)
 end
 
 function BMI.get_time_units(model::Model)
-    string("seconds since ", unix2datetime(0))
+    "s"
 end
 
 function BMI.get_time_step(model::Model)

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -180,7 +180,7 @@ function BMI.get_end_time(model::Model)
     datetime2unix(DateTime(model.config.endtime))
 end
 
-function BMI.get_time_units(::Type{<:Model})
+function BMI.get_time_units(model::Model)
     string("seconds since ", unix2datetime(0))
 end
 

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -169,15 +169,15 @@ function BMI.get_var_location(model::Model, name::String)
 end
 
 function BMI.get_current_time(model::Model)
-    datetime2unix(reinterpret(DateTime, model.clock.time))
+    0.001 * Dates.value(model.clock.time - model.config.starttime)
 end
 
 function BMI.get_start_time(model::Model)
-    datetime2unix(DateTime(model.config.starttime))
+    0.0
 end
 
 function BMI.get_end_time(model::Model)
-    datetime2unix(DateTime(model.config.endtime))
+    0.001 * Dates.value(model.config.endtime - model.config.starttime)
 end
 
 function BMI.get_time_units(model::Model)

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -9,7 +9,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         model = BMI.initialize(Wflow.Model, tomlpath)
 
         @testset "initialization and time functions" begin
-            @test BMI.get_time_units(Wflow.Model) == "seconds since 1970-01-01T00:00:00"
+            @test BMI.get_time_units(model) == "seconds since 1970-01-01T00:00:00"
             @test BMI.get_time_step(model) == 86400.0
             @test BMI.get_start_time(model) == 9.467712e8
             @test BMI.get_current_time(model) == 9.467712e8

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -11,9 +11,9 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         @testset "initialization and time functions" begin
             @test BMI.get_time_units(model) == "s"
             @test BMI.get_time_step(model) == 86400.0
-            @test BMI.get_start_time(model) == 9.467712e8
-            @test BMI.get_current_time(model) == 9.467712e8
-            @test BMI.get_end_time(model) == 9.493632e8
+            @test BMI.get_start_time(model) == 0.0
+            @test BMI.get_current_time(model) == 0.0
+            @test BMI.get_end_time(model) == 30 * 86400.0
         end
 
         @testset "model information functions" begin
@@ -48,7 +48,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         model = BMI.update(model)
 
         @testset "update and get and set functions" begin
-            @test BMI.get_current_time(model) == 9.468576e8
+            @test BMI.get_current_time(model) == 86400.0
             @test mean(BMI.get_value(model, "vertical.zi")) ≈ 276.3767651555451
             @test BMI.get_value_at_indices(model, "lateral.river.q", [1, 100, 5617]) ≈
                   [0.6211503865184697, 5.219305686635002, 0.026163746306482282]

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -9,7 +9,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
         model = BMI.initialize(Wflow.Model, tomlpath)
 
         @testset "initialization and time functions" begin
-            @test BMI.get_time_units(model) == "seconds since 1970-01-01T00:00:00"
+            @test BMI.get_time_units(model) == "s"
             @test BMI.get_time_step(model) == 86400.0
             @test BMI.get_start_time(model) == 9.467712e8
             @test BMI.get_current_time(model) == 9.467712e8


### PR DESCRIPTION
(includes the commits from #245)

As long as BMI is used properly, this shouldn't be breaking. This is the same behavior as Modflow and Ribasim, and the [BMI docs](https://bmi.readthedocs.io/en/stable/#get-start-time) state:

> The start time in BMI is typically defined to be 0.0.