### PR TITLE
Edit "Installing as Julia package"

### DIFF
--- a/docs/getting_started/install.qmd
+++ b/docs/getting_started/install.qmd
@@ -19,14 +19,10 @@ Wflow is a [Julia](https://julialang.org/) package that can be installed in seve
 Below, we show how to install wflow from Julia's package repository and how to install the
 latest version from GitHub.
 
-First, download and install the [current stable release of
-Julia](https://julialang.org/downloads/#current_stable_release).  If you have any issues
-installing Julia, please see [platform specific
-instructions](https://julialang.org/downloads/platform/) for further instructions.
+First, download and install the [current stable release of Julia](https://modernjuliaworkflows.org/writing/#installation).
 
-If you are new to Julia, it might be a good idea to check out the [Getting Started section of
-the Julia Manual](https://docs.julialang.org/en/v1/manual/getting-started/). You can also find
-additional learning resources at [julialang.org/learning](https://julialang.org/learning/).
+If you are new to Julia, it might be a good idea to check out the [REPL](https://modernjuliaworkflows.org/writing/#repl).
+You can also find additional learning resources at [julialang.org/learning](https://julialang.org/learning/).
 
 ### Install from Julia's package repository
 

--- a/docs/getting_started/install.qmd
+++ b/docs/getting_started/install.qmd
@@ -19,10 +19,12 @@ Wflow is a [Julia](https://julialang.org/) package that can be installed in seve
 Below, we show how to install wflow from Julia's package repository and how to install the
 latest version from GitHub.
 
-First, download and install the [current stable release of Julia](https://modernjuliaworkflows.org/writing/#installation).
+First, download and install the [current stable release of
+Julia](https://modernjuliaworkflows.org/writing/#installation).
 
-If you are new to Julia, it might be a good idea to check out the [REPL](https://modernjuliaworkflows.org/writing/#repl).
-You can also find additional learning resources at [julialang.org/learning](https://julialang.org/learning/).
+If you are new to Julia, it might be a good idea to check out the
+[REPL](https://modernjuliaworkflows.org/writing/#repl). You can also find additional
+learning resources at [julialang.org/learning](https://julialang.org/learning/).
 
 ### Install from Julia's package repository
 


### PR DESCRIPTION
The current link https://julialang.org/downloads/#current_stable_release goes to the old way to install. As you can see on top of that page the current recommended way is with `juliaup`, which is described here: https://julialang.org/install/.

It is not the official docs, but for new users I think https://modernjuliaworkflows.org/writing/#installation is more accessible, so I link there instead.