### PR TITLE
Fix rutter interception

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   amounts. And the first drainage amount `dd`, controlled by a change over time in canopy
   storage capacity `cmax`, should not be subtracted from precipitation to compute net
   interception.
+- The `netinterception` (net interception) computed by the modified Rutter interception
+  model was stored as `interception` in `SBM`, while this should be the `interception`
+  (interception loss by evaporation) output of the modified Rutter interception model. The
+  `interception` of `SBM` is used to compute the total actual evapotranspiration `actevap`.
 
 ## v0.7.1 - 2023-06-30
 

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Fixed
+- Water balance of modified Rutter interception model. The sum of the stemflow partitioning
+  coefficient `pt` and free throughfall coefficient `p` could get larger than 1, resulting
+  in an overestimation of stemflow and throughfall amounts and negative net interception
+  amounts. And the first drainage amount `dd`, controlled by a change over time in canopy
+  storage capacity `cmax`, should not be subtracted from precipitation to compute net
+  interception.
+
 ## v0.7.1 - 2023-06-30
 
 ### Fixed

--- a/docs/src/model_docs/params_vertical.md
+++ b/docs/src/model_docs/params_vertical.md
@@ -76,7 +76,7 @@ specific_leaf = "Sl"
 | `pottrans_soil` | interception subtracted from potential evaporation) | mm Δt``^{-1}`` | - |
 | `transpiration` | transpiration | mm Δt``^{-1}`` | - |
 | `ae_ustore` | actual evaporation from unsaturated store | mm Δt``^{-1}`` | - |
-| `interception` | interception | mm Δt``^{-1}`` | - |
+| `interception` | interception loss by evaporation | mm Δt``^{-1}`` | - |
 | `soilevap` | total soil evaporation from unsaturated and saturated store | mm Δt``^{-1}`` | - |
 | `soilevapsat` | soil evaporation from saturated store | mm Δt``^{-1}`` | - |
 | `actcapflux` | actual capillary rise | mm Δt``^{-1}`` | - |

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -84,7 +84,7 @@
     transpiration::Vector{T}
     # Actual evaporation from unsaturated store [mm Δt⁻¹]
     ae_ustore::Vector{T}
-    # Interception [mm Δt⁻¹]
+    # Interception loss by evaporation [mm Δt⁻¹]
     interception::Vector{T}
     # Soil evaporation from unsaturated and saturated store [mm Δt⁻¹]
     soilevap::Vector{T}
@@ -650,7 +650,6 @@ function update_until_snow(sbm::SBM, config)
                     cmax,
                 )
             pottrans_soil = max(0.0, leftover)  # now in mm
-            interception = netinterception
         end
 
         if modelsnow

--- a/src/vertical_process.jl
+++ b/src/vertical_process.jl
@@ -61,7 +61,7 @@ function rainfall_interception_gash(
     overestimate = interception > maxevap ? interception - maxevap : 0.0
     interception = min(interception, maxevap)
 
-    # Add surpluss to the thoughdfall
+    # Add surpluss to the throughfall
     throughfall = throughfall + overestimate
 
     return throughfall, interception, stemflow, canopystorage
@@ -82,7 +82,7 @@ function rainfall_interception_modrut(
     cmax,
 )
 
-    # TODO: improve computation of stemflow partitioning coefficient pt ((0.1 * canopygapfraction)
+    # TODO: improve computation of stemflow partitioning coefficient pt (0.1 * canopygapfraction)
     pt = min(0.1 * canopygapfraction, 1.0 - canopygapfraction)
 
     # Amount of p that falls on the canopy


### PR DESCRIPTION
## Issue addressed
Fixes #299

## Explanation
The amount of computed `throughfall` and `stemflow` in the modified Rutter interception model could become larger than the precipitation input (water balance issue), because the sum of the stemflow partitioning coefficient `pt` and free throughfall coefficient `p` could get larger than 1. In addition, the net interception (`netinterception`) was not computed correctly: the first drainage term `dd` was subtracted from precipitation (as part of `throughfall`), while `dd` is controlled by a change in the canopy storage capacity `cmax` over time (e.g. because of a change in leaf area index LAI), and thus not part of the precipitation input. This could result in a negative `netinterception`: 
```julia
netinterception = precipitation - throughfall - stemflow
````
Finally, the `interception` (interception loss through evaporation) output from the modified Rutter interception model  should be stored in `SBM`, and not `netinterception`. The interception loss through evaporation is used to compute total actual evapotranspiration (`actevap`).

## Checklist
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.md if needed