### PR TITLE
Fix `set_states` function of model type `sbm`

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   occur).
 - Limit lake evaporation (added variable `actevap`) and lake outflow to prevent negative
   lake storage. The variable `actevap` has also been added to the reservoir module.
+- The `set_states` function for model type `sbm` with local inertial routing for river and
+  land component.
 
 ### Changed
 - Stop exposing scalar variables through BMI. The `BMI.get_value_ptr` function was

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -508,7 +508,7 @@ function set_states(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SbmModel}
                 " bed elevation `zb` to cell elevation `z`. Please update the input state",
                 " file if it was produced with Wflow version v0.5.2.",
             )
-            for i = 1:n
+            for i in eachindex(lateral.land.volume)
                 if lateral.land.rivercells[i]
                     j = network.land.index_river[i]
                     if lateral.land.h[i] > 0.0

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -483,7 +483,6 @@ function set_states(model::Model{N,L,V,R,W,T}) where {N,L,V,R,W,T<:SbmModel}
             " input state file if it was produced with a Wflow version up to v0.5.2.",
         )
         set_states(instate_path, model, state_ncnames; type = Float, dimname = :layer)
-        @unpack lateral, vertical, network = model
         # update zi for vertical sbm and kinematic wave volume for river and land domain
         zi =
             max.(


### PR DESCRIPTION
## Issue addressed
Fixes #357 

## Explanation
Fixed the for loop for the local inertial routing of the land component in the `set_states` function of model type `sbm`.