### PR TITLE
Starttime

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The time values returned in the BMI interface are no longer in seconds since 1970, but in
   seconds since the model start time. This is more in line with standard BMI practices.
+- The `starttime` was defined one model timestep `Δt` ahead of the actual model time (the
+  initial conditions timestamp (state time)). As a consequence this was also the case for
+  the current model time. To allow for an easier interpretation of Wflow time handling,
+  either through BMI or directly, the `starttime` is now equal to the state time, resulting
+  in current model times without an offset.
 
 ### Added
 - For (regulated) lakes with rating curve of type 1 (H-Q table), lake `storage` above the

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -267,8 +267,10 @@ specified in the main section of the TOML configuration file:
 fews_run = true  # optional, default value is false
 ```
 
-This ensures that a different format for the log file is used such that each log message
-takes up only one line. That meets the [General Adapter
+This ensures that Wflow offsets the time handling, to meet the expectations of Delft-FEWS.
+
+It also uses a different format for the log file such that each log message takes up only
+one line. That meets the [General Adapter
 logFile](https://publicwiki.deltares.nl/display/FEWSDOC/05+General+Adapter+Module#id-05GeneralAdapterModule-logFile)
 expectations, which then can get parsed with these Delft-FEWS log parsing settings:
 

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -267,10 +267,8 @@ specified in the main section of the TOML configuration file:
 fews_run = true  # optional, default value is false
 ```
 
-This ensures that Wflow offsets the time handling, to meet the expectations of Delft-FEWS.
-
-It also uses a different format for the log file such that each log message takes up only
-one line. That meets the [General Adapter
+This ensures that a different format for the log file is used such that each log message
+takes up only one line. That meets the [General Adapter
 logFile](https://publicwiki.deltares.nl/display/FEWSDOC/05+General+Adapter+Module#id-05GeneralAdapterModule-logFile)
 expectations, which then can get parsed with these Delft-FEWS log parsing settings:
 

--- a/docs/src/user_guide/step2_settings_file.md
+++ b/docs/src/user_guide/step2_settings_file.md
@@ -6,15 +6,19 @@ The filepaths that are provided in this file are relative to the location of the
 or to `dir_input` and `dir_output` if they are given.
 
 ## General time info
-Time information is optional. When left out, each time step in the forcing NetCDF will be
-calculated. If you wish to calculate a subset of this time range, or a different timestep,
-you can specify a `starttime`, `endtime` and `timestepsecs` yourself. The `time_units`
-optional information is used by the `writer` of the model, for model output in netCDF
-format. The `calendar` option allows you to calculate in one of the different [CF
-conventions calendars](http://cfconventions.org/cf-conventions/cf-conventions.html#calendar)
-provided by the [CFTime.jl package](https://juliageo.org/CFTime.jl/latest/), such as
-`"360_day"`. This is useful if you want to calculate climate scenarios which are sometimes
-provided in these alternative calendars.
+Time information is optional. When left out, for each timestamp in the forcing NetCDF Wflow
+will do computations, except for the first forcing timestamp that is considered equal to the
+initial conditions of the Wflow model (state time). If you wish to calculate a subset of
+this time range, or a different timestep, you can specify a `starttime`, `endtime` and
+`timestepsecs` yourself. The `starttime` is defined as the model state time. In the TOML
+file settings below the `starttime` is 2000-01-01T00:00:00 (state time) and the first update
+(and output) of the Wflow model is at 2000-01-02T00:00:00. The `time_units` optional
+information is used by the `writer` of the model, for model output in netCDF format. The
+`calendar` option allows you to calculate in one of the different [CF conventions
+calendars](http://cfconventions.org/cf-conventions/cf-conventions.html#calendar) provided by
+the [CFTime.jl package](https://juliageo.org/CFTime.jl/latest/), such as `"360_day"`. This
+is useful if you want to calculate climate scenarios which are sometimes provided in these
+alternative calendars.
 
 ```toml
 calendar = "standard"                           # optional, this is default value

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -189,6 +189,16 @@ function run(config::Config)
     run(model)
 end
 
+function run_timestep(model::Model; update_func = update, write_model_output = true)
+    advance!(model.clock)
+    load_dynamic_input!(model)
+    model = update_func(model)
+    if write_model_output
+        write_output(model)
+    end
+    return model
+end
+
 function run(model::Model; close_files = true)
     @unpack network, config, writer, clock = model
 
@@ -205,9 +215,7 @@ function run(model::Model; close_files = true)
     runstart_time = now()
     @progress for (i, time) in enumerate(times)
         @debug "Starting timestep." time i now()
-        advance!(clock)
-        load_dynamic_input!(model)
-        model = update(model)
+        model = run_timestep(model)
     end
     @info "Simulation duration: $(canonicalize(now() - runstart_time))"
 

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -45,20 +45,20 @@ end
 
 function Clock(config, reader)
     nctimes = reader.dataset["time"][:]
-    # if the config file does not have a start or endtime, folow the NetCDF times
-    # and add them to the config
+    
     # if the timestep is not given, use the difference between NetCDF time 1 and 2
     timestepsecs = get(config, "timestepsecs", nothing)
     if timestepsecs === nothing
         timestepsecs = Dates.value(Second(nctimes[2] - nctimes[1]))
         config.timestepsecs = timestepsecs
     end
-
     Δt = Second(timestepsecs)
-
+    
+    # if the config file does not have a start or endtime, follow the NetCDF times
+    # and add them to the config
     starttime = get(config, "starttime", nothing)
     if starttime === nothing
-        starttime = first(nctimes) - Δt
+        starttime = first(nctimes)
         config.starttime = starttime
     end
     endtime = get(config, "endtime", nothing)

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -40,7 +40,7 @@ function Clock(config)
     calendar = get(config, "calendar", "standard")::String
     starttime = cftime(config.starttime, calendar)
     Δt = Second(config.timestepsecs)
-    Clock(starttime, 1, Δt)
+    Clock(starttime, 0, Δt)
 end
 
 function Clock(config, reader)
@@ -48,9 +48,17 @@ function Clock(config, reader)
     # if the config file does not have a start or endtime, folow the NetCDF times
     # and add them to the config
     # if the timestep is not given, use the difference between NetCDF time 1 and 2
+    timestepsecs = get(config, "timestepsecs", nothing)
+    if timestepsecs === nothing
+        timestepsecs = Dates.value(Second(nctimes[2] - nctimes[1]))
+        config.timestepsecs = timestepsecs
+    end
+
+    Δt = Second(timestepsecs)
+
     starttime = get(config, "starttime", nothing)
     if starttime === nothing
-        starttime = first(nctimes)
+        starttime = first(nctimes) - Δt
         config.starttime = starttime
     end
     endtime = get(config, "endtime", nothing)
@@ -58,22 +66,11 @@ function Clock(config, reader)
         endtime = last(nctimes)
         config.endtime = endtime
     end
-    timestepsecs = get(config, "timestepsecs", nothing)
-    if timestepsecs === nothing
-        timestepsecs = Dates.value(Second(nctimes[2] - nctimes[1]))
-        config.timestepsecs = timestepsecs
-    end
 
     calendar = get(config, "calendar", "standard")::String
     starttime = cftime(config.starttime, calendar)
-    Δt = Second(timestepsecs)
-
-    fews_run = get(config, "fews_run", false)::Bool
-    if fews_run
-        starttime = starttime + Δt
-    end
-
-    Clock(starttime, 1, Δt)
+    
+    Clock(starttime, 0, Δt)
 end
 
 include("io.jl")
@@ -202,21 +199,19 @@ function run(model::Model; close_files = true)
     starttime = clock.time
     Δt = clock.Δt
     endtime = cftime(config.endtime, calendar)
-    times = range(starttime, endtime, step = Δt)
+    times = range(starttime + Δt, endtime, step = Δt)
 
     @info "Run information" model_type starttime Δt endtime nthreads()
     runstart_time = now()
     @progress for (i, time) in enumerate(times)
         @debug "Starting timestep." time i now()
+        advance!(clock)
         load_dynamic_input!(model)
         model = update(model)
     end
     @info "Simulation duration: $(canonicalize(now() - runstart_time))"
 
     # write output state NetCDF
-    # undo the clock advance at the end of the last iteration, since there won't
-    # be a next step, and then the output state falls on the correct time
-    rewind!(clock)
     if haskey(config, "state") && haskey(config.state, "path_output")
         @info "Write output states to NetCDF file `$(model.writer.state_nc_path)`."
     end

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -206,6 +206,11 @@ function run(model::Model; close_files = true)
 
     # determine timesteps to run
     calendar = get(config, "calendar", "standard")::String
+    @warn string(
+        "The definition of `starttime` has changed (equal to model state time).\n Please", 
+        " update your settings TOML file by subtracting one model timestep Δt from the", 
+        " `starttime`, if it was used with a Wflow version up to v0.6.3.",
+    )
     starttime = clock.time
     Δt = clock.Δt
     endtime = cftime(config.endtime, calendar)

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -58,7 +58,7 @@ function Clock(config, reader)
     # and add them to the config
     starttime = get(config, "starttime", nothing)
     if starttime === nothing
-        starttime = first(nctimes)
+        starttime = first(nctimes) - Δt
         config.starttime = starttime
     end
     endtime = get(config, "endtime", nothing)
@@ -68,6 +68,10 @@ function Clock(config, reader)
     end
 
     calendar = get(config, "calendar", "standard")::String
+    fews_run = get(config, "fews_run", false)::Bool
+    if fews_run
+        config.starttime = starttime + Δt
+    end
     starttime = cftime(config.starttime, calendar)
     
     Clock(starttime, 0, Δt)

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -50,15 +50,17 @@ Update the model for a single timestep.
 function BMI.update(model::Model; run = nothing)
     @unpack clock, network, config = model
     if isnothing(run)
-        update_func = update
+        model = run_timestep(model)
     elseif run == "sbm_until_recharge"
-        update_func = update_until_recharge
+        model = run_timestep(
+            model,
+            update_func = update_until_recharge,
+            write_model_output = false,
+        )
     elseif run == "sbm_after_subsurfaceflow"
-        update_func = update_after_subsurfaceflow
+        model = run_timestep(model, update_func = update_after_subsurfaceflow)
     end
-    advance!(clock)
-    load_dynamic_input!(model)
-    return update_func(model)
+    return model
 end
 
 function BMI.update_until(model::Model, time::Float64)
@@ -66,9 +68,7 @@ function BMI.update_until(model::Model, time::Float64)
     curtime = BMI.get_current_time(model)
     n = Int(max(0, (time - curtime) / model.clock.Δt.value))
     for _ = 1:n
-        advance!(clock)
-        load_dynamic_input!(model)
-        update(model)
+        model = run_timestep(model)
     end
     return model
 end

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -48,7 +48,7 @@ Update the model for a single timestep.
 - `run = nothing`: to update a model partially.
 """
 function BMI.update(model::Model; run = nothing)
-    @unpack network, config = model
+    @unpack clock, network, config = model
     if isnothing(run)
         update_func = update
     elseif run == "sbm_until_recharge"
@@ -56,17 +56,17 @@ function BMI.update(model::Model; run = nothing)
     elseif run == "sbm_after_subsurfaceflow"
         update_func = update_after_subsurfaceflow
     end
+    advance!(clock)
     load_dynamic_input!(model)
     return update_func(model)
 end
 
 function BMI.update_until(model::Model, time::Float64)
-    @unpack network, config = model
+    @unpack clock, network, config = model
     curtime = BMI.get_current_time(model)
-    n_iter = Int(max(0, (time - curtime) / model.clock.Δt.value))
-    end_time = curtime + n_iter * config.timestepsecs
-    @info "Updating model until $end_time."
-    for _ = 1:n_iter
+    n = Int(max(0, (time - curtime) / model.clock.Δt.value))
+    for _ = 1:n
+        advance!(clock)
         load_dynamic_input!(model)
         update(model)
     end
@@ -76,7 +76,6 @@ end
 "Write state output to netCDF and close files."
 function BMI.finalize(model::Model)
     @unpack config, writer, clock = model
-    rewind!(clock)
     write_netcdf_timestep(model, writer.state_dataset, writer.state_parameters)
     reset_clock!(model.clock, config)
     close_files(model, delete_output = false)

--- a/src/flextopo_model.jl
+++ b/src/flextopo_model.jl
@@ -720,7 +720,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:FlextopoModel}
 
     surface_routing(model)
 
-    write_output(model)
-
     return model
 end

--- a/src/flextopo_model.jl
+++ b/src/flextopo_model.jl
@@ -722,8 +722,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:FlextopoModel}
 
     write_output(model)
 
-    # update the clock
-    advance!(clock)
-
     return model
 end

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -428,8 +428,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:HbvModel}
 
     write_output(model)
 
-    # update the clock
-    advance!(clock)
-
     return model
 end

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -426,7 +426,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:HbvModel}
 
     surface_routing(model)
 
-    write_output(model)
-
     return model
 end

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -478,8 +478,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SbmGwfModel}
 
     write_output(model)
 
-    # update the clock
-    advance!(clock)
-
     return model
 end

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -476,7 +476,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SbmGwfModel}
     ssf_toriver[inds_riv] = -lateral.subsurface.river.flux ./ lateral.river.Δt
     surface_routing(model, ssf_toriver = ssf_toriver)
 
-    write_output(model)
-
     return model
 end

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -498,8 +498,5 @@ function update_after_subsurfaceflow(
 
     write_output(model)
 
-    # update the clock
-    advance!(clock)
-
     return model
 end

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -496,7 +496,5 @@ function update_after_subsurfaceflow(
     ssf_toriver = lateral.subsurface.to_river ./ tosecond(basetimestep)
     surface_routing(model, ssf_toriver = ssf_toriver)
 
-    write_output(model)
-
     return model
 end

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -201,8 +201,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SedimentModel}
 
     write_output(model)
 
-    # update the clock
-    advance!(clock)
-
     return model
 end

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -199,7 +199,5 @@ function update(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SedimentModel}
         update(lateral.river, network.river, config)
     end
 
-    write_output(model)
-
     return model
 end

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -13,7 +13,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
             @test BMI.get_time_step(model) == 86400.0
             @test BMI.get_start_time(model) == 0.0
             @test BMI.get_current_time(model) == 0.0
-            @test BMI.get_end_time(model) == 30 * 86400.0
+            @test BMI.get_end_time(model) == 31 * 86400.0
         end
 
         @testset "model information functions" begin

--- a/test/flextopo_config.toml
+++ b/test/flextopo_config.toml
@@ -1,6 +1,6 @@
 casename = "wflow_meuse"
 calendar = "proleptic_gregorian"
-starttime = "2010-01-01T00:00:00"
+starttime = "2009-12-31T00:00:00"
 endtime = "2010-07-01T00:00:00"
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400

--- a/test/hbv_config.toml
+++ b/test/hbv_config.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-02-01T00:00:00
-starttime = 2000-01-01T00:00:00
+starttime = 1999-12-31T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -71,11 +71,11 @@ end
     pop!(Dict(config), "timestepsecs")
     clock = Wflow.Clock(config, reader)
 
-    @test clock.time == DateTimeProlepticGregorian(2000, 1, 1)
+    @test clock.time == DateTimeProlepticGregorian(2000, 1, 2)
     @test clock.iteration == 0
     @test clock.Δt == Second(Day(1))
     # test that the missing keys have been added to the config
-    @test config.starttime == DateTime(2000, 1, 1)
+    @test config.starttime == DateTime(2000, 1, 2)
     @test config.endtime == DateTime(2001, 1, 1)
     @test config.timestepsecs == 86400
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -71,11 +71,11 @@ end
     pop!(Dict(config), "timestepsecs")
     clock = Wflow.Clock(config, reader)
 
-    @test clock.time == DateTimeProlepticGregorian(2000, 1, 2)
+    @test clock.time == DateTimeProlepticGregorian(2000, 1, 1)
     @test clock.iteration == 0
     @test clock.Δt == Second(Day(1))
     # test that the missing keys have been added to the config
-    @test config.starttime == DateTime(2000, 1, 2)
+    @test config.starttime == DateTime(2000, 1, 1)
     @test config.endtime == DateTime(2001, 1, 1)
     @test config.timestepsecs == 86400
 

--- a/test/io.jl
+++ b/test/io.jl
@@ -18,7 +18,7 @@ config = Wflow.Config(tomlpath)
     @test dirname(config) == dirname(tomlpath)
 
     # test if the values are parsed as expected
-    @test config.starttime === DateTime(2000, 1, 2)
+    @test config.starttime === DateTime(2000, 1, 1)
     @test config.endtime === DateTime(2000, 2)
     @test config.output.path == "output_moselle.nc"
     @test config.output isa Wflow.Config
@@ -71,11 +71,11 @@ end
     pop!(Dict(config), "timestepsecs")
     clock = Wflow.Clock(config, reader)
 
-    @test clock.time == DateTimeProlepticGregorian(2000, 1, 2)
-    @test clock.iteration == 1
+    @test clock.time == DateTimeProlepticGregorian(2000, 1, 1)
+    @test clock.iteration == 0
     @test clock.Δt == Second(Day(1))
     # test that the missing keys have been added to the config
-    @test config.starttime == DateTime(2000, 1, 2)
+    @test config.starttime == DateTime(2000, 1, 1)
     @test config.endtime == DateTime(2001, 1, 1)
     @test config.timestepsecs == 86400
 
@@ -87,7 +87,7 @@ end
 
     clock = Wflow.Clock(config, reader)
     @test clock.time == DateTimeStandard(2003, 4, 5)
-    @test clock.iteration == 1
+    @test clock.iteration == 0
     @test clock.Δt == Second(Hour(1))
 
     close(ds)
@@ -98,17 +98,17 @@ end
     # 29 days in this February due to leap year
     starttime = DateTimeStandard(2000, 2, 28)
     Δt = Day(1)
-    clock = Wflow.Clock(starttime, 1, Second(Δt))
+    clock = Wflow.Clock(starttime, 0, Second(Δt))
 
     Wflow.advance!(clock)
     Wflow.advance!(clock)
     @test clock.time == DateTimeStandard(2000, 3, 1)
-    @test clock.iteration == 3
+    @test clock.iteration == 2
     @test clock.Δt == Δt
 
     Wflow.rewind!(clock)
     @test clock.time == DateTimeStandard(2000, 2, 29)
-    @test clock.iteration == 2
+    @test clock.iteration == 1
     @test clock.Δt == Δt
 
     config = Wflow.Config(
@@ -116,7 +116,7 @@ end
     )
     Wflow.reset_clock!(clock, config)
     @test clock.time == starttime
-    @test clock.iteration == 1
+    @test clock.iteration == 0
     @test clock.Δt == Δt
 end
 
@@ -124,17 +124,17 @@ end
     # 30 days in each month
     starttime = DateTime360Day(2000, 2, 29)
     Δt = Day(1)
-    clock = Wflow.Clock(starttime, 1, Second(Δt))
+    clock = Wflow.Clock(starttime, 0, Second(Δt))
 
     Wflow.advance!(clock)
     Wflow.advance!(clock)
     @test clock.time == DateTime360Day(2000, 3, 1)
-    @test clock.iteration == 3
+    @test clock.iteration == 2
     @test clock.Δt == Δt
 
     Wflow.rewind!(clock)
     @test clock.time == DateTime360Day(2000, 2, 30)
-    @test clock.iteration == 2
+    @test clock.iteration == 1
     @test clock.Δt == Δt
 
     config = Wflow.Config(
@@ -147,7 +147,7 @@ end
     Wflow.reset_clock!(clock, config)
     @test clock.time isa DateTime360Day
     @test string(clock.time) == "2020-02-29T00:00:00"
-    @test clock.iteration == 1
+    @test clock.iteration == 0
     @test clock.Δt == Δt
 end
 
@@ -193,6 +193,7 @@ config.input["path_forcing"] = abs_path_forcing
 @test isabspath(config.input.path_forcing)
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 
 @unpack vertical, clock, reader, writer = model
@@ -273,6 +274,7 @@ config.input.vertical.c = Dict(
 )
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 
 @testset "changed parameter values" begin
@@ -429,11 +431,11 @@ end
     # test Clock{DateTimeNoLeap}
     clock = Wflow.Clock(config, reader)
     @test clock.time isa DateTimeNoLeap
-    @test clock.time == DateTimeNoLeap(2000, 1, 2)
+    @test clock.time == DateTimeNoLeap(2000, 1, 1)
 
     starttime = DateTimeNoLeap(2000, 2, 28)
     Δt = Day(1)
-    clock = Wflow.Clock(starttime, 1, Second(Δt))
+    clock = Wflow.Clock(starttime, 0, Second(Δt))
     Wflow.advance!(clock)
     @test clock.time == DateTimeNoLeap(2000, 3, 1)
 end

--- a/test/run.jl
+++ b/test/run.jl
@@ -11,7 +11,7 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 config = Wflow.Config(tomlpath)
 
 # January at once, cold start
-config.starttime = DateTime("2000-01-02T00:00:00")
+config.starttime = DateTime("2000-01-01T00:00:00")
 config.endtime = DateTime("2000-02-01T00:00:00")
 config.model.reinit = true  # cold start
 # note that this needs to be relative to the tomlpath
@@ -23,7 +23,7 @@ model = Wflow.initialize_sbm_model(config)
 Wflow.run(model)
 
 # first half of January, cold start
-config.starttime = DateTime("2000-01-02T00:00:00")
+config.starttime = DateTime("2000-01-01T00:00:00")
 config.endtime = DateTime("2000-01-15T00:00:00")
 config.model.reinit = true  # cold start
 config.state.path_output =
@@ -34,33 +34,15 @@ model = Wflow.initialize_sbm_model(config)
 Wflow.run(model)
 
 # second half of January, warm start
-config.starttime = DateTime("2000-01-16T00:00:00")
+config.starttime = DateTime("2000-01-15T00:00:00")
 config.endtime = DateTime("2000-02-01T00:00:00")
 config.model.reinit = false  # warm start
-config.fews_run = false
 config.state.path_input =
     joinpath(dirname(tomlpath), "data/state-test/outstates-moselle-january-1of2.nc")
 config.state.path_output =
     joinpath(dirname(tomlpath), "data/state-test/outstates-moselle-january-2of2.nc")
 config.output.path =
     joinpath(dirname(tomlpath), "data/state-test/output-moselle-january-2of2.nc")
-model = Wflow.initialize_sbm_model(config)
-Wflow.run(model)
-
-# second half of January, warm start, fews_run set to true, and starttime set one day earlier
-# to match endtime of part 1
-config.starttime = DateTime("2000-01-15T00:00:00")
-config.endtime = DateTime("2000-02-01T00:00:00")
-config.model.reinit = false  # warm start
-config.fews_run = true
-config.state.path_input =
-    joinpath(dirname(tomlpath), "data/state-test/outstates-moselle-january-1of2.nc")
-config.state.path_output = joinpath(
-    dirname(tomlpath),
-    "data/state-test/outstates-moselle-january-2of2-fews_run.nc",
-)
-config.output.path =
-    joinpath(dirname(tomlpath), "data/state-test/output-moselle-january-2of2-fews_run.nc")
 model = Wflow.initialize_sbm_model(config)
 Wflow.run(model)
 
@@ -80,24 +62,5 @@ varnames = setdiff(keys(endstate_restart), keys(endstate_restart.dim))
         b = endstate_restart[varname][:]
         maxdiff = maximum(abs.(skipmissing(b - a)))
         @test maxdiff < 1e-9
-    end
-end
-
-# the fews_run restart should match the other restart exactly
-endstate_fewsrun_path = joinpath(
-    dirname(tomlpath),
-    "data/state-test/outstates-moselle-january-2of2-fews_run.nc",
-)
-endstate_restart_path =
-    joinpath(dirname(tomlpath), "data/state-test/outstates-moselle-january-2of2.nc")
-endstate_fewsrun = NCDataset(endstate_fewsrun_path)
-endstate_restart = NCDataset(endstate_restart_path)
-
-varnames = setdiff(keys(endstate_restart), keys(endstate_restart.dim))
-@testset "fews_run" begin
-    for varname in varnames
-        a = endstate_fewsrun[varname][:]
-        b = endstate_restart[varname][:]
-        @test all(skipmissing(a) .== skipmissing(b))
     end
 end

--- a/test/run_flextopo.jl
+++ b/test/run_flextopo.jl
@@ -5,9 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_flextopo_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 # test if the first timestep was written to the CSV file
 flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
@@ -39,9 +37,7 @@ end
 end
 
 # run the second timestep
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "second timestep" begin
     flextopo = model.vertical
@@ -88,9 +84,7 @@ config["model"]["select_slow"] = ["common_slow_storage"]
 model = Wflow.initialize_flextopo_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "first timestep" begin
     flextopo = model.vertical

--- a/test/run_flextopo.jl
+++ b/test/run_flextopo.jl
@@ -5,6 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_flextopo_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -28,7 +29,7 @@ end
 @testset "first timestep" begin
     flextopo = model.vertical
     @test flextopo.tt[3500] ≈ 1.3f0
-    @test model.clock.iteration == 2
+    @test model.clock.iteration == 1
     @test flextopo.rootzonestorage[3500] ≈
           [147.11238663084805f0, 79.08369375691255f0, 79.23637697443984f0]
     @test flextopo.runoff[3500] ≈ 0.19008129369467497f0
@@ -38,6 +39,7 @@ end
 end
 
 # run the second timestep
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -86,6 +88,7 @@ config["model"]["select_slow"] = ["common_slow_storage"]
 model = Wflow.initialize_flextopo_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 

--- a/test/run_hbv.jl
+++ b/test/run_hbv.jl
@@ -5,9 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_hbv_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 # test if the first timestep was written to the CSV file
 flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
@@ -37,9 +35,7 @@ end
 end
 
 # run the second timestep
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "second timestep" begin
     hbv = model.vertical

--- a/test/run_hbv.jl
+++ b/test/run_hbv.jl
@@ -5,6 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_hbv_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -28,7 +29,7 @@ end
 @testset "first timestep" begin
     hbv = model.vertical
     @test hbv.tt[4377] ≈ 0.0
-    @test model.clock.iteration == 2
+    @test model.clock.iteration == 1
     @test hbv.soilmoisture[4377] ≈ 134.35299682617188f0
     @test hbv.runoff[4377] ≈ 7.406898120121746f0
     @test hbv.soilevap[4377] == 0.0
@@ -36,6 +37,7 @@ end
 end
 
 # run the second timestep
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -6,6 +6,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sbm_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -74,7 +75,7 @@ end
 
     @test sbm.tt[50063] ≈ 0.0f0
 
-    @test model.clock.iteration == 2
+    @test model.clock.iteration == 1
 
     @test sbm.θₛ[50063] ≈ 0.48755401372909546f0
     @test sbm.θᵣ[50063] ≈ 0.15943120419979095f0
@@ -84,6 +85,7 @@ end
 end
 
 # run the second timestep
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -152,7 +154,7 @@ model = Wflow.run(config)
     # clock has been reset
     calendar = get(config, "calendar", "standard")::String
     @test model.clock.time == Wflow.cftime(config.starttime, calendar)
-    @test model.clock.iteration == 1
+    @test model.clock.iteration == 0
 end
 
 @testset "river flow at basin outlets and downstream of one pit" begin
@@ -178,8 +180,10 @@ config.input.vertical.leaf_area_index =
     Dict("scale" => 1.6, "netcdf" => Dict("variable" => Dict("name" => "LAI")))
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -200,8 +204,10 @@ config.input.cyclic = ["vertical.leaf_area_index", "lateral.river.inflow"]
 config.input.lateral.river.inflow = "inflow"
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -222,6 +228,7 @@ Wflow.load_fixed_forcing(model)
     @test all(isapprox.(model.lateral.river.reservoir.precipitation, 2.5))
 end
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -239,8 +246,10 @@ config = Wflow.Config(tomlpath)
 config.model.river_routing = "local-inertial"
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -264,8 +273,10 @@ tomlpath = joinpath(@__DIR__, "sbm_swf_config.toml")
 config = Wflow.Config(tomlpath)
 
 model = Wflow.initialize_sbm_model(config)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -388,8 +399,10 @@ river = model.lateral.river
     @test Wflow.wetted_perimeter(fp, h, 4, i1) ≈ 90.11775307900271f0
 end
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -6,9 +6,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sbm_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 # test if the first timestep was written to the CSV file
 flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
@@ -85,9 +83,7 @@ end
 end
 
 # run the second timestep
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "second timestep" begin
     sbm = model.vertical
@@ -180,12 +176,8 @@ config.input.vertical.leaf_area_index =
     Dict("scale" => 1.6, "netcdf" => Dict("variable" => Dict("name" => "LAI")))
 
 model = Wflow.initialize_sbm_model(config)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
+model = Wflow.run_timestep(model)
 
 @testset "changed dynamic parameters" begin
     res = model.lateral.river.reservoir
@@ -204,12 +196,8 @@ config.input.cyclic = ["vertical.leaf_area_index", "lateral.river.inflow"]
 config.input.lateral.river.inflow = "inflow"
 
 model = Wflow.initialize_sbm_model(config)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
+model = Wflow.run_timestep(model)
 
 @testset "river inflow (cyclic)" begin
     @test model.lateral.river.inflow[44] ≈ 0.75
@@ -228,9 +216,7 @@ Wflow.load_fixed_forcing(model)
     @test all(isapprox.(model.lateral.river.reservoir.precipitation, 2.5))
 end
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "fixed precipitation forcing (first timestep)" begin
     @test maximum(model.vertical.precipitation) ≈ 2.5
@@ -246,12 +232,8 @@ config = Wflow.Config(tomlpath)
 config.model.river_routing = "local-inertial"
 
 model = Wflow.initialize_sbm_model(config)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
+model = Wflow.run_timestep(model)
 
 @testset "river flow and depth (local inertial)" begin
     q = model.lateral.river.q_av
@@ -273,12 +255,8 @@ tomlpath = joinpath(@__DIR__, "sbm_swf_config.toml")
 config = Wflow.Config(tomlpath)
 
 model = Wflow.initialize_sbm_model(config)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
+model = Wflow.run_timestep(model)
 
 @testset "river and overland flow and depth (local inertial)" begin
     q = model.lateral.river.q_av
@@ -399,12 +377,8 @@ river = model.lateral.river
     @test Wflow.wetted_perimeter(fp, h, 4, i1) ≈ 90.11775307900271f0
 end
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
+model = Wflow.run_timestep(model)
 
 @testset "river flow (local inertial) with floodplain schematization simulation" begin
     q = model.lateral.river.q_av

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -5,6 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sbm_gwf_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -21,7 +22,7 @@ end
 @testset "first timestep" begin
     sbm = model.vertical
 
-    @test model.clock.iteration == 2
+    @test model.clock.iteration == 1
     @test sbm.θₛ[1] ≈ 0.44999998807907104f0
     @test sbm.runoff[1] == 0.0
     @test sbm.soilevap[1] == 0.0
@@ -29,6 +30,7 @@ end
 end
 
 # run the second timestep
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 

--- a/test/run_sbm_gwf.jl
+++ b/test/run_sbm_gwf.jl
@@ -5,9 +5,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sbm_gwf_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 # test if the first timestep was written to the CSV file
 flush(model.writer.csv_io)  # ensure the buffer is written fully to disk
@@ -30,9 +28,7 @@ end
 end
 
 # run the second timestep
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "second timestep" begin
     sbm = model.vertical

--- a/test/run_sediment.jl
+++ b/test/run_sediment.jl
@@ -6,9 +6,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sediment_model(config)
 @unpack network = model
 
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "first timestep sediment model (vertical)" begin
     eros = model.vertical
@@ -23,9 +21,7 @@ model = Wflow.update(model)
 end
 
 # run the second timestep
-Wflow.advance!(model.clock)
-Wflow.load_dynamic_input!(model)
-model = Wflow.update(model)
+model = Wflow.run_timestep(model)
 
 @testset "second timestep sediment model (vertical)" begin
     eros = model.vertical

--- a/test/run_sediment.jl
+++ b/test/run_sediment.jl
@@ -6,6 +6,7 @@ config = Wflow.Config(tomlpath)
 model = Wflow.initialize_sediment_model(config)
 @unpack network = model
 
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 
@@ -13,7 +14,7 @@ model = Wflow.update(model)
     eros = model.vertical
 
     @test eros.erosov[1] ≈ 0.9f0
-    @test model.clock.iteration == 2
+    @test model.clock.iteration == 1
     @test mean(eros.leaf_area_index) ≈ 1.7120018886212223f0
     @test eros.dmsand[1] == 200.0f0
     @test eros.dmlagg[1] == 500.0f0
@@ -22,6 +23,7 @@ model = Wflow.update(model)
 end
 
 # run the second timestep
+Wflow.advance!(model.clock)
 Wflow.load_dynamic_input!(model)
 model = Wflow.update(model)
 

--- a/test/sbm_config.toml
+++ b/test/sbm_config.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-02-01T00:00:00
-starttime = 2000-01-02T00:00:00
+starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 dir_input = "data/input"

--- a/test/sbm_gw.toml
+++ b/test/sbm_gw.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-02-01T00:00:00
-starttime = 2000-01-02T00:00:00
+starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 dir_input = "data/input"

--- a/test/sbm_gwf_config.toml
+++ b/test/sbm_gwf_config.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-06-30T00:00:00
-starttime = 2000-06-01T00:00:00
+starttime = 2000-05-31T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 dir_input = "data/input"

--- a/test/sbm_swf_config.toml
+++ b/test/sbm_swf_config.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-02-01T00:00:00
-starttime = 2000-01-02T00:00:00
+starttime = 2000-01-01T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 dir_input = "data/input"

--- a/test/sediment_config.toml
+++ b/test/sediment_config.toml
@@ -5,7 +5,7 @@
 
 calendar = "proleptic_gregorian"
 endtime = 2000-01-03T00:00:00
-starttime = 2000-01-01T00:00:00
+starttime = 1999-12-31T00:00:00
 time_units = "days since 1900-01-01 00:00:00"
 timestepsecs = 86400
 dir_input = "data/input"


### PR DESCRIPTION
The `starttime` was defined one model timestep `Δt` ahead of the actual model time (the initial conditions timestamp (state time)). As a consequence this was also the case for the current model time. To allow for an easier interpretation of Wflow time handling, either through BMI or directly, the `starttime` is now equal to the state time, resulting in current model times without an offset.