### PR TITLE
Fix `BMI.update_until` (`InexactError: Int64`)

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -22,6 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `to_river` variable from overland flow and lateral subsurface flow was not added to the
   inflow of these locations.
 - Close netCDF `NCDataset` with state variables in extended BMI function `save_state`.
+- `BMI.update_until` could throw an `InexactError: Int64` caused by a not whole number. This
+  is fixed by applying `round()`.
 
 ### Changed
 - Stop exposing scalar variables through BMI. The `BMI.get_value_ptr` function was

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -25,8 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - For the computation of Gash interception model parameter `e_r` multiply the precipitation
   input with the canopy fraction (this was only done for the potential evapotranspiration
   input).
- - `BMI.update_until` could throw an `InexactError: Int64` caused by a not whole number. This
-  is fixed by applying `round()`.
+ - Function `BMI.update_until` could throw an `InexactError: Int64` caused by a not whole
+  number, representing how many times (`steps`) an update of a wflow model is required. This
+  is fixed by using `divrem` for the computation of the number of `steps` in this function.
+  An error is thrown when the absolute remainder of `divrem` is larger than `eps()`, or when
+  the number of `steps` is negative.
   
 ### Changed
 - Stop exposing scalar variables through BMI. The `BMI.get_value_ptr` function was not

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -66,19 +66,19 @@ end
 function BMI.update_until(model::Model, time::Float64)
     @unpack clock, network, config = model
     t = BMI.get_current_time(model)
-    steps = (time - t) / model.clock.Δt.value
+    _div, _rem = divrem(time - t, model.clock.Δt.value)
+    steps = Int(_div)
     if steps < 0
         error("The current model timestamp $t is larger than provided `time` $time")
-    elseif !isinteger(steps)
+    elseif abs(_rem) > eps()
         error_message = string(
             "Provided `time` $time minus the current model timestamp $t",
             " is not an integer multiple of model time step $(model.clock.Δt.value)",
         )
         error(error_message)
-    else
-        for _ = 1:steps
-            model = run_timestep(model)
-        end
+    end
+    for _ = 1:steps
+        model = run_timestep(model)
     end
     return model
 end

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -65,11 +65,20 @@ end
 
 function BMI.update_until(model::Model, time::Float64)
     @unpack clock, network, config = model
-    curtime = BMI.get_current_time(model)
-    steps = round((time - curtime) / model.clock.Δt.value)
-    n = Int(max(0, steps))
-    for _ = 1:n
-        model = run_timestep(model)
+    t = BMI.get_current_time(model)
+    steps = (time - t) / model.clock.Δt.value
+    if steps < 0
+        error("The current model timestamp $t is larger than provided `time` $time")
+    elseif !isinteger(steps)
+        error_message = string(
+            "Provided `time` $time minus the current model timestamp $t",
+            " is not an integer multiple of model time step $(model.clock.Δt.value)",
+        )
+        error(error_message)
+    else
+        for _ = 1:steps
+            model = run_timestep(model)
+        end
     end
     return model
 end

--- a/src/bmi.jl
+++ b/src/bmi.jl
@@ -66,7 +66,8 @@ end
 function BMI.update_until(model::Model, time::Float64)
     @unpack clock, network, config = model
     curtime = BMI.get_current_time(model)
-    n = Int(max(0, (time - curtime) / model.clock.Δt.value))
+    steps = round((time - curtime) / model.clock.Δt.value)
+    n = Int(max(0, steps))
     for _ = 1:n
         model = run_timestep(model)
     end

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -119,9 +119,10 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
             time = BMI.get_current_time(model) + 2 * BMI.get_time_step(model)
             model = BMI.update_until(model, time)
             @test model.clock.iteration == 3
-            time = BMI.get_current_time(model) + 1 * BMI.get_time_step(model) + 1e-06
-            @test_throws ErrorException model = BMI.update_until(model, time)
-            @test_throws ErrorException model = BMI.update_until(model, -0.01)
+            time_off = BMI.get_current_time(model) + 1 * BMI.get_time_step(model) + 1e-06
+            @test_throws ErrorException model = BMI.update_until(model, time_off)
+            @test_throws ErrorException model =
+                BMI.update_until(model, time - BMI.get_time_step(model))
             BMI.finalize(model)
         end
 

--- a/test/bmi.jl
+++ b/test/bmi.jl
@@ -117,8 +117,11 @@ tomlpath = joinpath(@__DIR__, "sbm_config.toml")
 
         @testset "update until and finalize" begin
             time = BMI.get_current_time(model) + 2 * BMI.get_time_step(model)
-            @test_logs (:info, "update model until 9.470304e8")
             model = BMI.update_until(model, time)
+            @test model.clock.iteration == 3
+            time = BMI.get_current_time(model) + 1 * BMI.get_time_step(model) + 1e-06
+            @test_throws ErrorException model = BMI.update_until(model, time)
+            @test_throws ErrorException model = BMI.update_until(model, -0.01)
             BMI.finalize(model)
         end
 


### PR DESCRIPTION
## Issue addressed
Fixes #386 

## Explanation
`BMI.update_until` could throw an `InexactError: Int64` caused by a not whole number. This is fixed by using `divrem` for the computation of the number of  `steps` in `BMI.update_until`, an error is thrown when the absolute remainder is larger than `eps()`. An error is also thrown when `steps` is a negative number. 

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.md if needed
