### PR TITLE
Water balance computation setup

### DIFF
--- a/src/Wflow.jl
+++ b/src/Wflow.jl
@@ -125,6 +125,7 @@ struct Model{N, L, V, R, W, T}
     network::N  # connectivity information, directed graph
     lateral::L  # lateral model that holds lateral state, moves along network
     vertical::V  # vertical model that holds vertical state, independent of each other
+    # water_balance::WaterBalance{Float64}
     clock::Clock  # to keep track of simulation time
     reader::R  # provides the model with dynamic input
     writer::W  # writes model output
@@ -139,6 +140,7 @@ struct SedimentModel end    # "sediment" type / sediment_model.jl
 # prevent a large printout of model components and arrays
 Base.show(io::IO, m::Model) = print(io, "model of type ", typeof(m))
 
+include("water_balance.jl")
 include("forcing.jl")
 include("parameters.jl")
 include("groundwater/connectivity.jl")
@@ -256,6 +258,8 @@ function run_timestep!(model::Model; update_func = update!, write_model_output =
     if write_model_output
         write_output(model)
     end
+    # compute_water_balance!(model, model.water_balance.water_balance_vertical)
+    # compute_water_balance!(model, model.water_balance.water_balance_overland)
     return nothing
 end
 

--- a/src/sbm_gwf_model.jl
+++ b/src/sbm_gwf_model.jl
@@ -476,11 +476,15 @@ function initialize_sbm_gwf_model(config::Config)
         )
     end
 
+    # n = ?
+    # water_balance = WaterBalance(n, Float64)
+
     model = Model(
         config,
         (; land, river, reservoir = reservoir_network, lake = lake_network, drain),
         (subsurface = subsurface_map, land = overland_flow, river = river_flow),
         land_hydrology,
+        # water_balance,
         clock,
         reader,
         writer,

--- a/src/sediment_model.jl
+++ b/src/sediment_model.jl
@@ -133,11 +133,15 @@ function initialize_sediment_model(config::Config)
         reverse_indices = rev_indices_riv,
     )
 
+    # n = ?
+    # water_balance = WaterBalance(n, Float64)
+
     model = Model(
         config,
         (; land, river, reservoir, lake, index_river, frac_toriver),
         (land = overland_flow_sediment, river = river_sediment),
         soilloss,
+        # water_balance,
         clock,
         reader,
         writer,

--- a/src/water_balance.jl
+++ b/src/water_balance.jl
@@ -1,0 +1,97 @@
+struct WaterBalanceVertical{T <: AbstractFloat} # Terms in [mm]
+    storage_total::Vector{T}
+    storage_total_prev::Vector{T}
+    inflow_total::Vector{T}
+    outflow_total::Vector{T}
+    balance_error::Vector{T}
+    relative_error::Vector{T}
+end
+
+function WaterBalanceVertical(n::Integer, float_type::Type{T}) where {T <: AbstractFloat}
+    WaterBalanceVertical(ntuple(_ -> fill(float_type(Nan), n), 6)...)
+end
+
+function compute_water_balance!(model, water_balance::WaterBalanceVertical)::Nothing
+    (;
+        storage_total,
+        storage_total_prev,
+        inflow_total,
+        outflow_total,
+        balance_error,
+        relative_error,
+    ) = water_balance
+    (; vertical, lateral) = model
+
+    (; soil, runoff) = vertical
+    (; satwaterdepth, ustoredepth, actevap) = soil.variables
+    (; runoff_land, net_runoff_river) = runoff.variables
+
+    (; subsurface) = lateral
+    (; ssf, ssfin) = subsurface.variables
+    (; flow_length, flow_width) = subsurface.parameters
+
+    storage_total .= satwaterdepth
+    storage_total .+= ustoredepth
+
+    inflow_total .= vertical.atmospheric_forcing.precipitation
+    inflow_total .+= runoff.variables.net_runoff_river
+    inflow_total .+= 1000.0 * ssfin ./ (flow_length .* flow_width)
+
+    outflow_total .= runoff_land
+    outflow_total .+= net_runoff_river
+    outflow_total .+= actevap
+    outflow_total .+= 1000.0 * ssf ./ (flow_length .* flow_width)
+
+    @. balance_error = (inflow_total - outflow_total - (storage_total - storage_total_prev))
+    @. relative_error = balance_error / ((inflow_total + outflow_total) / 2)
+
+    copyto!(storage_total_prev, storage_total)
+
+    #TODO : What to do with results?
+
+    return nothing
+end
+
+struct WaterBalanceOverLand{T <: AbstractFloat} # Terms in [?]
+    volume_t_prev::Vector{T}
+    volume_rate::Vector{T}
+    water_in::Vector{T}
+    water_out::Vector{T}
+    balance_error::Vector{T}
+    relative_error::Vector{T}
+end
+
+function WaterBalanceOverLand(n::Integer, float_type::Type{T}) where {T <: AbstractFloat}
+    WaterBalanceOverLand(ntuple(_ -> fill(float_type(Nan), n), 6)...)
+end
+
+# function compute_water_balance!(model, water_balance::WaterBalanceOverLand)::Nothing
+#     (; vertical, lateral) = model
+#     (; volume_t_prev, volume_rate, water_in, water_out, balance_error, relative_error) = water_balance_overland
+
+#     (; land, river) = lateral
+#     (; volume) = land.variables
+#     volume_t = volume
+
+#     water_in .= lateral.land.qin_av
+#     @. water_in += lateral.land.qlat_av * lateral.land.dl
+
+#     water_out .= lateral.land.q_av
+
+#     @. volume_rate = (volume_t - volume_t_previous) / vertical.dt
+
+#     @. balance_error = (water_in - water_out) - volume_rate
+
+#     #TODO : What to do with results?
+
+#     return nothing
+# end
+
+struct WaterBalance{T}
+    water_balance_vertical::WaterBalanceVertical{T}
+    water_balance_over_land::WaterBalanceOverLand{T}
+end
+
+function WaterBalance(n::Integer, float_type::Type{T}) where {T <: AbstractFloat}
+    WaterBalance(WaterBalanceVertical(n, float_type), WaterBalanceOverLand(n, float_type))
+end


### PR DESCRIPTION
## Issue addressed
Fixes https://github.com/Deltares/Wflow.jl/issues/90

## Explanation
I created a new script `water_balance.jl`, with:
- Structs with arrays for in-place computations of water balance errors
- Associated constructors
- Functions for evaluating the water balance errors for `vertical` and `over_land` separately

I have a few open questions about this:
- How to deal with the start of the simulation? I.e. data from before and after a timestep is needed to compute a water balance error. An explicit example: how to obtain `storage_total_prev` after the first timestep in `compute_water_balance!` for vertical processes
- What is the cleanest way to deduce how much cells (`n`) there are (for array initialization)?
- Please check which variables I have to use to cover all water storage in the model
- What should be done with the water balance data (in this PR)? Should we already implement an error when certain bounds are exceeded? Should the data be written to an output file? 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.qmd if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.