### PR TITLE
Fix initialization of LateralSSF variables `ssf` and `ssfmax` with `ksat_profile` `exponential_constant`

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Initialization of `LateralSSF` variables `ssf` and `ssfmax` with vertical hydraulic
+  conductivity profile `exponential_constant`. Removed parameter `khfrac` from the
+  computation, as it is already part of parameter `kh_0`.
+
 ## v0.8.1 - 2024-08-27
 
 ### Fixed

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -779,14 +779,11 @@ end
 
 "Initialize lateral subsurface variables `ssf` and `ssfmax` with `ksat_profile` `exponential_constant`"
 function initialize_lateralssf_exp_const!(ssf::LateralSSF)
-    ssf_constant = @. ssf.khfrac *
-       ssf.kh_0 *
-       exp(-ssf.f * ssf.z_exp) *
-       ssf.slope *
-       (ssf.soilthickness - ssf.z_exp)
+    ssf_constant =
+        @. ssf.kh_0 * exp(-ssf.f * ssf.z_exp) * ssf.slope * (ssf.soilthickness - ssf.z_exp)
     for i in eachindex(ssf.ssf)
         ssf.ssfmax[i] =
-            ((ssf.khfrac[i] * ssf.kh_0[i] * ssf.slope[i]) / ssf.f[i]) *
+            ((ssf.kh_0[i] * ssf.slope[i]) / ssf.f[i]) *
             (1.0 - exp(-ssf.f[i] * ssf.z_exp[i])) + ssf_constant[i]
         if ssf.zi[i] < ssf.z_exp[i]
             ssf.ssf[i] =

--- a/test/run_sbm.jl
+++ b/test/run_sbm.jl
@@ -457,6 +457,8 @@ Wflow.close_files(model, delete_output = false)
             i,
             "exponential",
         )
+        @test model.lateral.subsurface.ssfmax[i] ≈ 28.32720603576582f0
+        @test model.lateral.subsurface.ssf[i] ≈ 11683.330684556406f0
         @test all(isnan.(vertical.z_layered))
         @test all(isnan.(vertical.kv[i]))
         @test all(vertical.nlayers_kv .== 0)
@@ -491,6 +493,8 @@ Wflow.close_files(model, delete_output = false)
             i,
             "exponential_constant",
         )
+        @test model.lateral.subsurface.ssfmax[i] ≈ 49.38558575188426f0
+        @test model.lateral.subsurface.ssf[i] ≈ 24810.460986497365f0
         @test all(isnan.(vertical.z_layered))
         @test all(isnan.(vertical.kv[i]))
         @test all(vertical.nlayers_kv .== 0)
@@ -505,6 +509,8 @@ Wflow.close_files(model, delete_output = false)
         @test Wflow.hydraulic_conductivity_at_depth(vertical, z, i, 2, "layered") ≈
               vertical.kv[100][2]
         @test Wflow.kh_layered_profile(vertical, 100.0, i, "layered") ≈ 47.508932674632355f0
+        @test model.lateral.subsurface.ssfmax[i] ≈ 30.237094380100316f0
+        @test model.lateral.subsurface.ssf[i] ≈ 14546.518932613191f0
         @test vertical.nlayers_kv[i] == 4
         @test vertical.z_layered == vertical.soilthickness
         @test all(isnan.(vertical.z_exp))
@@ -525,6 +531,8 @@ Wflow.close_files(model, delete_output = false)
         @test vertical.nlayers_kv[i] == 2
         @test Wflow.kh_layered_profile(vertical, 100.0, i, "layered_exponential") ≈
               33.76026208801769f0
+        @test model.lateral.subsurface.ssfmax[i] ≈ 23.4840490395906f0
+        @test model.lateral.subsurface.ssf[i] ≈ 10336.88327617503f0
         @test all(vertical.z_layered[1:10] .== 400.0)
         @test all(isnan.(vertical.z_exp))
     end


### PR DESCRIPTION
## Issue addressed
Fixes #473 

## Explanation
See issue #473

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [x] Tests & pre-commit hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.md if needed