### PR TITLE
Remove git-tree-sha1 from metadata

### DIFF
--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -43,7 +43,19 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
         version = TOML.parsefile(normpath(git_repo, "Project.toml"))["version"]
         repo = GitRepo(git_repo)
         branch = LibGit2.head(repo)
+        commit = LibGit2.peel(LibGit2.GitCommit, branch)
         short_name = LibGit2.shortname(branch)
+        short_commit = string(LibGit2.GitShortHash(LibGit2.GitHash(commit), 10))
+
+        # get the release from the current tag, like `git describe --tags`
+        # if it is a commit after a tag, it will be <tag>-g<short-commit>
+        options = LibGit2.DescribeOptions(; describe_strategy = LibGit2.Consts.DESCRIBE_TAGS)
+        result = LibGit2.GitDescribeResult(repo; options)
+        suffix = "-dirty"
+        foptions =
+            LibGit2.DescribeFormatOptions(; dirty_suffix = Base.unsafe_convert(Cstring, suffix))
+        GC.@preserve suffix tag = LibGit2.format(result; options = foptions)[2:end]  # skip v prefix
+
         url = "https://github.com/Deltares/Wflow.jl/tree"
         version_info = """
 
@@ -52,7 +64,9 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
         This build uses the Wflow.jl version mentioned below.
 
         ```toml
+        release = "$tag"
         version = "$version"
+        commit = "$url/$short_commit"
         branch = "$url/$short_name"
         julia_version = "$julia_version"
         ```"""

--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -40,14 +40,10 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
             error("Manifest.toml is in the old format, run Pkg.upgrade_manifest()")
         end
         julia_version = manifest["julia_version"]
-        wflow_entry = only(manifest["deps"]["Wflow"])
-        tree = wflow_entry["git-tree-sha1"]
         version = TOML.parsefile(normpath(git_repo, "Project.toml"))["version"]
         repo = GitRepo(git_repo)
         branch = LibGit2.head(repo)
-        # commit = LibGit2.peel(LibGit2.GitCommit, branch)
         short_name = LibGit2.shortname(branch)
-        # short_commit = string(LibGit2.GitShortHash(LibGit2.GitHash(commit), 10))
         url = "https://github.com/Deltares/Wflow.jl/tree"
         version_info = """
 
@@ -57,7 +53,6 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
 
         ```toml
         version = "$version"
-        git-tree-sha1 = "$tree"
         branch = "$url/$short_name"
         julia_version = "$julia_version"
         ```"""

--- a/pixi.toml
+++ b/pixi.toml
@@ -13,7 +13,7 @@ platforms = ["win-64", "linux-64"]
 install-julia = "juliaup add 1.10.5 && juliaup override unset && juliaup override set 1.10.5"
 # Julia
 update-registry-julia = "julia --eval='using Pkg; Registry.update()'"
-instantiate-julia = "julia --project --eval='using Pkg; Pkg.instantiate()'"
+instantiate-julia = {cmd = "julia --project --eval='using Pkg; Pkg.instantiate()'",env = { JULIA_SSL_CA_ROOTS_PATH = "" } }
 initialize-julia = { depends_on = [
     "update-registry-julia",
     "instantiate-julia",
@@ -28,7 +28,7 @@ download-test-data = { cmd = "julia --project download_test_data.jl", cwd = "bui
 build-wflow-cli = { cmd = "julia --project create_app.jl", cwd = "build/create_binaries", depends_on = [
     "download-test-data",
     "instantiate-wflow-cli",
-] }
+], env = { JULIA_SSL_CA_ROOTS_PATH = "" } }
 # Test
 test-wflow-cli = { cmd = "julia --project --eval 'using Pkg; Pkg.test()'", cwd = "build/wflow_cli", depends_on = [
     "download-test-data",


### PR DESCRIPTION
It is not part of the Wflow entry in the Manifest.toml file and as a result the build fails.

## Issue addressed
Fixes #479 