### PR TITLE
Small fix in test/example toml

### DIFF
--- a/test/sbm_piave_demand_config.toml
+++ b/test/sbm_piave_demand_config.toml
@@ -151,23 +151,23 @@ soil_water_sat-zone_top__depth = "zi"
 [output.csv]
 path = "output-piave-demand.csv"
 
-[[output.column]]
+[[output.csv.column]]
 header = "Q"
 map = "river_gauge"
 parameter = "river_water__volume_flow_rate"
 
-[[output.column]]
+[[output.csv.column]]
 header = "Q"
 map = "river_gauge_grdc"
 parameter = "river_water__volume_flow_rate"
 
-[[output.column]]
+[[output.csv.column]]
 coordinate.x = 12.7243
 coordinate.y = 45.5851
 header = "paddy_h_bycoord"
 parameter = "land_surface_water~paddy__depth"
 
-[[output.column]]
+[[output.csv.column]]
 coordinate.x = 12.7243
 coordinate.y = 45.5851
 header = "irri_bycoord"


### PR DESCRIPTION
## Explanation
One of the tomls had an incorrect `[output.csv]` section. This PR fixes that

