### PR TITLE
Add Wflow source location to Project.tomls

### DIFF
--- a/build/create_binaries/Project.toml
+++ b/build/create_binaries/Project.toml
@@ -7,3 +7,6 @@ Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
 [compat]
 PackageCompiler = "2"
 julia = "1.10"
+
+[sources]
+Wflow = {path = "../../Wflow"}

--- a/build/wflow_cli/Project.toml
+++ b/build/wflow_cli/Project.toml
@@ -9,3 +9,6 @@ Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
 
 [compat]
 julia = "1.10"
+
+[sources]
+Wflow = {path = "../../Wflow"}

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,3 +4,6 @@ DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 MarkdownTables = "1862ce21-31c7-451e-824c-f20fa3f90fa2"
 Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
+
+[sources]
+Wflow = {path = "../Wflow"}

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,7 +42,7 @@ test-wflow-cov = { cmd = "julia --project --eval 'using Pkg; Pkg.test(coverage=t
 test-wflow-server = { cmd = "julia --project=server --eval 'using Pkg; Pkg.test(\"WflowServer\", coverage=true)'", depends-on = [
     "instantiate-wflow-server",
 ] }
-instantiate-wflow-server = "julia --project=server --eval 'using Pkg; Pkg.instantiate(); Pkg.develop(path=\"Wflow/\")'"
+instantiate-wflow-server = "julia --project=server --eval 'using Pkg; Pkg.instantiate()'"
 # Docs
 install-ci = { depends-on = ["install-julia", "update-registry-julia"] }
 quarto-check = { cmd = "quarto check all" }

--- a/server/Project.toml
+++ b/server/Project.toml
@@ -23,3 +23,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Downloads", "Statistics", "Test"]
+
+[sources]
+Wflow = {path = "../Wflow"}


### PR DESCRIPTION
Related to https://github.com/Deltares/Wflow.jl/issues/577#issuecomment-2796910094.

This doesn't do much directly since we have all Manifest.toml files checked in, and they point to the right directory for Wflow. But if you'd remove them and reinstantiate, you'd get Wflow from the registry instead of the one in this repo. Hence it is convenient to specify where to find Wflow.