### PR TITLE
Update julia-actions/cache

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,12 @@ on:
       - master
       - v1
     tags: '*'
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: Julia - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ matrix.threads }} threads - ${{ github.event_name }}
@@ -24,9 +30,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/cache@v2
-        with:
-          cache-compiled: "true"
-          cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: "latest"

--- a/.github/workflows/CIWflowServer.yml
+++ b/.github/workflows/CIWflowServer.yml
@@ -6,6 +6,12 @@ on:
       - master
       - v1
     tags: '*'
+
+# needed to allow julia-actions/cache to delete old caches that it has created
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   test:
     name: WflowServer Julia - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -21,9 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/cache@v2
-        with:
-          cache-compiled: "true"
-          cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: "latest"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/cache@v2
-        with:
-          cache-compiled: "true"
-          cache-registries: "true"
       - uses: prefix-dev/setup-pixi@v0.8.1
         with:
           pixi-version: "latest"


### PR DESCRIPTION
The options we had to opt into before are true by default now according to https://github.com/julia-actions/cache. Also setting the permissions as documented in those docs.
