### PR TITLE
Fix unit conversion `kv_0` to `kh_0`

### DIFF
--- a/Wflow/src/routing/subsurface.jl
+++ b/Wflow/src/routing/subsurface.jl
@@ -71,15 +71,15 @@ function LateralSsfParameters(
 
     kh_profile_type =
         get(config.model, "saturated_hydraulic_conductivity_profile", "exponential")::String
-    dt = Second(config.time.timestepsecs) / BASETIMESTEP
+    factor_dt = BASETIMESTEP / Second(config.time.timestepsecs)
     if kh_profile_type == "exponential"
         (; kv_0, f) = soil.kv_profile
-        kh_0 = khfrac .* kv_0 .* 0.001 .* dt
+        kh_0 = khfrac .* kv_0 .* 0.001 .* factor_dt
         kh_profile = KhExponential(kh_0, f .* 1000.0)
     elseif kh_profile_type == "exponential_constant"
         (; z_exp) = soil.kv_profile
         (; kv_0, f) = soil.kv_profile.exponential
-        kh_0 = khfrac .* kv_0 .* 0.001 .* dt
+        kh_0 = khfrac .* kv_0 .* 0.001 .* factor_dt
         exp_profile = KhExponential(kh_0, f .* 1000.0)
         kh_profile = KhExponentialConstant(exp_profile, z_exp .* 0.001)
     elseif kh_profile_type == "layered" || kh_profile_type == "layered_exponential"

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -10,6 +10,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Unreleased
 
 ### Fixed
+- Introduced in v1.0.0-rc1, fixed unit conversion model parameter `kv_0` to `kh_0` for
+  sub-daily model timestep. 
 
 ### Changed
 - Refactor `SimpleReservoir` and `Lake` structs by introducing a `Reservoir` struct that


### PR DESCRIPTION
This was not correct for a sub-daily model timestep.

## Issue addressed
Fixes #661