### PR TITLE
Fix broken doc links

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -179,15 +179,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Show total duration of simulation in the log file (info), and show the current time at
   execution of each timestep (debug).
-- Support for exponential decline in horizontal conductivity in the sbm\_gwf concept. This can
-  be enabled using the `conductivity_profile` setting (either "uniform" or "exponential"). If
-  set to "exponential", it exponentially reduces the `kh0` (or `conductivity`) based on the
-  value of `gwf_f` to the actual horizontal conductivity (`k`).
+- Support for exponential decline in horizontal conductivity in the sbm\_gwf concept. This
+  can be enabled using the `conductivity_profile` setting (either "uniform" or
+  "exponential"). If set to "exponential", it exponentially reduces the `kh0` (or
+  `conductivity`) based on the value of `gwf_f` to the actual horizontal conductivity (`k`).
 - An optional 1D floodplain schematization for the river flow inertial model, based on
   provided flood volumes as a function of flood depth per river cell. See also the following
-  sections: [SBM + Local inertial river and floodplain](@ref) and [River and floodplain
-  routing](@ref) for a short description, and the following section for associated [model
-  parameters](@ref local-inertial_floodplain_params).
+  sections: [SBM + Local inertial river](@ref config_sbm_gwf_lie_river) and [River and
+  floodplain routing](@ref) for a short description, and the following section for
+  associated [model parameters](@ref local-inertial_floodplain_params).
 
 ## v0.6.2 - 2022-09-01
 
@@ -208,8 +208,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   model from `bankfull_depth` to zero.
 
 ### Added
-- External inflow to the [SBM + Local inertial river (1D) and land (2D)](@ref) model
-  configuration.
+- External inflow to the [SBM + Local inertial river (1D) and land (2D)](@ref
+  config_sbm_gwf_lie_river_land) model configuration.
 
 ## v0.6.1 - 2022-04-26
 
@@ -272,10 +272,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Additional log messages and log file as output, see also [Logging](@ref logging_toml).
 - Option to use the local inertial model for river flow as part of the `sbm` model type. See
-  also [SBM + Local inertial river](@ref).
+  also [SBM + Local inertial river](@ref config_sbm_gwf_lie_river).
 - Option to use the local inertial model for 1D river flow combined with 2D overland flow as
   part of the `sbm` model type. See also [SBM + Local inertial river (1D) and land
-  (2D)](@ref).
+  (2D)](@ref config_sbm_gwf_lie_river_land).
 
 ### Fixed
 - Model type `hbv`: the surface width for overland flow was not corrected with the river
@@ -356,7 +356,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Option to use the local inertial model for river flow as part of the [SBM + Kinematic
-  wave](@ref). See also [SBM + Local inertial river](@ref).
+  wave](@ref config_sbm). See also [SBM + Local inertial river](@ref config_sbm_gwf_lie_river_land).
 
 ### Fixed
 - River inflow for reservoirs and lakes in the kinematic wave. This inflow was based on
@@ -372,11 +372,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Multi-threading of vertical SBM concept and lateral kinematic wave components (overland,
-  river and subsurface flow) of wflow\_sbm model [SBM + Kinematic wave](@ref).
+  river and subsurface flow) of wflow\_sbm model [SBM + Kinematic wave](@ref config_sbm).
 - Improved error message for CSV Reducer.
 - The TOML keys `kv₀`, `θᵣ` and `θₛ` have been replaced with the ASCII versions `kv_0`,
-  `theta_r` and `theta_s`, to avoid encoding issues with certain text editors. The old keys still
-  work as well.
+  `theta_r` and `theta_s`, to avoid encoding issues with certain text editors. The old keys
+  still work as well.
 
 ### Fixed
 - Calculation of volumetric water content of vertical SBM (soil layers and root zone).

--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is fixed by using `divrem` for the computation of the number of `steps` in this function.
   An error is thrown when the absolute remainder of `divrem` is larger than `eps()`, or when
   the number of `steps` is negative.
+- Fixed internal and external broken links in docs. 
   
 ### Changed
 - Stop exposing scalar variables through BMI. The `BMI.get_value_ptr` function was not
@@ -61,6 +62,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   names of variables, structs, functions and macros. Using the non-ASCII character for
   built-in operators is still allowed. This change in naming convention is now in effect and
   all invalid uses of non-ASCII characters have been replaced by ASCII equivalents.
+- Improved description of different model configurations in model-setup.md, also in relation
+  to hydromt_wflow in docs.
 
 ### Added
 - Total water storage as an export variable for `SBM` concept. This is the total water stored

--- a/docs/src/model_docs/lateral/local-inertial.md
+++ b/docs/src/model_docs/lateral/local-inertial.md
@@ -139,7 +139,7 @@ h_thresh = 0.1                   # water depth [m] threshold for calculating flo
 The properties `inertial_flow_alpha`, `froude_limit` and `h_thresh` apply to 1D river
 routing as well as 2D overland flow. The properties `inertial_flow_alpha` and
 `froude_limit`, and the adaptive model time step ``\Delta t`` are explained in more detail
-in the [River routing](@ref) section of the local inertial model.
+in the [River and floodplain routing](@ref) section of the local inertial model.
 
 ## Inflow
 External water (supply/abstraction) `inflow` [m``^3`` s``^{-1}``]  can be added to the local

--- a/docs/src/model_docs/model_configurations.md
+++ b/docs/src/model_docs/model_configurations.md
@@ -81,7 +81,7 @@ lateral.river.lake => struct NaturalLake{T} # optional
 lateral.river.reservoir => struct SimpleReservoir{T} # optional
 ```
 
-### Local inertial river and floodplain + `sbm` and `sbm_gwf` model types
+### [Local inertial river and floodplain + `sbm` and `sbm_gwf` model types](@id LIE_river_floodplain_model)
 By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
 flow. There is also the option to use the local inertial model for river flow with an
 optional 1D floodplain schematization (routing is done separately for the river channel and
@@ -101,7 +101,7 @@ parameters.
 lateral.river => struct ShallowWaterRiver{T,R,L}
 ```
 
-### Local inertial river (1D) and land (2D) + `sbm` and `sbm_gwf` model types
+### [Local inertial river (1D) and land (2D) + `sbm` and `sbm_gwf` model types](@id LIE_river_land_model)
 By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
 and overland flow. There is also the option to use the local inertial model for 1D river and
 2D overland flow, by providing the following in the TOML file:

--- a/docs/src/model_docs/model_configurations.md
+++ b/docs/src/model_docs/model_configurations.md
@@ -21,7 +21,7 @@ Topog\_SBM uses an element network based on contour lines and trajectories for w
 routing. Wflow\_sbm models differ in how the lateral components river, land, and subsurface
 are solved. Below the different wflow\_sbm model configurations are described.
 
-### SBM + Kinematic wave
+### [SBM + Kinematic wave](@id config_sbm)
 For the lateral components of this wflow\_sbm model water is routed over a D8 network, and
 the kinematic wave approach is used for river, overland and lateral subsurface flow. This is
 described in more detail in the section [Kinematic wave](@ref kin_wave).
@@ -45,7 +45,7 @@ lateral.river.lake => struct NaturalLake{T} # optional
 lateral.river.reservoir => struct SimpleReservoir{T} # optional
 ```
 
-### SBM + Groundwater flow
+### [SBM + Groundwater flow](@id config_sbm_gwf)
 For river and overland flow the kinematic wave approach over a D8 network is used for this
 wflow\_sbm model. For the subsurface domain, an unconfined aquifer with groundwater flow in
 four directions (adjacent cells) is used. This is described in more detail in the section
@@ -81,7 +81,7 @@ lateral.river.lake => struct NaturalLake{T} # optional
 lateral.river.reservoir => struct SimpleReservoir{T} # optional
 ```
 
-### [Local inertial river and floodplain + `sbm` and `sbm_gwf` model types](@id LIE_river_floodplain_model)
+### [Local inertial river and floodplain + `sbm` and `sbm_gwf` model types](@id config_sbm_gwf_lie_river)
 By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
 flow. There is also the option to use the local inertial model for river flow with an
 optional 1D floodplain schematization (routing is done separately for the river channel and
@@ -101,7 +101,7 @@ parameters.
 lateral.river => struct ShallowWaterRiver{T,R,L}
 ```
 
-### [Local inertial river (1D) and land (2D) + `sbm` and `sbm_gwf` model types](@id LIE_river_land_model)
+### [Local inertial river (1D) and land (2D) + `sbm` and `sbm_gwf` model types](@id config_sbm_gwf_lie_river_land)
 By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
 and overland flow. There is also the option to use the local inertial model for 1D river and
 2D overland flow, by providing the following in the TOML file:
@@ -245,7 +245,7 @@ offset = [0.0, 0.0, 0.0]
 class = ["h", "p", "w"]
 ```
 
-## wflow\_sediment
+## [wflow\_sediment](@id config_sediment)
 The processes and fate of many particles and pollutants impacting water quality at the
 catchment level are intricately linked to the processes governing sediment dynamics. Both
 nutrients such as phosphorus, carbon or other pollutants such as metals are influenced by

--- a/docs/src/model_docs/model_configurations.md
+++ b/docs/src/model_docs/model_configurations.md
@@ -81,8 +81,8 @@ lateral.river.lake => struct NaturalLake{T} # optional
 lateral.river.reservoir => struct SimpleReservoir{T} # optional
 ```
 
-### [Local inertial river and floodplain + `sbm` and `sbm_gwf` model types](@id config_sbm_gwf_lie_river)
-By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
+### [SBM + Local inertial river](@id config_sbm_gwf_lie_river)
+By default the model types `sbm` and `sbm_gwf` use the kinematic wave approach for river
 flow. There is also the option to use the local inertial model for river flow with an
 optional 1D floodplain schematization (routing is done separately for the river channel and
 floodplain), by providing the following in the TOML file:
@@ -101,10 +101,10 @@ parameters.
 lateral.river => struct ShallowWaterRiver{T,R,L}
 ```
 
-### [Local inertial river (1D) and land (2D) + `sbm` and `sbm_gwf` model types](@id config_sbm_gwf_lie_river_land)
-By default the model types `sbm` and `sbm_gwf` uses the kinematic wave approach for river
-and overland flow. There is also the option to use the local inertial model for 1D river and
-2D overland flow, by providing the following in the TOML file:
+### [SBM + Local inertial river (1D) and land (2D)](@id config_sbm_gwf_lie_river_land)
+By default the model types `sbm` and `sbm_gwf` use the kinematic wave approach for river and
+overland flow. There is also the option to use the local inertial model for 1D river and 2D
+overland flow, by providing the following in the TOML file:
 
 ```toml
 [model]

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -141,13 +141,13 @@ h = "h_floodplain"
 Wflow supports multi-threading execution of the wflow\_sbm model that uses the kinematic
 wave approach for river, overland and lateral subsurface flow. Both the vertical SBM concept
 and the kinematic wave components of this model can run on multiple threads. The optional
-local inertial model for river flow [SBM + Local inertial river](@ref) model and the
-optional local inertial model for river (1D) and land (2D) [SBM + Local inertial river (1D)
-and land (2D)](@ref), both part of wflow\_sbm, can also run on multiple threads. The
-threading functionality for the kinematic wave may also be useful for models that make
-(partly) use of this routing approach as the [wflow_hbv](@ref config_hbv) model and
-the wflow\_sbm model [SBM + Groundwater flow](@ref). The multi-threading functionality in
-wflow is considered experimental, see also the following
+[local inertial model for river flow](@ref config_sbm_gwf_lie_river_land) and the optional
+[local inertial model for river (1D) and land (2D)](@ref config_sbm_gwf_lie_river_land),
+both part of wflow\_sbm, can also run on multiple threads. The threading functionality for
+the kinematic wave may also be useful for models that make (partly) use of this routing
+approach as the [wflow_hbv](@ref config_hbv) model and the wflow\_sbm model [SBM +
+Groundwater flow](@ref config_sbm_gwf). The multi-threading functionality in wflow is
+considered experimental, see also the following
 [issue](https://github.com/Deltares/Wflow.jl/issues/139), where an error was not thrown
 running code multi-threaded. Because of this we advise to start with running a wflow model
 single-threaded (for example during the testing phase of setting up an new wflow model).
@@ -294,4 +294,4 @@ expectations, which then can get parsed with these Delft-FEWS log parsing settin
 It is possible to run wflow as a ZMQ Server, for example for the coupling to the
 [OpenDA](https://openda.org/) software for data-assimilation. The code for the wflow ZMQ
 Server is not part of the Wflow.jl package, and is located
-[here](https://github.com/Deltares/Wflow.jl/tree/zmq_server/server).
+[here](https://github.com/Deltares/Wflow.jl/tree/master/server).

--- a/docs/src/user_guide/additional_options.md
+++ b/docs/src/user_guide/additional_options.md
@@ -290,7 +290,7 @@ expectations, which then can get parsed with these Delft-FEWS log parsing settin
 </logFile>
 ```
 
-## [Run wflow as a ZMQ Server]
+## Run wflow as a ZMQ Server
 It is possible to run wflow as a ZMQ Server, for example for the coupling to the
 [OpenDA](https://openda.org/) software for data-assimilation. The code for the wflow ZMQ
 Server is not part of the Wflow.jl package, and is located

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -100,7 +100,7 @@ The Model parameters section lists all the parameters per Model component and th
 can also be used to check which parameters can be part of the output, see also [Output
 netCDF section](@ref) and [Output CSV section](@ref).
 
-Example models can be found in the [Example model section](@ref sample_data).
+Example models can be found in the [Example models section](@ref sample_data).
 
 ## hydroMT
 [hydroMT](https://github.com/Deltares/hydromt) is a Python package, developed by Deltares,

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -121,10 +121,9 @@ documentation](https://deltares.github.io/hydromt_wflow/latest/index.html).
 To inspect or modify (for example in QGIS) the netCDF static data of these wflow models it
 is convenient to export the maps to a raster format. This can be done as part of the
 hydroMT-wflow plugin, see also the following [example]
-(https://deltares.github.io/hydromt_wflow/latest/examples/examples/convert_staticmaps_to_mapstack.html).
+(https://deltares.github.io/hydromt_wflow/latest/_examples/convert_staticmaps_to_mapstack.html).
 It is also possible to create again the netCDF static data file based on the modified raster
 map stack.
-
 
 ## References
 + Yamazaki, D., Ikeshima, D., Sosa, J., Bates, P. D., Allen, G. H. and Pavelsky, T. M.:

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -24,10 +24,10 @@ An approach to generate `ldd` data is to make use of the Python package
 [pyflwdir](https://github.com/Deltares/pyflwdir):
 
 + to [upscale existing flow direction
-  data](https://deltares.github.io/pyflwdir/latest/upscaling.html) as the 3 arcsec MERIT
+  data](https://deltares.github.io/pyflwdir/latest/_examples/upscaling.html) as the 3 arcsec MERIT
   Hydro data (Yamazaki et al., 2019)
 + or to [derive flow directions from elevation
-  data](https://deltares.github.io/pyflwdir/latest/from_dem.html),
+  data](https://deltares.github.io/pyflwdir/latest/_examples/from_dem.html),
 
 see also Eilander et al. (2021) for more information.
 Pyflwdir is also used by the [hydroMT](@ref) Python package described in the next paragraph.
@@ -54,15 +54,17 @@ consists of the vertical concept [SBM](@ref vert_sbm) and input parameters for t
 component are described in the [SBM](@ref params_sbm) section of Model parameters. Finally,
 the SBM + Kinematic wave model includes the lateral component [Subsurface flow
 routing](@ref) and parameters that are part of this component are described in the [Lateral
-subsurface flow](@ref) section of Model parameters. Input parameters for this component of
-the SBM + Kinematic wave model are derived from the SBM vertical concept and the land slope.
-One external parameter [`ksathorfrac`](@ref params_ssf) is used to calculate the horizontal
-hydraulic conductivity at the soil surface `kh_0`.
+subsurface flow](@ref params_ssf) section of Model parameters. Input parameters for this
+component of the SBM + Kinematic wave model are derived from the SBM vertical concept and
+the land slope. One external parameter [`ksathorfrac`](@ref params_ssf) is used to calculate
+the horizontal hydraulic conductivity at the soil surface `kh_0`.
 
-There is also the option to use the local inertial model as part of the `sbm` model type:
-+ for river flow, see also  [SBM + Local inertial river](@ref) model.
-+ for 1D river flow and 2D overland flow combined, see also [SBM + Local inertial river (1D)
-  and land (2D)](@ref) model.
+There is also the option to use the local inertial model as part of the `sbm` and `sbm_gwf`
+model types:
++ for river flow, see also [Local inertial river and floodplain](@ref
+  LIE_river_floodplain_model) model.
++ for 1D river flow and 2D overland flow combined, see also [Local inertial river (1D) and
+  land (2D)](@ref LIE_river_land_model) model.
 
 Input parameters for this approach are described in [River flow (local inertial)](@ref
 local-inertial_river_params), including the optional 1D [floodplain schematization](@ref

--- a/docs/src/user_guide/model-setup.md
+++ b/docs/src/user_guide/model-setup.md
@@ -38,64 +38,63 @@ example
 Optionally, but also not directly part of a model component are `gauge` locations, that are
 used to extract gridded data from certain locations.
 
-The following Model types make use of the kinematic wave:
-+ wflow\_sbm + kinematic wave
-+ wflow\_sbm + groundwater flow
-+ wflow\_hbv
-+ wflow\_flextopo
+The different supported model configurations are described in the section [Model
+configurations](@ref). Wflow\_sbm models have the vertical concept [SBM](@ref vert_sbm) in
+common and input parameters for this component are described in the [SBM](@ref params_sbm)
+section of Model parameters. For wflow\_sbm models there are two ways to include subsurface
+flow:
 
-and require for the river and overland flow components input data that is described in [Surface
-flow](@ref). Reservoirs or lakes can be part of the kinematic wave (optional) and input
-parameters are described in [Reservoirs](@ref reservoir_params) and [Lakes](@ref
-lake_params).
+1. The kinematic wave approach (see section [Subsurface flow routing](@ref)) as part of the
+   `sbm` model type. Parameters that are part of this component are described in the
+   [Lateral subsurface flow](@ref params_ssf) section of Model parameters. Input parameters
+   for this component are derived from the SBM vertical concept and the land slope. One
+   external parameter [`ksathorfrac`](@ref params_ssf) is used to calculate the horizontal
+   hydraulic conductivity at the soil surface `kh_0`.
+2. Groundwater flow (see section [Groundwater flow component](@ref lateral_gwf)) as part of
+   the `sbm_gwf` model type. For the unconfined aquifer the input parameters are described
+   in the section [Unconfined aquifer](@ref) of Model parameters. The bottom (`bottom`) of
+   the groundwater layer is derived from from the `soilthickness` [mm] parameter of `SBM`
+   and the provided surface elevation `altitude` [m] as part of the static input. The `area`
+   parameter is derived from the model grid. Parameters that are part of the boundary
+   conditions of the unconfined aquifer are listed under [Constant Head](@ref) and [Boundary
+   conditions](@ref) of the Model parameters section.
 
-Besides the river and overland flow components the wflow\_sbm + kinematic wave model
-consists of the vertical concept [SBM](@ref vert_sbm) and input parameters for this
-component are described in the [SBM](@ref params_sbm) section of Model parameters. Finally,
-the SBM + Kinematic wave model includes the lateral component [Subsurface flow
-routing](@ref) and parameters that are part of this component are described in the [Lateral
-subsurface flow](@ref params_ssf) section of Model parameters. Input parameters for this
-component of the SBM + Kinematic wave model are derived from the SBM vertical concept and
-the land slope. One external parameter [`ksathorfrac`](@ref params_ssf) is used to calculate
-the horizontal hydraulic conductivity at the soil surface `kh_0`.
-
-There is also the option to use the local inertial model as part of the `sbm` and `sbm_gwf`
-model types:
-+ for river flow, see also [Local inertial river and floodplain](@ref
-  LIE_river_floodplain_model) model.
-+ for 1D river flow and 2D overland flow combined, see also [Local inertial river (1D) and
-  land (2D)](@ref LIE_river_land_model) model.
+Most hydrological model configurations make use of the kinematic wave surface routing (river
+flow, overland flow or both) and input data required for the river and overland flow
+components is described in [Surface flow](@ref).  There is also the option to use the local
+inertial model as part of the wflow\_sbm models (model types `sbm` and `sbm_gwf`):
++ for river flow, see also the [Local inertial river and floodplain](@ref
+  config_sbm_gwf_lie_river) model.
++ for 1D river flow and 2D overland flow combined, see also the [Local inertial river (1D)
+  and land (2D)](@ref config_sbm_gwf_lie_river_land) model.
 
 Input parameters for this approach are described in [River flow (local inertial)](@ref
 local-inertial_river_params), including the optional 1D [floodplain schematization](@ref
 local-inertial_floodplain_params), and [Overland flow (local inertial)](@ref
 local-inertial_land_params) of the Model parameters section.
 
-The HBV model consists besides the river and overland flow components of the [HBV](@ref
-vert_hbv) vertical concept. Input parameters for this component are described in the
-[HBV](@ref params_hbv) section of Model parameters.
+Reservoirs or lakes can be part of the kinematic wave or local inertial model for river flow
+and input parameters are described in [Reservoirs](@ref reservoir_params) and [Lakes](@ref
+lake_params).
 
-The FLEXTopo model consists besides the river and overland flow components of the
-[FLEXTopo](@ref vert_flextopo) vertical concept. Input parameters for this component are
-described in the [FLEXTopo](@ref params_flextopo) section of Model parameters.
+The [wflow\_hbv](@ref config_hbv) model configuration consists besides the river and
+overland flow components of the [HBV](@ref vert_hbv) vertical concept. Input parameters for
+this component are described in the [HBV](@ref params_hbv) section of Model parameters. For
+the river and overland flow components the kinematic wave approach is used.
 
-The SBM + Groundwater flow includes besides the river and overland flow components and the
-vertical SBM concept, the lateral [Groundwater flow component](@ref lateral_gwf). For the
-unconfined aquifer the input parameters are described in the section [Unconfined
-aquifer](@ref) of Model parameters. The bottom (`bottom`) of the groundwater layer is
-derived from from the `soilthickness` [mm] parameter of `SBM` and the provided surface
-elevation `altitude` [m] as part of the static input. The `area` parameter is derived from
-the model grid. Parameters that are part of the boundary conditions of the unconfined
-aquifer are listed under [Constant Head](@ref) and [Boundary conditions](@ref) of the Model
-parameters section.
+The [wflow\_flextopo](@ref config_flextopo) model configuration consists besides the river
+and overland flow components of the [FLEXTopo](@ref vert_flextopo) vertical concept. Input
+parameters for this component are described in the [FLEXTopo](@ref params_flextopo) section
+of Model parameters. For the river and overland flow components the kinematic wave approach
+is used.
 
-The wflow\_sediment model consists of the vertical [Soil Erosion](@ref) concept and the
-input parameters for this concept are described in the [Sediment](@ref params_sediment)
-section of the Model parameters. The parameters of the lateral [Sediment Flux in overland
-flow](@ref) concept are described in the [Overland flow](@ref) section of the Model
-parameters. Parameters of this component are not directly set by data from static input. The
-input parameters of the lateral concept [River Sediment Model](@ref) are listed in [River
-flow](@ref) of the Model parameters section.
+The [wflow\_sediment](@ref config_sediment) model configuration consists of the vertical
+[Soil Erosion](@ref) concept and the input parameters for this concept are described in the
+[Sediment](@ref params_sediment) section of the Model parameters. The parameters of the
+lateral [Sediment Flux in overland flow](@ref) concept are described in the [Overland
+flow](@ref) section of the Model parameters. Parameters of this component are not directly
+set by data from static input. The input parameters of the lateral concept [River Sediment
+Model](@ref) are listed in [River flow](@ref) of the Model parameters section.
 
 The Model parameters section lists all the parameters per Model component and these Tables
 can also be used to check which parameters can be part of the output, see also [Output
@@ -108,12 +107,13 @@ Example models can be found in the [Example model section](@ref sample_data).
 to build and analyze hydro models. It provides a generic model api with attributes to
 access the model schematization, (dynamic) forcing data, results and states.
 
-For the following wflow models:
-  - wflow\_sbm + kinematic wave
-  - wflow_sediment
-
-the wflow plugin [hydroMT-wflow](https://github.com/Deltares/hydromt_wflow) of hydroMT can
-be used to build and analyze these wflow model types in an automated way.
+For the following wflow\_sbm model (modeltype `sbm`) configurations:
+  - [wflow\_sbm + kinematic wave routing](@ref config_sbm)
+  - [wflow\_sbm + local inertial river and floodplain](@ref config_sbm_gwf_lie_river)
+  - [wflow\_sbm + local inertial river (1D) and land (2D)](@ref config_sbm_gwf_lie_river_land)
+and the [wflow\_sediment](@ref config_sediment) model configuration, the wflow plugin
+[hydroMT-wflow](https://github.com/Deltares/hydromt_wflow) of hydroMT can be used to build
+and analyze these wflow models in an automated way.
 
 To learn more about the wflow plugin of this Python package, we refer to the [hydroMT-wflow
 documentation](https://deltares.github.io/hydromt_wflow/latest/index.html).


### PR DESCRIPTION
## Issue addressed
Fixes #395 

## Explanation
Fixed broken internal and external links in docs. 
Improved the description of different model configurations in `model-setup.md`, also in relation to `hydromt_wflow` in docs. 

## Checklist
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.md if needed