### PR TITLE
share mapname as dimension for scalar netcdf

### DIFF
--- a/Wflow/test/run_sbm.jl
+++ b/Wflow/test/run_sbm.jl
@@ -62,11 +62,11 @@ end
         8.601765,
         2.7730224,
     ]
-    @test ds["Q_river_gauge__count"].attrib["cf_role"] == "timeseries_id"
+    @test ds["river_gauge__count"].attrib["cf_role"] == "timeseries_id"
     @test ds["temp_index"][:] ≈ [2.39]
     @test ds["temp_coord"][:] ≈ [2.39]
     @test keys(ds.dim) ==
-          ["time", "layer", "Q_river_gauge__count", "temp_bycoord", "temp_byindex"]
+          ["time", "layer", "river_gauge__count", "temp_bycoord", "temp_byindex"]
 end
 
 @testset "first timestep" begin

--- a/Wflow/test/sbm_config.toml
+++ b/Wflow/test/sbm_config.toml
@@ -154,6 +154,11 @@ map = "river_gauge__count"
 parameter = "routing.river_flow.variables.q"
 
 [[output.netcdf_scalar.variable]]
+name = "T"
+map = "river_gauge__count"
+parameter = "atmosphere_air__temperature"
+
+[[output.netcdf_scalar.variable]]
 coordinate.x = 6.255
 coordinate.y = 50.012
 name = "temp_coord"


### PR DESCRIPTION
test is also added

## Issue addressed
Fixes #692

## Explanation
Share the mapname as the dimension name. Required a small fix when defining the dimension, as that only needs to happen once (errors otherwise). Also slightly modified the test toml to test the resulting dimensions.

Now produces the following dataset (note the `Q` and and `T` layers)
```
<xarray.Dataset> Size: 27kB
Dimensions:             (time: 31, layer: 4, river_gauge__count: 96,
                         temp_bycoord: 1, temp_byindex: 1)
Coordinates:
  * time                (time) datetime64[ns] 248B 2000-01-02 ... 2000-02-01
  * layer               (layer) float64 32B 1.0 2.0 3.0 4.0
  * river_gauge__count  (river_gauge__count) <U7 3kB '9116039' ... '9316144'
  * temp_bycoord        (temp_bycoord) <U12 48B 'temp_bycoord'
  * temp_byindex        (temp_byindex) <U12 48B 'temp_byindex'
Data variables:
    Q                   (time, river_gauge__count) float32 12kB ...
    T                   (time, river_gauge__count) float32 12kB ...
    temp_coord          (time, temp_bycoord) float32 124B ...
    temp_index          (time, temp_byindex) float32 124B ...
```

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.qmd if needed

## Additional Notes (optional)
Add any additional notes or information that may be helpful.