### PR TITLE
Rename glacier parameter `g_tt` to `g_ttm`

### DIFF
--- a/docs/model_docs/parameters_vertical.qmd
+++ b/docs/model_docs/parameters_vertical.qmd
@@ -40,7 +40,7 @@ the `layered` profile, input parameter `kv` is used, and for the `layered_expone
 | **`whc`**  | water holding capacity as fraction of current snow pack  | - | 0.1  |
 | **`w_soil`**  | soil temperature smooth factor  | - | 0.1125  |
 | **`cf_soil`**  | controls soil infiltration reduction factor when soil is frozen  | - | 0.038  |
-| **`g_tt`**  | threshold temperature for glacier melt  | ᵒC | 0.0  |
+| **`g_ttm`**  | threshold temperature for glacier melt  | ᵒC | 0.0  |
 | **`g_cfmax`**  | Degree-day factor for glacier  | mm ᵒC$^{-1}$ Δt$^{-1}$| 3.0 mm ᵒC$^{-1}$ day$^{-1}$ |
 | **`g_sifrac`**  | fraction of the snowpack on top of the glacier converted into ice  | Δt$^{-1}$ | 0.001 day$^{-1}$ |
 | **`glacierfrac`**  | fraction covered by a glacier | - | 0.0  |

--- a/docs/model_docs/vertical/shared_processes.qmd
+++ b/docs/model_docs/vertical/shared_processes.qmd
@@ -17,18 +17,18 @@ parameter `tti` defines how precipitation can occur partly as rain or snowfall.
 # https://gist.github.com/JoostBuitink/21dd32e71fd1360117fcd1c532c4fd9d#file-snowfall_fig-py # hide
 -->
 
-If precipitation occurs as snowfall, it is added to the dry snow component
-within the snow pack. Otherwise it ends up in the free water reservoir, which represents the
-liquid water content of the snow pack. Between the two components of the snow pack,
-interactions take place, either through snow melt (if temperatures are above a threshold `tt`)
-or through snow refreezing (if temperatures are below threshold `tt`).
+If precipitation occurs as snowfall, it is added to the dry snow component within the snow
+pack. Otherwise it ends up in the free water reservoir, which represents the liquid water
+content of the snow pack. Between the two components of the snow pack, interactions take
+place, either through snow melt (if temperatures are above a threshold `ttm`) or through
+snow refreezing (if temperatures are below threshold `ttm`).
 
 The respective rates of snow melt and refreezing are:
 
 $$
 \begin{align*}
-    Q_m &=& \subtext{\mathrm{cf}}{max}(T_a−\mathrm{tt})\, &&T_a > \mathrm{tt} \\
-    Q_r &=& \subtext{\mathrm{cf}}{max} \, \mathrm{cf}_r(\mathrm{tt}−T_a) &&T_a < \mathrm{tt}
+    Q_m &=& \subtext{\mathrm{cf}}{max}(T_a−\mathrm{ttm})\, &&T_a > \mathrm{ttm} \\
+    Q_r &=& \subtext{\mathrm{cf}}{max} \, \mathrm{cf}_r(\mathrm{ttm}−T_a) &&T_a < \mathrm{ttm}
 \end{align*}
 $$
 
@@ -61,12 +61,12 @@ into firn/ice (using the HBV-light model) and glacier melt (using a temperature 
 model).
 
 The definition of glacier boundaries and initial volume is defined by two parameters. The
-parameter `glacierfrac` gives the fraction of each grid cell covered by a glacier as a number
-between zero and one. The state parameter `glacierstore` gives the amount of water (in mm w.e.)
-within the glaciers at each grid cell. Because the glacier store (`glacierstore`) cannot be
-initialized by running thFe model for a couple of years, a default initial state should be
-supplied by adding this parameter to the input static file. The required glacier data can be
-prepared from available glacier datasets.
+parameter `glacierfrac` gives the fraction of each grid cell covered by a glacier as a
+number between zero and one. The state parameter `glacierstore` gives the amount of water
+(in mm w.e.) within the glaciers at each grid cell. Because the glacier store
+(`glacierstore`) cannot be initialized by running the model for a couple of years, a default
+initial state should be supplied by adding this parameter to the input static file. The
+required glacier data can be prepared from available glacier datasets.
 
 First, a fixed fraction of the snowpack on top of the glacier is converted into ice for each
 timestep and added to the `glacierstore` using the HBV-light model (Seibert et al., 2018). This
@@ -74,21 +74,21 @@ fraction `g_sifrac` typically ranges from $0.001$ to $0.006$.
 
 Then, when the snowpack on top of the glacier is almost all melted (snow cover $<
 \SI{10}{mm}$), glacier melt is enabled and estimated with a degree-day model. If the air
-temperature, $T_a$, is below a certain threshold `g_tt` ($\SIb{}{\degree C}$) precipitation
-occurs as snowfall, whereas it occurs as rainfall if $T_a ≥$ `g_tt`.
+temperature, $T_a$, is above a certain threshold `g_ttm` ($\SIb{}{\degree C}$) glacier melt
+occurs.
 
 With this the rate of glacier melt in mm is estimated as:
 
 $$
-Q_m = \subtext{g}{cfmax}(T_a − \subtext{g}{tt})\, ; \, T_a > \subtext{g}{tt}
+Q_m = \subtext{g}{cfmax}(T_a − \subtext{g}{ttm})\, ; \, T_a > \subtext{g}{ttm}
 $$
 
 where $Q_m$ is the rate of glacier melt and $\SIb{\subtext{g}{cfmax}}{mm (\degree
-C)^{-1}day^{-1}}$ is the melting factor. Parameter `g_tt` can be taken as equal to the snow
-`tt` parameter. Values of the melting factor `g_cfmax` normally varies from one glacier to
+C)^{-1}day^{-1}}$ is the melting factor. Parameter `g_ttm` can be taken as equal to the snow
+`ttm` parameter. Values of the melting factor `g_cfmax` normally varies from one glacier to
 another and some values are reported in the literature. `g_cfmax` can also be estimated by
-multiplying snow `cfmax` by a factor between 1 and 2, to take into account the higher albedo of
-ice compared to snow.
+multiplying snow `cfmax` by a factor between 1 and 2, to take into account the higher albedo
+of ice compared to snow.
 
 ## Rainfall interception
 Both the Gash and Rutter models are available to estimate rainfall interception by the

--- a/docs/user_guide/model_config.qmd
+++ b/docs/user_guide/model_config.qmd
@@ -18,7 +18,7 @@ water_holding_capacity = "WHC"
 glacierstore = "wflow_glacierstore"
 glacierfrac = "wflow_glacierfrac"
 g_cfmax = "G_Cfmax"
-g_tt = "G_TT"
+g_ttm = "G_TT"
 g_sifrac = "G_SIfrac"
 
 [state.vertical]

--- a/src/glacier/glacier.jl
+++ b/src/glacier/glacier.jl
@@ -33,7 +33,7 @@ end
 "Struct for storing glacier HBV model parameters"
 @get_units @grid_loc @with_kw struct GlacierHbvParameters{T}
     # Threshold temperature for glacier melt [ᵒC]
-    g_tt::Vector{T} | "ᵒC"
+    g_ttm::Vector{T} | "ᵒC"
     # Degree-day factor [mm ᵒC⁻¹ Δt⁻¹] for glacier
     g_cfmax::Vector{T} | "mm ᵒC-1 dt-1"
     # Fraction of the snowpack on top of the glacier converted into ice [Δt⁻¹]
@@ -55,10 +55,10 @@ struct NoGlacierModel{T} <: AbstractGlacierModel{T} end
 
 "Initialize glacier HBV model parameters"
 function GlacierHbvParameters(nc, config, inds, dt)
-    g_tt = ncread(
+    g_ttm = ncread(
         nc,
         config,
-        "vertical.glacier.parameters.g_tt";
+        "vertical.glacier.parameters.g_ttm";
         sel = inds,
         defaults = 0.0,
         type = Float,
@@ -94,13 +94,8 @@ function GlacierHbvParameters(nc, config, inds, dt)
         fill = 0.0,
     )
     max_snow_to_glacier = 8.0 * (dt / basetimestep)
-    glacier_hbv_params = GlacierHbvParameters(;
-        g_tt = g_tt,
-        g_cfmax = g_cfmax,
-        g_sifrac = g_sifrac,
-        glacier_frac = glacier_frac,
-        max_snow_to_glacier = max_snow_to_glacier,
-    )
+    glacier_hbv_params =
+        GlacierHbvParameters(; g_ttm, g_cfmax, g_sifrac, glacier_frac, max_snow_to_glacier)
     return glacier_hbv_params
 end
 
@@ -118,7 +113,7 @@ function update!(model::GlacierHbvModel, atmospheric_forcing::AtmosphericForcing
     (; temperature) = atmospheric_forcing
     (; glacier_store, glacier_melt) = model.variables
     (; snow_storage) = model.boundary_conditions
-    (; g_tt, g_cfmax, g_sifrac, glacier_frac, max_snow_to_glacier) = model.parameters
+    (; g_ttm, g_cfmax, g_sifrac, glacier_frac, max_snow_to_glacier) = model.parameters
 
     n = length(temperature)
 
@@ -128,7 +123,7 @@ function update!(model::GlacierHbvModel, atmospheric_forcing::AtmosphericForcing
             glacier_store[i],
             snow_storage[i],
             temperature[i],
-            g_tt[i],
+            g_ttm[i],
             g_cfmax[i],
             g_sifrac[i],
             max_snow_to_glacier,

--- a/src/glacier/glacier_process.jl
+++ b/src/glacier/glacier_process.jl
@@ -12,7 +12,7 @@ occurs if the snow storage < 10 mm.
 - `glacierstore` volume of the glacier [mm] w.e.
 - `snow_storage` snow storage on top of glacier [mm]
 - `temperature` air temperature [°C]
-- `tt` temperature threshold for ice melting [°C]
+- `ttm` temperature threshold for ice melting [°C]
 - `cfmax` ice degree-day factor in [mm/(°C/day)]
 - `g_sifrac` fraction of the snow turned into ice [-]
 - `max_snow_to_glacier` maximum snow to glacier conversion rate
@@ -29,7 +29,7 @@ function glacier_hbv(
     glacierstore,
     snow,
     temperature,
-    tt,
+    ttm,
     cfmax,
     g_sifrac,
     max_snow_to_glacier,
@@ -46,7 +46,7 @@ function glacier_hbv(
     glacierstore = glacierstore + snow_to_glacier
 
     # Potential snow melt, based on temperature
-    potmelt = temperature > tt ? cfmax * (temperature - tt) : 0.0
+    potmelt = temperature > ttm ? cfmax * (temperature - ttm) : 0.0
 
     # actual Glacier melt
     glaciermelt = snow < 10.0 ? min(potmelt, glacierstore) : 0.0

--- a/test/sbm_gwf_piave_demand_config.toml
+++ b/test/sbm_gwf_piave_demand_config.toml
@@ -77,7 +77,7 @@ head = "head"
 [input.vertical.glacier.parameters]
 glacier_frac = "wflow_glacierfrac"
 g_cfmax = "G_Cfmax"
-g_tt = "G_TT"
+g_ttm = "G_TT"
 g_sifrac = "G_SIfrac"
 
 [input.vertical.glacier.variables]

--- a/test/sbm_piave_config.toml
+++ b/test/sbm_piave_config.toml
@@ -60,7 +60,7 @@ glacier_store = "glacierstore"
 [input.vertical.glacier.parameters]
 glacier_frac = "wflow_glacierfrac"
 g_cfmax = "G_Cfmax"
-g_tt = "G_TT"
+g_ttm = "G_TT"
 g_sifrac = "G_SIfrac"
 
 [input.vertical.glacier.variables]

--- a/test/sbm_piave_demand_config.toml
+++ b/test/sbm_piave_demand_config.toml
@@ -72,7 +72,7 @@ h = "h_paddy"
 [input.vertical.glacier.parameters]
 glacier_frac = "wflow_glacierfrac"
 g_cfmax = "G_Cfmax"
-g_tt = "G_TT"
+g_ttm = "G_TT"
 g_sifrac = "G_SIfrac"
 
 [input.vertical.glacier.variables]


### PR DESCRIPTION
## Issue addressed
Fixes #511 

## Explanation
See issue #511. Also fixed the use of `tt` (should be `ttm`) for describing snow melt in shared_process.qmd.