### PR TITLE
Improve spelling and grammar in the user guide

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -128,7 +128,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.6.3 - 2023-03-01
 
 ### Fixed
-- Removed error when `_FillValue` is present in the time dimension of the forcing NetCDF
+- Removed error when `_FillValue` is present in the time dimension of the forcing netCDF
   file. The simulation is allowed to continue with the attribute present, given that there
   are no missing values in the time dimension. This is checked by the code, and an error is
   thrown if this is the case.
@@ -137,9 +137,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   counted).
 
 ### Changed
-- `NCDatasets` version. Reading the `time` dimension of multifile NetCDF file became very
+- `NCDatasets` version. Reading the `time` dimension of multifile netCDF file became very
   slow since `NCDatasets` v0.12.4, this issue has been solved in v0.12.11.
-- Store the `time` dimension of the forcing NetCDF file as part of the struct `NCreader`
+- Store the `time` dimension of the forcing netCDF file as part of the struct `NCreader`
   instead of calling `dataset["time"][:]` each time step when loading forcing data.
 
 ### Added
@@ -195,7 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parameters](@ref).
 - Modify input parameters with an extra dimension at multiple indices with different `scale`
   and `offset` values, through the TOML file. See also [Modify parameters](@ref).
-- Added support for NetCDF compression for gridded model output, through the option
+- Added support for netCDF compression for gridded model output, through the option
   `compressionlevel` in the `[output]` section in the TOML file. The setting defaults to 0
   (no compression), but all levels between 0 and 9 can be used.
 
@@ -257,10 +257,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed how number of iterations `its` for kinematic wave river flow are calculated during
   initialization when using a fixed sub-timestep (specified in the TOML file). For a model
   timestep smaller than the fixed sub-timestep an InexactError was thrown.
-- Fixed providing a cyclic parameter when the NetCDF variable is read during model
-  initialization with `ncread`, this gave an error about the size of the NetCDF `time`
+- Fixed providing a cyclic parameter when the netCDF variable is read during model
+  initialization with `ncread`, this gave an error about the size of the netCDF `time`
   dimension.
-- Fixed CSV and NetCDF scalar output of variables with dimension `layer` (`SVector`).
+- Fixed CSV and netCDF scalar output of variables with dimension `layer` (`SVector`).
 
 ## v0.5.1 - 2021-11-24
 
@@ -373,7 +373,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## v0.3.1 - 2021-05-19
 
 ### Fixed
-- Ignore extra dimensions in input NetCDFs if they are size 1
+- Ignore extra dimensions in input netCDFs if they are size 1
 
 ## v0.3.0 - 2021-05-10
 
@@ -406,7 +406,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed dependency of the `f` model parameter of wflow\_sbm on the parameters
   ``\theta_{s}``, ``\theta_{r}`` and ``M``. This approach is used in Topog\_SBM, but not
-  applicable for wflow\_sbm. The `f` parameter needs to be provided as part of the NetCDF
+  applicable for wflow\_sbm. The `f` parameter needs to be provided as part of the netCDF
   model parameter file.
 - Grid properties as cell length and elevation now stored as part of the
   `model.land.network` component and not as part of the vertical model components, as it is
@@ -416,10 +416,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed parameter ``\theta_{e}`` from SBM struct (not used in update). Parameters
   ``\theta_{s}`` and ``\theta_{r}`` included separately (instead of ``\theta_{e}``) in
   `LateralSSF struct`, now directly linked to SBM parameters.
-- Improve error messages (NetCDF and cyclic flow graph).
+- Improve error messages (netCDF and cyclic flow graph).
 
 ### Added
-- Export of NetCDF scalar timeseries (separate NetCDF file from gridded timeseries). This
+- Export of netCDF scalar timeseries (separate netCDF file from gridded timeseries). This
   also allows for importing these timeseries by Delft-FEWS (General Adapter).
 
 ### Fixed

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -63,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For cyclic parameters different cyclic time inputs are supported (only one common cyclic
   time (for example daily or monthly) was allowed).
 - BMI: 1) added grid information (type and location) and whether a variable can be exchanged
-  to metadata Structs, 2) extend model grid functions for Wflow components that store
+  to metadata Structs, 2) extend model grid functions for wflow components that store
   variables on `edges` (local inertial model) with `get_grid_edge_count` and
   `get_grid_edge_nodes`.
 
@@ -107,7 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   seconds since the model start time. This is more in line with standard BMI practices.
 - The `starttime` was defined one model timestep `Δt` ahead of the actual model time (the
   initial conditions timestamp (state time)). As a consequence this was also the case for
-  the current model time. To allow for an easier interpretation of Wflow time handling,
+  the current model time. To allow for an easier interpretation of wflow time handling,
   either through BMI or directly, the `starttime` is now equal to the state time, resulting
   in current model times without an offset.
 - Using more than 8 threads can result in too much overhead with `Threads.@threads`. After
@@ -246,7 +246,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Model type `hbv`: the surface width for overland flow was not corrected with the river
   width.
-- Fixed use of absolute path for `path_forcing` in TOML file, which gave an error in Wflow
+- Fixed use of absolute path for `path_forcing` in TOML file, which gave an error in wflow
   v0.5.1.
 - Fixed a crash when glacier processes are simulated as part of the `hbv` concept (Δt was
   not defined).
@@ -354,7 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   larger or smaller than `xp`, maximum(`xp`) or minimum(`xp`) was returned instead of
   maximum(`fp`) or minimum(`fp`).
 - Fixed model timestep of reservoirs (`SimpleReservoir`) and lakes (`NaturalLake`) in
-  relation to precipitation and evapotranspiration fluxes. This was set to the fixed Wflow
+  relation to precipitation and evapotranspiration fluxes. This was set to the fixed wflow
   `basetimestep` of 86400 s, and should be set to the actual model time step from the TOML
   configuration file.
 - Add `flux` from `Drainage` (`GroundwaterFlow`) in the `sbm_gwf_model` to the overland flow

--- a/docs/src/intro/use_cases.md
+++ b/docs/src/intro/use_cases.md
@@ -8,7 +8,7 @@ planning. In collaboration with Rijkswaterstaat, Deltares is setting-up a new li
 for the Rhine and the Meuse basins. The models will be used for forecasting and to estimate the
 impact of climate change on water resources and extreme streamflow. In the model development,
 we seek to improve hydrological predictions by including relevant processes in the model
-schematization. The modularity of the Wflow framework is ideal for this as we can easily
+schematization. The modularity of the wflow framework is ideal for this as we can easily
 evaluate the combination of different vertical and lateral model components. For example, the
 local inertial routing for river and overland flow enables us to consider retention of water in
 the floodplains, which will likely improve extreme streamflow predictions.
@@ -49,7 +49,7 @@ flood inundation forecasting in Australia. Hydrology Water and Resources Symposi
 ## [Simulating plastic transport in Thailand](@id case_mfa)
 
 For the Polution Control Board of the Government of Thailand and The World Bank, we supported
-the material flow analysis of plastics in Thailand using Wflow. Plastic polution is a growing
+the material flow analysis of plastics in Thailand using wflow. Plastic polution is a growing
 problem globally. Plastic waste enters the rivers and is transported to the ocean where it
 remains and threatens the health of the ocean, seas and coasts. The initial movement of plastic
 waste is in many cases triggered by runoff from (heavy) rainfall and with the flow of water

--- a/docs/src/model_docs/model_configurations.md
+++ b/docs/src/model_docs/model_configurations.md
@@ -182,7 +182,7 @@ The kinematic wave function is used to route the water downstream. In a similar 
 HBV, all runoff that is generated in a cell in one of the FLEXTopo storages is added to the
 kinematic wave reservoir at the end of a timestep. There is no connection between the
 different vertical FLEXTopo cells within the model. The FLEXTopo model is implemented in a
-fully distributed way in the Wflow Julia framework.
+fully distributed way in the wflow Julia framework.
 
 In wflow\_flextopo, the user is free to determine the number of classes and which model
 components to include or exclude for each class, this is done in the TOML file. Currently,

--- a/docs/src/model_docs/params_lateral.md
+++ b/docs/src/model_docs/params_lateral.md
@@ -381,7 +381,7 @@ internal model parameter `z`, and is listed in the Table below between parenthes
 ### Confined aquifer
 The Table below shows the parameters (fields) of struct `ConfinedAquifer`, including a
 description of these parameters, the unit, and default value if applicable. Struct
-`ConfinedAquifer` is not (yet) part of a Wflow Model.
+`ConfinedAquifer` is not (yet) part of a wflow model.
 
 |  parameter  | description  	      | unit  | default |
 |:--------------- | ------------------| ----- | -------|

--- a/docs/src/model_docs/structures.md
+++ b/docs/src/model_docs/structures.md
@@ -19,7 +19,7 @@ end
 ```
 
 The `lateral` field of the `struct Model` can contain different lateral concepts. For each
-Wflow model these different lateral concepts are mapped through the use of a `NamedTuple`.
+wflow model these different lateral concepts are mapped through the use of a `NamedTuple`.
 The `vertical` field of the `struct Model` always contains one vertical concept, for example
 the SBM or HBV vertical concept.
 
@@ -41,7 +41,7 @@ name. See also the next paragraph [Vertical and lateral models](@ref) for a more
 detailed description.
 
 ## Vertical and lateral models
-The different model concepts used in Wflow are defined as parametric [composite
+The different model concepts used in wflow are defined as parametric [composite
 types](https://docs.julialang.org/en/v1/manual/types/#Composite-Types). For example the
 vertical `SBM` concept is defined as follows: `struct SBM{T,N,M}`. `T`, `N` and `M` between
 curly braces after the `struct` name refer to type parameters, for more information about
@@ -75,7 +75,7 @@ example with a part of the `SBM` struct:
     kvfrac::Vector{SVector{N,T}} | "-"
 ```
 
-The type parameter `T` is used in Wflow as a subtype of `AbstractFloat`, allowing to store
+The type parameter `T` is used in wflow as a subtype of `AbstractFloat`, allowing to store
 fields with a certain floating point precision (e.g. `Float64` or `Float32`) in a flexible
 way. `N` refers to the maximum number of soil layers of the `SBM` soil column, and `M`
 refers to the maximum number of soil layers + 1. See also part of the following instance of

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -262,9 +262,9 @@ world.
 
 This can be done without a model adapter that provides the interface between Delft-FEWS and
 an external model (or module). This is possible because time information in the TOML
-configuration file is optional and Delft-FEWS can import and export NetCDF files. When time
+configuration file is optional and Delft-FEWS can import and export netCDF files. When time
 information is left out from the TOML configuration file, the `starttime`, `endtime` and
-`timestepsecs` (timestep) of the run is extracted from the NetCDF forcing file by Wflow.
+`timestepsecs` (timestep) of the run is extracted from the netCDF forcing file by Wflow.
 
 To indicate that a Wflow model runs from Delft-FEWS, the following setting needs to be
 specified in the main section of the TOML configuration file:

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -147,10 +147,10 @@ and land (2D)](@ref), both part of wflow\_sbm, can also run on multiple threads.
 threading functionality for the kinematic wave may also be useful for models that make
 (partly) use of this routing approach as the [wflow_hbv](@ref config_hbv) model and
 the wflow\_sbm model [SBM + Groundwater flow](@ref). The multi-threading functionality in
-Wflow is considered experimental, see also the following
+wflow is considered experimental, see also the following
 [issue](https://github.com/Deltares/Wflow.jl/issues/139), where an error was not thrown
-running code multi-threaded. Because of this we advise to start with running a Wflow model
-single-threaded (for example during the testing phase of setting up an new Wflow model).
+running code multi-threaded. Because of this we advise to start with running a wflow model
+single-threaded (for example during the testing phase of setting up an new wflow model).
 
 For information on how to start Julia with multiple threads we refer to [How to start Julia
 with multiple
@@ -190,14 +190,14 @@ in the [Julia programming language](https://julialang.org/), makes use of the fo
 [Julia specification](https://github.com/Deltares/BasicModelInterface.jl), based on BMI 2.0
 version.
 
-For the BMI implementation of Wflow all grids are defined as [unstructured
+For the BMI implementation of wflow all grids are defined as [unstructured
 grids](https://bmi-spec.readthedocs.io/en/latest/model_grids.html#unstructured-grids),
 including the special cases `scalar` and `points`. While the input (forcing and model
 parameters) is structured (uniform rectilinear), internally wflow works with one dimensional
 arrays based on the active grid cells of the 2D model domain.
 
 ### Configuration
-The variables that Wflow can exchange through BMI are based on the different model
+The variables that wflow can exchange through BMI are based on the different model
 components and these components should be listed under the `API` section of the TOML
 configuration file of the model type. Below an example of this `API` section, that lists the
 `vertical` component and different `lateral` components:
@@ -220,7 +220,7 @@ Wflow.BMI.get_input_var_names
 ```
 
 Variables with a third dimension, for example `layer` as part of the vertical `SBM` concept,
-are exposed as two-dimensional grids through the Wflow BMI implementation. For these
+are exposed as two-dimensional grids through the wflow BMI implementation. For these
 variables the index of this third dimension is required, by adding `[k]` to the variable
 name (`k` refers to the index of the third dimension). For example, the variable
 `vertical.vwc[1]` refers to the first soil layer of the vertical `SBM` concept.
@@ -231,7 +231,7 @@ MODFLOW) it is possible to run:
 - wflow\_sbm in parts from the BMI, and
 - to switch off the lateral subsurface flow component of wflow\_sbm.
 
-The lateral subsurface component of wflow\_sbm is not initialized by Wflow when the
+The lateral subsurface component of wflow\_sbm is not initialized by wflow when the
 `[input.lateral.subsurface]` part of the TOML file is not included. Then from the BMI it is
 possible to run first the recharge part of SBM:
 
@@ -264,16 +264,16 @@ This can be done without a model adapter that provides the interface between Del
 an external model (or module). This is possible because time information in the TOML
 configuration file is optional and Delft-FEWS can import and export netCDF files. When time
 information is left out from the TOML configuration file, the `starttime`, `endtime` and
-`timestepsecs` (timestep) of the run is extracted from the netCDF forcing file by Wflow.
+`timestepsecs` (timestep) of the run is extracted from the netCDF forcing file by wflow.
 
-To indicate that a Wflow model runs from Delft-FEWS, the following setting needs to be
+To indicate that a wflow model runs from Delft-FEWS, the following setting needs to be
 specified in the main section of the TOML configuration file:
 
 ```toml
 fews_run = true  # optional, default value is false
 ```
 
-This ensures that Wflow offsets the time handling, to meet the expectations of Delft-FEWS.
+This ensures that wflow offsets the time handling, to meet the expectations of Delft-FEWS.
 
 It also uses a different format for the log file such that each log message takes up only
 one line. That meets the [General Adapter
@@ -290,8 +290,8 @@ expectations, which then can get parsed with these Delft-FEWS log parsing settin
 </logFile>
 ```
 
-## [Run Wflow as a ZMQ Server]
-It is possible to run Wflow as a ZMQ Server, for example for the coupling to the
-[OpenDA](https://openda.org/) software for data-assimilation. The code for the Wflow ZMQ
+## [Run wflow as a ZMQ Server]
+It is possible to run wflow as a ZMQ Server, for example for the coupling to the
+[OpenDA](https://openda.org/) software for data-assimilation. The code for the wflow ZMQ
 Server is not part of the Wflow.jl package, and is located
 [here](https://github.com/Deltares/Wflow.jl/tree/zmq_server/server).

--- a/docs/src/user_guide/install.md
+++ b/docs/src/user_guide/install.md
@@ -20,7 +20,7 @@ Wflow can be used in two different ways, depending on the required use of the co
   version is available. This consists of a single executable, `wflow_cli`, allowing you to
   run the model via the command line.
 
-Below, we describe how to install both versions of wflow.
+Below we describe how to install both versions of wflow.
 
 ## Installing as Julia package
 
@@ -75,7 +75,7 @@ have to pull in the latest changes yourself using `git pull`.
 
 ### Check installation of wflow
 
-Finally, go back the Julia REPL and try to load wflow:
+Finally, go back to the Julia REPL and try to load wflow:
 
 ```julia-repl
 julia> using Wflow
@@ -85,7 +85,7 @@ The first time this will take longer as any package that is new or changed needs
 pre-compiled first, to allow faster loading on subsequent uses. No error messages should
 appear, indicating that you have now successfully installed wflow.
 
-Before ending this section, we still want to recommend a few tools that can make using and
+Before ending this section, we want to recommend a few tools that can make using and
 developing Julia code easier.
 
 !!! tip
@@ -115,8 +115,8 @@ artifacts\
 bin\wflow_cli
 ```
 
-Check whether the installation was performed successfully, run `wflow_cli` with no
-arguments in the command line will give the following message:
+Check whether the installation was performed successfully by running `wflow_cli` with no
+arguments in the command line. This will give the following message:
 
 ```
 Usage: wflow_cli 'path/to/config.toml'

--- a/docs/src/user_guide/install.md
+++ b/docs/src/user_guide/install.md
@@ -108,7 +108,7 @@ Binaries of `wflow_cli` can be downloaded from our website
 [download.deltares.nl](https://download.deltares.nl/en/download/wflow/), and are currently
 available for Windows. Download and install the `.msi` file. After installing you can see
 two folders in the installation directory. It is only the `bin/wflow_cli` that is used. The
-artifacts folder contains binary dependencies such as NetCDF.
+artifacts folder contains binary dependencies such as netCDF.
 
 ```
 artifacts\

--- a/docs/src/user_guide/intro.md
+++ b/docs/src/user_guide/intro.md
@@ -2,7 +2,7 @@
 
 The purpose of this user guide is to describe the steps to install the wflow julia software
 and to set up a simple model. The user guide also contains a step-wise process how to
-configure your model using the TOML file (model settings) and the NetCDF gridded datasets.
+configure your model using the TOML file (model settings) and the netCDF gridded datasets.
 
 Sample data and model set up is also included for the Moselle River Basin (a major tributary
 of the Rhine River), which can be used to explore the model software. The model is set up

--- a/docs/src/user_guide/intro.md
+++ b/docs/src/user_guide/intro.md
@@ -8,6 +8,6 @@ Sample data and model set up is also included for the Moselle River Basin (a maj
 of the Rhine River), which can be used to explore the model software. The model is set up
 for the wflow\_sbm, wflow\_hbv and wflow\_sediment model concepts.
 
-Finally information is provided on setting up your own model, including building a model
+Finally, information is provided on setting up your own model, including building a model
 from scratch or alternatively using Deltares [HydroMT](https://github.com/Deltares/hydromt)
 model building tools which are open source.

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -106,17 +106,17 @@ Example models can be found in the [Example model section](@ref sample_data).
 to build and analyze hydro models. It provides a generic model api with attributes to
 access the model schematization, (dynamic) forcing data, results and states.
 
-For the following Wflow models:
+For the following wflow models:
   - wflow\_sbm + kinematic wave
   - wflow_sediment
 
-the Wflow plugin [hydroMT-wflow](https://github.com/Deltares/hydromt_wflow) of hydroMT can
-be used to build and analyze these Wflow model types in an automated way.
+the wflow plugin [hydroMT-wflow](https://github.com/Deltares/hydromt_wflow) of hydroMT can
+be used to build and analyze these wflow model types in an automated way.
 
-To learn more about the Wflow plugin of this Python package, we refer to the [hydroMT-wflow
+To learn more about the wflow plugin of this Python package, we refer to the [hydroMT-wflow
 documentation](https://deltares.github.io/hydromt_wflow/latest/index.html).
 
-To inspect or modify (for example in QGIS) the netCDF static data of these Wflow models it
+To inspect or modify (for example in QGIS) the netCDF static data of these wflow models it
 is convenient to export the maps to a raster format. This can be done as part of the
 hydroMT-wflow plugin, see also the following [example]
 (https://deltares.github.io/hydromt_wflow/latest/examples/examples/convert_staticmaps_to_mapstack.html).

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -103,7 +103,7 @@ Example models can be found in the [Example model section](@ref sample_data).
 
 ## hydroMT
 [hydroMT](https://github.com/Deltares/hydromt) is a Python package, developed by Deltares,
-to build and analysis hydro models. It provides a generic model api with attributes to
+to build and analyze hydro models. It provides a generic model api with attributes to
 access the model schematization, (dynamic) forcing data, results and states.
 
 For the following Wflow models:
@@ -111,7 +111,7 @@ For the following Wflow models:
   - wflow_sediment
 
 the Wflow plugin [hydroMT-wflow](https://github.com/Deltares/hydromt_wflow) of hydroMT can
-be used to build and analyse these Wflow model types in an automated way.
+be used to build and analyze these Wflow model types in an automated way.
 
 To learn more about the Wflow plugin of this Python package, we refer to the [hydroMT-wflow
 documentation](https://deltares.github.io/hydromt_wflow/latest/index.html).

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -97,7 +97,7 @@ flow](@ref) of the Model parameters section.
 
 The Model parameters section lists all the parameters per Model component and these Tables
 can also be used to check which parameters can be part of the output, see also [Output
-NetCDF section](@ref) and [Output CSV section](@ref).
+netCDF section](@ref) and [Output CSV section](@ref).
 
 Example models can be found in the [Example model section](@ref sample_data).
 

--- a/docs/src/user_guide/sample_data.md
+++ b/docs/src/user_guide/sample_data.md
@@ -19,7 +19,7 @@ and [Command Line Interface](@ref cli).
 
 ## [wflow\_sbm + kinematic wave](@id wflow_sbm_data)
 ```julia
-# urls to TOML and NetCDF of the Moselle example model
+# urls to TOML and netCDF of the Moselle example model
 toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/test/sbm_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.7/staticmaps-moselle.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.6/forcing-moselle.nc"
@@ -39,7 +39,7 @@ download(toml_url, toml_path)
 
 ## wflow\_sbm + groundwater flow
 ```julia
-# urls to TOML and NetCDF of the Moselle example model
+# urls to TOML and netCDF of the Moselle example model
 toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/test/sbm_gwf_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.2/staticmaps-sbm-groundwater.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.1/forcing-sbm-groundwater.nc"
@@ -57,7 +57,7 @@ download(toml_url, toml_path)
 
 ## wflow\_hbv
 ```julia
-# urls to TOML and NetCDF of the Moselle example model
+# urls to TOML and netCDF of the Moselle example model
 toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/test/hbv_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.1/staticmaps-lahn.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.0/forcing-lahn.nc"
@@ -75,7 +75,7 @@ download(toml_url, toml_path)
 
 ## [wflow\_flextopo](@id wflow_flextopo_data)
 ```julia
-# urls to TOML and NetCDF of the Meuse example model
+# urls to TOML and netCDF of the Meuse example model
 toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/test/flextopo_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.8/staticmaps_flex_meuse.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.8/forcing_meuse.nc"
@@ -93,7 +93,7 @@ download(toml_url, toml_path)
 
 ## wflow\_sediment
 ```julia
-# urls to TOML and NetCDF of the Moselle example model
+# urls to TOML and netCDF of the Moselle example model
 toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/test/sediment_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.3/staticmaps-moselle-sed.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v0.2.3/forcing-moselle-sed.nc"

--- a/docs/src/user_guide/sample_data.md
+++ b/docs/src/user_guide/sample_data.md
@@ -1,6 +1,6 @@
 # [Example models](@id sample_data)
 
-For each Wflow Model a test model is available that can help to understand the data
+For each wflow Model a test model is available that can help to understand the data
 requirements and the usage of each Model. The TOML configuration file per available model
 are listed in the Table below:
 

--- a/docs/src/user_guide/step1_requirements.md
+++ b/docs/src/user_guide/step1_requirements.md
@@ -2,12 +2,12 @@
 
 In order to run wflow, several files are required. These consist of a settings file and
 input data. The input data is typically separated into static maps and forcing data, both
-are supplied in a NetCDF file, except for lake storage and rating curves that are supplied
+are supplied in a netCDF file, except for lake storage and rating curves that are supplied
 via CSV files. A brief overview of the different files:
 
  - The `settings.toml` file contains information on the simulation period, links to the
-   input files (and their names in the NetCDF files), and links the correct names of the
-   variables in the NetCDF files to the variables and parameters of wflow.
+   input files (and their names in the netCDF files), and links the correct names of the
+   variables in the netCDF files to the variables and parameters of wflow.
  - The `staticmaps.nc` file contains spatial information on the elevation, locations of the
    gauges, land-use, drainage direction, etc. This file can also contain maps with parameter
    values.

--- a/docs/src/user_guide/step1_requirements.md
+++ b/docs/src/user_guide/step1_requirements.md
@@ -17,7 +17,7 @@ via CSV files. A brief overview of the different files:
 There are several model configurations supported by wflow. These model configurations
 require slightly different input requirements, yet the general structure is similar for each
 model. A wflow model configuration consists of a `vertical` concept like the [SBM](@ref
-vert_sbm), [HBV](@ref vert_hbv) or [FLEXTOPO](@ref vert_flextopo) vertical concept in
+vert_sbm), [HBV](@ref vert_hbv) or [FLEXTOPO](@ref vert_flextopo) in
 combination with `lateral` concepts that control how water is routed for example over the
 land or river domain. For the wflow\_sbm model different model configurations are possible.
 The following model configurations are supported in wflow:

--- a/docs/src/user_guide/step2_settings_file.md
+++ b/docs/src/user_guide/step2_settings_file.md
@@ -6,13 +6,13 @@ The filepaths that are provided in this file are relative to the location of the
 or to `dir_input` and `dir_output` if they are given.
 
 ## General time info
-Time information is optional. When left out, for each timestamp in the forcing netCDF Wflow
+Time information is optional. When left out, for each timestamp in the forcing netCDF wflow
 will do computations, except for the first forcing timestamp that is considered equal to the
-initial conditions of the Wflow model (state time). If you wish to calculate a subset of
+initial conditions of the wflow model (state time). If you wish to calculate a subset of
 this time range, or a different timestep, you can specify a `starttime`, `endtime` and
 `timestepsecs` yourself. The `starttime` is defined as the model state time. In the TOML
 file settings below the `starttime` is 2000-01-01T00:00:00 (state time) and the first update
-(and output) of the Wflow model is at 2000-01-02T00:00:00. The `time_units` optional
+(and output) of the wflow model is at 2000-01-02T00:00:00. The `time_units` optional
 information is used by the `writer` of the model, for model output in netCDF format. The
 `calendar` option allows you to calculate in one of the different [CF conventions
 calendars](http://cfconventions.org/cf-conventions/cf-conventions.html#calendar) provided by
@@ -247,7 +247,7 @@ internal layer index (see also example below). For model parameters and variable
 an extra dimension `classes` and are part of the vertical `FLEXTopo` concept it is possible
 to specify the class name. If multiple layers or classes are desired, this can be specified
 in separate `[[netcdf.variable]]` entries. Note that the specification of the extra
-dimension is not optional when Wflow is integrated with Delft-FEWS, for netCDF scalar data
+dimension is not optional when wflow is integrated with Delft-FEWS, for netCDF scalar data
 an extra dimension is not allowed by the `importNetcdfActivity` of the Delft-FEWS General
 Adapter. In the section [Output CSV section](@ref), similar functionality is available for
 CSV. For integration with Delft-FEWS, see also [Run from Delft-FEWS](@ref run_fews), it is

--- a/docs/src/user_guide/step2_settings_file.md
+++ b/docs/src/user_guide/step2_settings_file.md
@@ -6,7 +6,7 @@ The filepaths that are provided in this file are relative to the location of the
 or to `dir_input` and `dir_output` if they are given.
 
 ## General time info
-Time information is optional. When left out, for each timestamp in the forcing NetCDF Wflow
+Time information is optional. When left out, for each timestamp in the forcing netCDF Wflow
 will do computations, except for the first forcing timestamp that is considered equal to the
 initial conditions of the Wflow model (state time). If you wish to calculate a subset of
 this time range, or a different timestep, you can specify a `starttime`, `endtime` and
@@ -22,10 +22,10 @@ alternative calendars.
 
 ```toml
 calendar = "standard"                           # optional, this is default value
-starttime = 2000-01-01T00:00:00                 # optional, default from forcing NetCDF
-endtime = 2000-02-01T00:00:00                   # optional, default from forcing NetCDF
+starttime = 2000-01-01T00:00:00                 # optional, default from forcing netCDF
+endtime = 2000-02-01T00:00:00                   # optional, default from forcing netCDF
 time_units = "days since 1900-01-01 00:00:00"   # optional, this is default value
-timestepsecs = 86400                            # optional, default from forcing NetCDF
+timestepsecs = 86400                            # optional, default from forcing netCDF
 dir_input = "data/input"                        # optional, default is the path of the TOML
 dir_output = "data/output"                      # optional, default is the path of the TOML
 ```
@@ -143,7 +143,7 @@ forcing = [
 
 cyclic = ["vertical.leaf_area_index"]
 
-[input.vertical]    # Map internal model variable/parameter names to names of the variables in the NetCDF files
+[input.vertical]    # Map internal model variable/parameter names to names of the variables in the netCDF files
 altitude = "wflow_dem"
 c = "c"
 cf_soil = "cf_soil"
@@ -189,15 +189,15 @@ n = "N"
 slope = "Slope"
 ```
 
-## Output NetCDF section
+## Output netCDF section
 
 ### Grid data
 This optional section of the TOML file contains the output netCDF file for writing gridded
 model output, including a mapping between internal model parameter components and external
 netCDF variables.
 
-To limit the size of the resulting NetCDF file, file compression can be enabled. This causes
-an increase in computational time, but can significantly reduce the file size of the NetCDF
+To limit the size of the resulting netCDF file, file compression can be enabled. This causes
+an increase in computational time, but can significantly reduce the file size of the netCDF
 file. This can be enabled by setting the `compressionlevel` variable to any value between
 `0` and `9`. A setting of `0` indicates that compression is not enabled, and values between
 1 and 9 indicate different levels of compression (1: least compression, smallest impact on
@@ -234,24 +234,24 @@ h = "h_land"
 ```
 
 ### Scalar data
-Besides gridded data, it is also possible to write scalar data to a NetCDF file. Below is an
-example that writes scalar data to the file "output\_scalar\_moselle.nc". For each NetCDF
+Besides gridded data, it is also possible to write scalar data to a netCDF file. Below is an
+example that writes scalar data to the file "output\_scalar\_moselle.nc". For each netCDF
 variable a `name` (external variable name) and `parameter` (internal model parameter) is
 required. A `reducer` can be specified to apply to the model output, see for more
 information the following section [Output CSV section](@ref). When a `map` is provided to
 extract data for certain locations (e.g. `gauges`) or areas (e.g. `subcatchment`), the
-NetCDF location names are extracted from these maps. For a specific location (grid cell) a
+netCDF location names are extracted from these maps. For a specific location (grid cell) a
 `location` is required. For layered model parameters and variables that have an extra
 dimension `layer` and are part of the vertical `sbm` concept it is possible to specify an
 internal layer index (see also example below). For model parameters and variables that have
 an extra dimension `classes` and are part of the vertical `FLEXTopo` concept it is possible
 to specify the class name. If multiple layers or classes are desired, this can be specified
 in separate `[[netcdf.variable]]` entries. Note that the specification of the extra
-dimension is not optional when Wflow is integrated with Delft-FEWS, for NetCDF scalar data
+dimension is not optional when Wflow is integrated with Delft-FEWS, for netCDF scalar data
 an extra dimension is not allowed by the `importNetcdfActivity` of the Delft-FEWS General
 Adapter. In the section [Output CSV section](@ref), similar functionality is available for
 CSV. For integration with Delft-FEWS, see also [Run from Delft-FEWS](@ref run_fews), it is
-recommended to write scalar data to NetCDF format since the General Adapter of Delft-FEWS
+recommended to write scalar data to netCDF format since the General Adapter of Delft-FEWS
 can ingest this data format directly.
 
 ```toml
@@ -395,7 +395,7 @@ offset = 0.5
 
 For input parameters with an extra dimension it is also possible to modify multiple indices
 at once with different `scale` and `offset` values. In the example below the external
-NetCDF variable `c` is modified at `layer` index 1 and 2, with a `scale` factor of 2.0 and
+netCDF variable `c` is modified at `layer` index 1 and 2, with a `scale` factor of 2.0 and
 1.5 respectively, and an `offset` of 0.0 for both indices:
 
 ```toml

--- a/docs/src/user_guide/step3_input_data.md
+++ b/docs/src/user_guide/step3_input_data.md
@@ -10,7 +10,7 @@ As mentioned before, the input data can be classified into two types:
 
 ## Meteorological data
 
-Meteorological data is provided as a single NetCDF file, with several variables containing
+Meteorological data is provided as a single netCDF file, with several variables containing
 the forcing data for precipitation, temperature and potential evaporation. The code snippet
 below shows the contents of the example file (downloaded [here](@ref wflow_sbm_data)), and
 displaying the content with `NCDatasets` in Julia. As can be seen, each forcing variable
@@ -122,6 +122,6 @@ Land slope | `Slope` | m m$^{-1}$
 River slope | `RiverSlope` | m m$^{-1}$
 
 As mentioned before, the model parameters can also be defined as spatial maps. They can be
-included in the same NetCDF file, as long as their variable names are correctly mapped in
+included in the same netCDF file, as long as their variable names are correctly mapped in
 the TOML settings file. See the section on [example models](@ref sample_data) on how to
 use this functionality.

--- a/docs/src/user_guide/step4_running.md
+++ b/docs/src/user_guide/step4_running.md
@@ -29,7 +29,7 @@ Wflow.run(config)
 
 ## [Using the command line interface](@id cli)
 
-If you don't need the extra features of using Wflow as a library, but just want to run
+If you don't need the extra features of using wflow as a library, but just want to run
 simulations, the command line interface makes it easier to do so. It consists of a single
 executable, `wflow_cli` that accepts a single argument, the path to a TOML configuration
 file.

--- a/docs/src/user_guide/step5_output.md
+++ b/docs/src/user_guide/step5_output.md
@@ -3,7 +3,7 @@
 After running the model example from the previous step 4, the model results can be found in
 `data/output_moselle_simple.csv`.
 
-If required, it is also possible to output NetCDF files as output, by modifying the TOML
+If required, it is also possible to output netCDF files as output, by modifying the TOML
 file. An example is shown below:
 
 ```toml

--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -53,7 +53,7 @@ end
 function Clock(config, reader)
     nctimes = reader.dataset["time"][:]
 
-    # if the timestep is not given, use the difference between NetCDF time 1 and 2
+    # if the timestep is not given, use the difference between netCDF time 1 and 2
     timestepsecs = get(config, "timestepsecs", nothing)
     if timestepsecs === nothing
         timestepsecs = Dates.value(Second(nctimes[2] - nctimes[1]))
@@ -61,7 +61,7 @@ function Clock(config, reader)
     end
     Δt = Second(timestepsecs)
 
-    # if the config file does not have a start or endtime, follow the NetCDF times
+    # if the config file does not have a start or endtime, follow the netCDF times
     # and add them to the config
     starttime = get(config, "starttime", nothing)
     if starttime === nothing
@@ -236,16 +236,16 @@ function run(model::Model; close_files = true)
     end
     @info "Simulation duration: $(canonicalize(now() - runstart_time))"
 
-    # write output state NetCDF
+    # write output state netCDF
     if haskey(config, "state") && haskey(config.state, "path_output")
-        @info "Write output states to NetCDF file `$(model.writer.state_nc_path)`."
+        @info "Write output states to netCDF file `$(model.writer.state_nc_path)`."
     end
     write_netcdf_timestep(model, writer.state_dataset, writer.state_parameters)
 
     reset_clock!(model.clock, config)
 
     # option to support running function twice without re-initializing
-    # and thus opening the NetCDF files
+    # and thus opening the netCDF files
     if close_files
         Wflow.close_files(model, delete_output = false)
     end

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -391,7 +391,7 @@ end
 function save_state(model::Model)
     @unpack config, writer, clock = model
     if haskey(config, "state") && haskey(config.state, "path_output")
-        @info "Write output states to NetCDF file `$(model.writer.state_nc_path)`."
+        @info "Write output states to netCDF file `$(model.writer.state_nc_path)`."
     end
     write_netcdf_timestep(model, writer.state_dataset, writer.state_parameters)
 end

--- a/src/flextopo_model.jl
+++ b/src/flextopo_model.jl
@@ -598,7 +598,7 @@ function initialize_flextopo_model(config::Config)
     )
 
     # if fews_run = true, then classes are specified as Float64 index so FEWS can import
-    # netCDF output (3D data/SVector).
+    # NetCDF output (3D data/SVector).
     fews_run = get(config, "fews_run", false)::Bool
     classes = fews_run ? Float64.(collect(1:length(flextopo.classes))) : flextopo.classes
 

--- a/src/flextopo_model.jl
+++ b/src/flextopo_model.jl
@@ -5,7 +5,7 @@ Initial part of the FlexTopo model concept. Reads the input settings and data as
 Config object. Will return a Model that is ready to run.
 """
 function initialize_flextopo_model(config::Config)
-    # unpack the paths to the NetCDF files
+    # unpack the paths to the netCDF files
     static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)
@@ -598,7 +598,7 @@ function initialize_flextopo_model(config::Config)
     )
 
     # if fews_run = true, then classes are specified as Float64 index so FEWS can import
-    # NetCDF output (3D data/SVector).
+    # netCDF output (3D data/SVector).
     fews_run = get(config, "fews_run", false)::Bool
     classes = fews_run ? Float64.(collect(1:length(flextopo.classes))) : flextopo.classes
 

--- a/src/hbv_model.jl
+++ b/src/hbv_model.jl
@@ -5,7 +5,7 @@ Initial part of the SBM model concept. Reads the input settings and data as defi
 Config object. Will return a Model that is ready to run.
 """
 function initialize_hbv_model(config::Config)
-    # unpack the paths to the NetCDF files
+    # unpack the paths to the netCDF files
     static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,7 +1,7 @@
 #=
 Code to support input and output of data and configuration.
-Input data can be loaded from NetCDF files.
-Output data can be written to NetCDF or CSV files.
+Input data can be loaded from netCDF files.
+Output data can be written to netCDF or CSV files.
 For configuration files we use TOML.
 =#
 
@@ -109,7 +109,7 @@ function output_path(config::Config, path::AbstractString)
     return combined_path(config, dir, path)
 end
 
-"Extract NetCDF variable name `ncname` from `var` (type `String` or `Config`). If `var` has
+"Extract netCDF variable name `ncname` from `var` (type `String` or `Config`). If `var` has
 type `Config`, either `scale`, `offset` and an optional `index` are expected (with `ncname`)
 or a `value` (uniform value), these are stored as part of `NamedTuple` `modifier`."
 function ncvar_name_modifier(var; config = nothing)
@@ -159,7 +159,7 @@ function ncvar_name_modifier(var; config = nothing)
     return ncname, modifier
 end
 
-"Extract a NetCDF variable at a given time"
+"Extract a netCDF variable at a given time"
 function get_at(
     ds::CFDataset,
     varname::AbstractString,
@@ -239,7 +239,7 @@ function load_fixed_forcing(model)
     end
 end
 
-"Get dynamic NetCDF input for the given time"
+"Get dynamic netCDF input for the given time"
 function update_forcing!(model)
     @unpack vertical, clock, reader, network, config = model
     @unpack dataset, dataset_times, forcing_parameters = reader
@@ -260,7 +260,7 @@ function update_forcing!(model)
     # at 01-02-2000 00:00:00 is the accumulated total precipitation between 01-01-2000
     # 00:00:00 and 01-02-2000 00:00:00.
 
-    # load from NetCDF into the model according to the mapping
+    # load from netCDF into the model according to the mapping
     for (par, ncvar) in forcing_parameters
         # no need to update fixed values
         ncvar.name === nothing && continue
@@ -321,7 +321,7 @@ true
 """
 monthday_passed(curr, avail) = (curr[1] >= avail[1]) && (curr[2] >= avail[2])
 
-"Get dynamic and cyclic NetCDF input"
+"Get dynamic and cyclic netCDF input"
 function load_dynamic_input!(model)
     update_forcing!(model)
     if haskey(model.config.input, "cyclic")
@@ -329,7 +329,7 @@ function load_dynamic_input!(model)
     end
 end
 
-"Get cyclic NetCDF input for the given time"
+"Get cyclic netCDF input for the given time"
 function update_cyclic!(model)
     @unpack vertical, clock, reader, network, config = model
     @unpack cyclic_dataset, cyclic_times, cyclic_parameters = reader
@@ -345,7 +345,7 @@ function update_cyclic!(model)
             i = findlast(t -> monthday_passed(month_day, t), cyclic_times[par])
             isnothing(i) &&
                 error("Could not find applicable cyclic timestep for $month_day")
-            # load from NetCDF into the model according to the mapping
+            # load from netCDF into the model according to the mapping
             data = get_at(cyclic_dataset, ncvar.name, i)
             param_vector = param(model, par)
             sel = active_indices(network, par)
@@ -360,7 +360,7 @@ end
 """
     nc_handles::Dict{String, NCDataset{Nothing}}
 
-For each NetCDF file that will be opened for writing, store an entry in this Dict from the
+For each netCDF file that will be opened for writing, store an entry in this Dict from the
 absolute path of the file to the NCDataset. This allows us to close the NCDataset if we try
 to create them twice in the same session, and thus providing a workaround for this issue:
 https://github.com/Alexander-Barth/NCDatasets.jl/issues/106
@@ -370,7 +370,7 @@ NCDataset.
 """
 const nc_handles = Dict{String,NCDataset{Nothing}}()
 
-"Safely create a NetCDF file, even if it has already been opened for creation"
+"Safely create a netCDF file, even if it has already been opened for creation"
 function create_tracked_netcdf(path)
     abs_path = abspath(path)
     # close existing NCDataset if it exists
@@ -407,7 +407,7 @@ function setup_scalar_netcdf(
     )
     set_extradim_netcdf(ds, extra_dim)
     for (nc, netcdfvars) in zip(ncvars, config.netcdf.variable)
-        # Delft-FEWS requires the attribute :cf_role = "timeseries_id" when a NetCDF file
+        # Delft-FEWS requires the attribute :cf_role = "timeseries_id" when a netCDF file
         # contains more than one location list
         defVar(
             ds,
@@ -451,7 +451,7 @@ function setup_scalar_netcdf(
     return ds
 end
 
-"set extra dimension in output NetCDF file"
+"set extra dimension in output netCDF file"
 function set_extradim_netcdf(
     ds,
     extra_dim::NamedTuple{
@@ -630,19 +630,19 @@ struct NCReader{T}
 end
 
 struct Writer
-    dataset::Union{NCDataset,Nothing}           # dataset (NetCDF) for grid data
-    parameters::Dict{String,Any}                # mapping of NetCDF variable names to model parameters (arrays)
-    nc_path::Union{String,Nothing}              # path NetCDF file (grid data)
+    dataset::Union{NCDataset,Nothing}           # dataset (netCDF) for grid data
+    parameters::Dict{String,Any}                # mapping of netCDF variable names to model parameters (arrays)
+    nc_path::Union{String,Nothing}              # path netCDF file (grid data)
     csv_path::Union{String,Nothing}             # path of CSV file
     csv_cols::Vector                            # model parameter (arrays) and associated reducer function for CSV output
     csv_io::IO                                  # file handle to CSV file
-    state_dataset::Union{NCDataset,Nothing}     # dataset with model states (NetCDF)
-    state_parameters::Dict{String,Any}          # mapping of NetCDF variable names to model states (arrays)
-    state_nc_path::Union{String,Nothing}        # path NetCDF file with states
-    dataset_scalar::Union{NCDataset,Nothing}    # dataset (NetCDF) for scalar data
-    nc_scalar::Vector                           # model parameter (arrays) and associated reducer function for NetCDF scalar output
-    ncvars_dims::Vector                         # model parameter (String) and associated NetCDF variable, location dimension and location name for scalar data
-    nc_scalar_path::Union{String,Nothing}       # path NetCDF file (scalar data)
+    state_dataset::Union{NCDataset,Nothing}     # dataset with model states (netCDF)
+    state_parameters::Dict{String,Any}          # mapping of netCDF variable names to model states (arrays)
+    state_nc_path::Union{String,Nothing}        # path netCDF file with states
+    dataset_scalar::Union{NCDataset,Nothing}    # dataset (netCDF) for scalar data
+    nc_scalar::Vector                           # model parameter (arrays) and associated reducer function for netCDF scalar output
+    ncvars_dims::Vector                         # model parameter (String) and associated netCDF variable, location dimension and location name for scalar data
+    nc_scalar_path::Union{String,Nothing}       # path netCDF file (scalar data)
     extra_dim::Union{NamedTuple,Nothing}        # name and values for extra dimension (to store SVectors)
 end
 
@@ -694,7 +694,7 @@ function prepare_reader(config)
     # check for cyclic parameters
     do_cyclic = haskey(config.input, "cyclic")
 
-    # create map from internal location to NetCDF variable name for forcing parameters
+    # create map from internal location to netCDF variable name for forcing parameters
     forcing_parameters = Dict{Tuple{Symbol,Vararg{Symbol}},NamedTuple}()
     for par in config.input.forcing
         fields = symbols(par)
@@ -702,10 +702,10 @@ function prepare_reader(config)
         forcing_parameters[fields] =
             (name = ncname, scale = mod.scale, offset = mod.offset, value = mod.value)
 
-        @info "Set `$par` using NetCDF variable `$ncname` as forcing parameter."
+        @info "Set `$par` using netCDF variable `$ncname` as forcing parameter."
     end
 
-    # create map from internal location to NetCDF variable name for cyclic parameters and
+    # create map from internal location to netCDF variable name for cyclic parameters and
     # store cyclic times for each internal location (duplicate cyclic times are possible
     # this way, however it seems not worth to keep track of unique cyclic times for now
     # (memory usage))
@@ -723,7 +723,7 @@ function prepare_reader(config)
             cyclic_parameters[fields] =
                 (name = ncname, scale = mod.scale, offset = mod.offset)
 
-            @info "Set `$par` using NetCDF variable `$ncname` as cyclic parameter, with `$(length(cyclic_nc_times))` timesteps."
+            @info "Set `$par` using netCDF variable `$ncname` as cyclic parameter, with `$(length(cyclic_nc_times))` timesteps."
         end
     else
         cyclic_parameters = Dict{Tuple{Symbol,Vararg{Symbol}},NamedTuple}()
@@ -766,7 +766,7 @@ function locations_map(ds, mapname, config)
     return ids
 end
 
-"Get a Vector{Tuple} with model parameter and associated NetCDF variable name, dimension and location names for scalar data"
+"Get a Vector{Tuple} with model parameter and associated netCDF variable name, dimension and location names for scalar data"
 function nc_variables_dims(nc_variables, dataset, config)
     ncvars_dims = []
     for nc_var in nc_variables
@@ -846,7 +846,7 @@ end
 """
     ncnames(dict)
 
-Create a flat mapping from internal parameter locations to NetCDF variable names.
+Create a flat mapping from internal parameter locations to netCDF variable names.
 
 Ignores top level values in the Dict. This function is used to convert a TOML such as:
 
@@ -861,8 +861,8 @@ canopystorage = "my_canopystorage"
 q = "my_q"
 ```
 
-To a dictionary of the flattened parameter locations and NetCDF names. The top level
-values are ignored since the output path is not a NetCDF name.
+To a dictionary of the flattened parameter locations and netCDF names. The top level
+values are ignored since the output path is not a netCDF name.
 
 ```julia
 Dict(
@@ -884,7 +884,7 @@ end
 """
     out_map(ncnames_dict, modelmap)
 
-Create a Dict that maps parameter NetCDF names to arrays in the Model.
+Create a Dict that maps parameter netCDF names to arrays in the Model.
 """
 function out_map(ncnames_dict, modelmap)
     output_map = Dict{String,Any}()
@@ -925,15 +925,15 @@ function prepare_writer(
     calendar = get(config, "calendar", "standard")::String
     time_units = get(config, "time_units", CFTime.DEFAULT_TIME_UNITS)
 
-    # create an output NetCDF that will hold all timesteps of selected parameters for grid
+    # create an output netCDF that will hold all timesteps of selected parameters for grid
     # data but only if config.output.path has been set
     if haskey(config, "output") && haskey(config.output, "path")
         nc_path = output_path(config, config.output.path)
         deflatelevel = get(config.output, "compressionlevel", 0)::Int
-        @info "Create an output NetCDF file `$nc_path` for grid data, using compression level `$deflatelevel`."
-        # create a flat mapping from internal parameter locations to NetCDF variable names
+        @info "Create an output netCDF file `$nc_path` for grid data, using compression level `$deflatelevel`."
+        # create a flat mapping from internal parameter locations to netCDF variable names
         output_ncnames = ncnames(config.output)
-        # fill the output_map by mapping parameter NetCDF names to arrays
+        # fill the output_map by mapping parameter netCDF names to arrays
         output_map = out_map(output_ncnames, modelmap)
         ds = setup_grid_netcdf(
             nc_path,
@@ -952,13 +952,13 @@ function prepare_writer(
         ds = nothing
     end
 
-    # create a separate state output NetCDF that will hold the last timestep of all states
+    # create a separate state output netCDF that will hold the last timestep of all states
     # but only if config.state.path_output has been set
     if haskey(config, "state") && haskey(config.state, "path_output")
         state_ncnames = check_states(config)
         state_map = out_map(state_ncnames, modelmap)
         nc_state_path = output_path(config, config.state.path_output)
-        @info "Create a state output NetCDF file `$nc_state_path`."
+        @info "Create a state output netCDF file `$nc_state_path`."
         ds_outstate = setup_grid_netcdf(
             nc_state_path,
             x_nc,
@@ -976,12 +976,12 @@ function prepare_writer(
         nc_state_path = nothing
     end
 
-    # create an output NetCDF that will hold all timesteps of selected parameters for scalar
+    # create an output netCDF that will hold all timesteps of selected parameters for scalar
     # data, but only if config.netcdf.variable has been set.
     if haskey(config, "netcdf") && haskey(config.netcdf, "variable")
         nc_scalar_path = output_path(config, config.netcdf.path)
-        @info "Create an output NetCDF file `$nc_scalar_path` for scalar data."
-        # get NetCDF info for scalar data (variable name, locationset (dim) and
+        @info "Create an output netCDF file `$nc_scalar_path` for scalar data."
+        # get netCDF info for scalar data (variable name, locationset (dim) and
         # location ids)
         ncvars_dims = nc_variables_dims(config.netcdf.variable, nc_static, config)
         ds_scalar = setup_scalar_netcdf(
@@ -999,7 +999,7 @@ function prepare_writer(
         for var in config.netcdf.variable
             parameter = var["parameter"]
             reducer_func =
-                get_reducer_func(var, rev_inds, x_nc, y_nc, config, nc_static, "NetCDF")
+                get_reducer_func(var, rev_inds, x_nc, y_nc, config, nc_static, "netCDF")
             push!(nc_scalar, (parameter = parameter, reducer = reducer_func))
         end
     else
@@ -1056,7 +1056,7 @@ function prepare_writer(
     )
 end
 
-"Write a new timestep with scalar data to a NetCDF file"
+"Write a new timestep with scalar data to a netCDF file"
 function write_netcdf_timestep(model, dataset)
     @unpack writer, clock, config = model
 
@@ -1088,7 +1088,7 @@ function write_netcdf_timestep(model, dataset)
     return model
 end
 
-"Write a new timestep with grid data to a NetCDF file"
+"Write a new timestep with grid data to a netCDF file"
 function write_netcdf_timestep(model, dataset, parameters)
     @unpack vertical, clock, reader, network = model
 
@@ -1122,7 +1122,7 @@ function write_netcdf_timestep(model, dataset, parameters)
     return model
 end
 
-# don't do anything for no dataset, used if no output NetCDF is needed
+# don't do anything for no dataset, used if no output netCDF is needed
 write_netcdf_timestep(model, dataset::Nothing, parameters) = model
 write_netcdf_timestep(model, dataset::Nothing) = model
 
@@ -1392,8 +1392,8 @@ is_increasing(v) = last(v) > first(v)
     nc_dim_name(dims::Vector{Symbol}, name::Symbol)
     nc_dim_name(ds::CFDataset, name::Symbol)
 
-Given a NetCDF dataset or list of dimensions, and an internal dimension name, return the
-corresponding NetCDF dimension name. Certain common alternatives are supported, e.g. :lon or
+Given a netCDF dataset or list of dimensions, and an internal dimension name, return the
+corresponding netCDF dimension name. Certain common alternatives are supported, e.g. :lon or
 :longitude instead of :x.
 """
 function nc_dim_name(dims::Vector{Symbol}, name::Symbol)
@@ -1421,7 +1421,7 @@ nc_dim_name(ds::CFDataset, name::Symbol) = nc_dim_name(Symbol.(keys(ds.dim)), na
     nc_dim(ds::CFDataset, name::Symbol)
 
 Return the dimension coordinate, based on the internal name (:x, :y, :`extra_dim.name`,
-:time), `extra_dim` depends on the model type, which will map to the correct NetCDF name
+:time), `extra_dim` depends on the model type, which will map to the correct netCDF name
 using `nc_dim_name`.
 """
 nc_dim(ds::CFDataset, name) = ds[nc_dim_name(ds, name)]
@@ -1430,7 +1430,7 @@ nc_dim(ds::CFDataset, name) = ds[nc_dim_name(ds, name)]
 """
     internal_dim_name(name::Symbol)
 
-Given a NetCDF dimension name string, return the corresponding internal dimension name.
+Given a netCDF dimension name string, return the corresponding internal dimension name.
 """
 function internal_dim_name(name::Symbol)
     if name in (:x, :lon, :longitude)
@@ -1449,7 +1449,7 @@ end
 """
     read_dims(A::CFVariable_MF, dim_sel)
 
-Return the data of a NetCDF data variable as an Array. Only dimensions in `dim_sel`, a
+Return the data of a netCDF data variable as an Array. Only dimensions in `dim_sel`, a
 NamedTuple like (x=:, y=:, time=1). Other dimensions that may be present need to be size 1,
 otherwise an error is thrown.
 
@@ -1475,7 +1475,7 @@ function read_dims(A::CFVariable_MF, dim_sel::NamedTuple)
                     push!(data_dim_order, dim)
                 end
             else
-                throw(ArgumentError("""NetCDF dimension $dim_name has length $dim_size.
+                throw(ArgumentError("""netCDF dimension $dim_name has length $dim_size.
                     Only extra dimensions of length 1 are supported."""))
             end
         end
@@ -1584,7 +1584,7 @@ end
 """
     read_standardized(ds::CFDataset, varname::AbstractString, dim_names)
 
-Read the dimensions listed in dim_names from a variable with name `varname` from a NetCDF
+Read the dimensions listed in dim_names from a variable with name `varname` from a netCDF
 dataset `ds`. `dim_sel` should be a NamedTuple like (x=:, y=:, time=1), which will return
 a 2 dimensional array with x and y axes, representing the first index in the time dimension.
 """

--- a/src/io.jl
+++ b/src/io.jl
@@ -1475,7 +1475,7 @@ function read_dims(A::CFVariable_MF, dim_sel::NamedTuple)
                     push!(data_dim_order, dim)
                 end
             else
-                throw(ArgumentError("""netCDF dimension $dim_name has length $dim_size.
+                throw(ArgumentError("""NetCDF dimension $dim_name has length $dim_size.
                     Only extra dimensions of length 1 are supported."""))
             end
         end

--- a/src/sbm.jl
+++ b/src/sbm.jl
@@ -216,7 +216,7 @@ function initialize_canopy(nc, config, inds)
     n = length(inds)
     # if leaf area index climatology provided use sl, swood and kext to calculate cmax, e_r and canopygapfraction
     if haskey(config.input.vertical, "leaf_area_index")
-        # TODO confirm if leaf area index climatology is present in the NetCDF
+        # TODO confirm if leaf area index climatology is present in the netCDF
         sl = ncread(
             nc,
             config,

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -15,7 +15,7 @@ Will return a Model that is ready to run.
 """
 function initialize_sbm_gwf_model(config::Config)
 
-    # unpack the paths to the NetCDF files
+    # unpack the paths to the netCDF files
     static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)

--- a/src/sbm_model.jl
+++ b/src/sbm_model.jl
@@ -9,7 +9,7 @@ function initialize_sbm_model(config::Config)
     model_type = config.model.type::String
     @info "Initialize model variables for model type `$model_type`."
 
-    # unpack the paths to the NetCDF files
+    # unpack the paths to the netCDF files
     static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -9,7 +9,7 @@ function initialize_sediment_model(config::Config)
     model_type = config.model.type::String
     @info "Initialize model variables for model type `$model_type`."
 
-    # unpack the paths to the NetCDF files
+    # unpack the paths to the netCDF files
     static_path = input_path(config, config.input.path_static)
 
     reader = prepare_reader(config)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -129,9 +129,9 @@ end
 """
     set_states(instate_path, model, state_ncnames; <keyword arguments>)
 
-Read states contained in `Dict` `state_ncnames` from NetCDF file located in `instate_path`,
+Read states contained in `Dict` `state_ncnames` from netCDF file located in `instate_path`,
 and set states in `model` object. Active cells are selected with the corresponding network's
-(`Vector{CartesianIndex}`) from the NetCDF file.
+(`Vector{CartesianIndex}`) from the netCDF file.
 
 # Arguments
 - `type = nothing`: type to convert data to after reading. By default no conversion is done.
@@ -142,10 +142,10 @@ function set_states(instate_path, model; type = nothing, dimname = nothing)
     # Check if required states are covered
     state_ncnames = check_states(config)
 
-    # states in NetCDF include dim time (one value) at index 3 or 4, 3 or 4 dims are allowed
+    # states in netCDF include dim time (one value) at index 3 or 4, 3 or 4 dims are allowed
     NCDataset(instate_path) do ds
         for (state, ncname) in state_ncnames
-            @info "Setting initial state from NetCDF." ncpath = instate_path ncvarname =
+            @info "Setting initial state from netCDF." ncpath = instate_path ncvarname =
                 ncname state
             sel = active_indices(network, state)
             n = length(sel)
@@ -200,7 +200,7 @@ end
 """
     ncread(nc, config::Config, parameter::AbstractString; <keyword arguments>)
 
-Read a NetCDF variable `var` from file `nc`, based on `config` (parsed TOML file) and the
+Read a netCDF variable `var` from file `nc`, based on `config` (parsed TOML file) and the
 model `parameter` specified in the TOML configuration file. Supports various keyword
 arguments to get selections of data in desired types, with or without missing values.
 
@@ -209,7 +209,7 @@ arguments to get selections of data in desired types, with or without missing va
 - `optional=true` : By default specifying a model `parameter` in the TOML file is optional.
         Set to false if the model `parameter` is required.
 - `sel=nothing`: A selection of indices, such as a `Vector{CartesianIndex}` of active cells,
-        to return from the NetCDF. By default all cells are returned.
+        to return from the netCDF. By default all cells are returned.
 - `defaults=nothing`: A default value if `var` is not in `nc`. By default it gives an error
     in this case.
 - `type=nothing`: Type to convert data to after reading. By default no conversion is done.
@@ -233,7 +233,7 @@ function ncread(
     fill = nothing,
     dimname = nothing,
 )
-    # get var (NetCDF variable or type Config) from TOML file.
+    # get var (netCDF variable or type Config) from TOML file.
     # if var has type Config, input parameters can be changed.
     if isnothing(alias)
         if optional
@@ -273,8 +273,8 @@ function ncread(
     end
 
     # If var has type Config, input parameters can be changed (through scale, offset and
-    # input NetCDF var) or set to a uniform value (providing a value). Otherwise, input
-    # NetCDF var is read directly.
+    # input netCDF var) or set to a uniform value (providing a value). Otherwise, input
+    # netCDF var is read directly.
     var, mod = ncvar_name_modifier(var; config = config)
 
     if !isnothing(mod.value)
@@ -290,7 +290,7 @@ function ncread(
             return repeat(mod.value, 1, length(sel))
         end
     else
-        @info "Set `$parameter` using NetCDF variable `$var`."
+        @info "Set `$parameter` using netCDF variable `$var`."
         A = read_standardized(nc, var, dim_sel)
         if !isnothing(mod.index)
             # the modifier index is only set in combination with scale and offset for SVectors,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -274,7 +274,7 @@ function ncread(
 
     # If var has type Config, input parameters can be changed (through scale, offset and
     # input netCDF var) or set to a uniform value (providing a value). Otherwise, input
-    # netCDF var is read directly.
+    # NetCDF var is read directly.
     var, mod = ncvar_name_modifier(var; config = config)
 
     if !isnothing(mod.value)

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -199,6 +199,6 @@ end
     @test satwaterdepth ≠ mean(model.vertical.satwaterdepth)
     @test_logs (
         :info,
-        "Write output states to NetCDF file `$(model.writer.state_nc_path)`.",
+        "Write output states to netCDF file `$(model.writer.state_nc_path)`.",
     ) Wflow.save_state(model)
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -65,7 +65,7 @@ end
     ds = NCDataset(ncpath)
     reader = (; dataset = ds)
 
-    # if these keys are missing, they are derived from the NetCDF
+    # if these keys are missing, they are derived from the netCDF
     pop!(Dict(config), "starttime")
     pop!(Dict(config), "endtime")
     pop!(Dict(config), "timestepsecs")
@@ -413,7 +413,7 @@ end
     rm(tomlpath_error)
 end
 
-# test calendar setting `noleap` in forcing NetCDF file (including `_FillValue` in time
+# test calendar setting `noleap` in forcing netCDF file (including `_FillValue` in time
 # dimension) and in TOML file (Clock{DateTimeNoLeap}).
 @testset "Calendar noleap (DateTimeNoLeap) for time and clock" begin
     config = Wflow.Config(tomlpath)


### PR DESCRIPTION
This PR updates the spelling and grammar in the User guide section of the Wflow documentation.
This resolves one of the tasks in issue #377, namely the update of the User guide section.\
As I joined the team this week I have been reading the documentation in sequential order from front to back and along the way I commit languages changes.