### PR TITLE
feat: copy all lisence files during app creation

### DIFF
--- a/build/create_binaries/Manifest.toml
+++ b/build/create_binaries/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.11.3"
 manifest_format = "2.0"
-project_hash = "ea2528725d34650b23f042d15e2cf1ec29a55822"
+project_hash = "3d9fa91f1a60d4d39e72c3ce91d0447242ed5033"
 
 [[deps.AbstractTrees]]
 git-tree-sha1 = "2d9c9a55f9c93e8887ad391fbae72f8ef55e1177"
@@ -345,6 +345,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
 uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
 version = "1.18.0+0"
+
+[[deps.LicenseCheck]]
+deps = ["licensecheck_jll"]
+git-tree-sha1 = "e98bc9e1f773123cfdb1fa3d7a4c898e1f030341"
+uuid = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
+version = "0.2.2"
 
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
@@ -718,6 +724,12 @@ deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "OpenSSL_jll", "XZ_jll
 git-tree-sha1 = "86addc139bca85fdf9e7741e10977c45785727b7"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
 version = "1.11.3+0"
+
+[[deps.licensecheck_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b790ad21ac235c39c0eb34214ccf3d5f5ea60efa"
+uuid = "4ecb348a-8b88-51ea-b912-4c460483ee91"
+version = "0.3.101+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/build/create_binaries/Project.toml
+++ b/build/create_binaries/Project.toml
@@ -1,12 +1,13 @@
 [deps]
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
+LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
 
+[sources]
+Wflow = {path = "../../Wflow"}
+
 [compat]
 PackageCompiler = "2"
 julia = "1.10"
-
-[sources]
-Wflow = {path = "../../Wflow"}

--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -81,6 +81,7 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
     ctx = PackageCompiler.create_pkg_context(project_dir)
     license_dir = joinpath(output_dir, "dep_licenses") 
     mkpath(license_dir)
+
     for (uuid,pkg_entry) in ctx.env.manifest.deps
 	if isnothing(pkg_entry.tree_hash)
 	    # seems as though stdlib packages don't have a tree_sha. as there doesn't seem to be 
@@ -88,11 +89,11 @@ function add_metadata(project_dir, license_file, output_dir, git_repo)
 	    continue 
 	end
 	install_path = Pkg.Operations.find_installed(pkg_entry.name, uuid, pkg_entry.tree_hash)
-	files = readdir(install_path, join=true)
-	license_file_index =findfirst(x-> isfile(x) && !isnothing(match(r"(?i).*/license.*\b$",x)), files) 
-	if !isnothing(license_file_index)
-	    license_file_path = files[license_file_index] 
-	    cp(license_file_path, joinpath(license_dir,pkg_entry.name), force=true)
+
+	license = LicenseCheck.find_license(install_path)
+	if !isnothing(license) 
+	    license_file_path = joinpath(install_path,license.license_filename)
+	    cp(license_file_path , joinpath(license_dir,pkg_entry.name), force=true)
 	end
     end
 end

--- a/build/create_binaries/create_app.jl
+++ b/build/create_binaries/create_app.jl
@@ -2,6 +2,7 @@ using PackageCompiler
 using TOML
 using LibGit2
 using Pkg
+using LicenseCheck
 
 # change directory to this script's location
 cd(@__DIR__)


### PR DESCRIPTION
## Issue addressed
Fixes #631 

## Explanation
Added some code to the `add_metadata` functionality in creating binaries. It will look at all the dependencies in the `wflow_cli` environment, and copy any file that is named license (with optional extension and case insensitive) and copy them into a folder of the output called `dep_licenses`. Because it is added to the existing functionality, any time it is built the licenses will automatically be included. It only includes the licenses of the version that are actually used in the environment to avoid adding too much bloat to the distribution artifacts. 

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.qmd if needed
 