### PR TITLE
Add instantiate to build-cli and test-cli tasks

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -73,7 +73,7 @@ outputs = ["Wflow.spdx.json"]
 
 [dependencies]
 juliaup = "*"
-python = ">=3.10"
+python  = ">=3.10"
 jupyter = ">=1.1.1,<2"
 
 [system-requirements]

--- a/pixi.toml
+++ b/pixi.toml
@@ -26,10 +26,16 @@ download-test-data = { cmd = "julia --project download_test_data.jl", cwd = "bui
 	"initialize-julia",
 ] }
 build-wflow-cli = { cmd = "julia --project create_app.jl", cwd = "build/create_binaries", depends-on = [
+	{ "task" = "instantiate-julia", "args" = [
+		"build/create_binaries",
+	] },
 	"download-test-data",
 ], env = { SSL_CERT_DIR = "", JULIA_SSL_CA_ROOTS_PATH = "" } }
 # Test
 test-wflow-cli = { cmd = "julia --project --eval 'using Pkg; Pkg.test(allow_reresolve=false)'", cwd = "build/wflow_cli", depends-on = [
+	{ "task" = "instantiate-julia", "args" = [
+		"build/wflow_cli",
+	] },
 	"download-test-data",
 ] }
 test-wflow-cov = { cmd = "julia --project --eval 'using Pkg; Pkg.test(allow_reresolve=false, coverage=true, julia_args=[\"--check-bounds=yes\"])'", cwd = "Wflow", depends-on = [
@@ -67,7 +73,7 @@ outputs = ["Wflow.spdx.json"]
 
 [dependencies]
 juliaup = "*"
-python  = ">=3.10"
+python = ">=3.10"
 jupyter = ">=1.1.1,<2"
 
 [system-requirements]


### PR DESCRIPTION
## Issue addressed
No issue, build and test on TeamCity were failing due to missing project instantiates. I guess last time they ran successfully due to cached environments (?). 

## Explanation
I have added project instantiate dependencies to the relevant pixi tasks

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.qmd if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.