### PR TITLE
Fix computation exfiltration rate for `GroundwaterFlow`

### DIFF
--- a/Wflow/src/groundwater/aquifer.jl
+++ b/Wflow/src/groundwater/aquifer.jl
@@ -94,11 +94,13 @@ transmissivity).
 end
 
 @with_kw struct AquiferVariables
-    head::Vector{Float64}         # hydraulic head [m]
-    head_av::Vector{Float64}      # average hydraulic head [m] for model timestep Δt
-    conductance::Vector{Float64}  # conductance [m² d⁻¹]
-    storage::Vector{Float64}      # total storage of water that can be released [m³]
-    q_net::Vector{Float64}        # net flow [m³ d⁻¹]
+    head::Vector{Float64}               # hydraulic head [m]
+    head_av::Vector{Float64}            # average hydraulic head [m] for model timestep Δt
+    conductance::Vector{Float64}        # conductance [m² d⁻¹]
+    storage::Vector{Float64}            # total storage of water that can be released [m³]
+    q_net::Vector{Float64}              # net flow [m³ d⁻¹]
+    exfiltwater::Vector{Float64}        # Exfiltration [m Δt⁻¹] (groundwater above surface level, saturated excess conditions)
+    exfiltwater_av::Vector{Float64}     # Average exfiltration [m Δt⁻¹] for model timestep Δt (groundwater above surface level, saturated excess conditions)
 end
 
 @with_kw struct ConfinedAquifer <: Aquifer
@@ -179,7 +181,17 @@ function UnconfinedAquifer(
     n = length(storage)
     q_net = zeros(n)
     head_av = zeros(n)
-    variables = AquiferVariables(head, head_av, conductance, storage, q_net)
+    exfiltwater = zeros(n)
+    exfiltwater_av = zeros(n)
+    variables = AquiferVariables(
+        head,
+        head_av,
+        conductance,
+        storage,
+        q_net,
+        exfiltwater,
+        exfiltwater_av,
+    )
     aquifer = UnconfinedAquifer(parameters, variables)
     return aquifer
 end
@@ -440,6 +452,10 @@ minimum_head(aquifer::ConfinedAquifer) = aquifer.variables.head
 minimum_head(aquifer::UnconfinedAquifer) =
     max.(aquifer.variables.head, aquifer.parameters.bottom)
 
+maximum_head(aquifer::ConfinedAquifer) = aquifer.variables.head
+maximum_head(aquifer::UnconfinedAquifer) =
+    min.(aquifer.variables.head, aquifer.parameters.top)
+
 Base.@kwdef struct GroundwaterFlow{A} <: AbstractSubsurfaceFlowModel
     timestepping::TimeStepping
     aquifer::A
@@ -479,10 +495,18 @@ function update_head!(gwf::GroundwaterFlow{A}, dt::Float64) where {A <: Aquifer}
     gwf.aquifer.variables.head[gwf.constanthead.index] .= gwf.constanthead.variables.head
     # Make sure no heads ends up below an unconfined aquifer bottom
     gwf.aquifer.variables.head .= minimum_head(gwf.aquifer)
+    # Compute exfiltration rate and make sure head is not above surface for unconfined aquifer 
+    gwf.aquifer.variables.exfiltwater .=
+        (gwf.aquifer.variables.head .- maximum_head(gwf.aquifer)) .*
+        storativity(gwf.aquifer)
+    gwf.aquifer.variables.head .= maximum_head(gwf.aquifer)
+    # Adjust exfiltration rate for constant head boundaries
+    gwf.aquifer.variables.exfiltwater[gwf.constanthead.index] .= 0.0
     gwf.aquifer.variables.storage .=
         saturated_thickness(gwf.aquifer) .* gwf.aquifer.parameters.area .*
         storativity(gwf.aquifer)
     gwf.aquifer.variables.head_av .+= gwf.aquifer.variables.head .* dt
+    gwf.aquifer.variables.exfiltwater_av .+= gwf.aquifer.variables.exfiltwater .* dt
     return nothing
 end
 
@@ -496,6 +520,7 @@ function update!(
         boundary.variables.flux_av .= 0.0
     end
     gwf.aquifer.variables.head_av .= 0.0
+    gwf.aquifer.variables.exfiltwater_av .= 0.0
     t = 0.0
     while t < dt
         gwf.aquifer.variables.q_net .= 0.0
@@ -509,26 +534,15 @@ function update!(
         boundary.variables.flux_av ./= dt
     end
     gwf.aquifer.variables.head_av ./= dt
+    gwf.aquifer.variables.exfiltwater_av ./= dt
     return nothing
 end
 
-function get_water_depth(gwf::GroundwaterFlow{A}) where {A <: UnconfinedAquifer}
-    gwf.aquifer.variables.head .=
-        min.(gwf.aquifer.variables.head, gwf.aquifer.parameters.top)
-    gwf.aquifer.variables.head[gwf.constanthead.index] .= gwf.constanthead.variables.head
-    wtd = gwf.aquifer.parameters.top .- gwf.aquifer.variables.head
-    return wtd
-end
+get_water_depth(gwf::GroundwaterFlow{A}) where {A <: UnconfinedAquifer} =
+    gwf.aquifer.parameters.top .- gwf.aquifer.variables.head
 
-function get_exfiltwater(gwf::GroundwaterFlow{A}) where {A <: UnconfinedAquifer}
-    exfiltwater =
-        (
-            gwf.aquifer.variables.head .-
-            min.(gwf.aquifer.variables.head, gwf.aquifer.parameters.top)
-        ) .* storativity(gwf.aquifer)
-    exfiltwater[gwf.constanthead.index] .= 0
-    return exfiltwater
-end
+get_exfiltwater(gwf::GroundwaterFlow{A}) where {A <: UnconfinedAquifer} =
+    gwf.aquifer.variables.exfiltwater_av
 
 function get_flux_to_river(
     subsurface_flow::GroundwaterFlow{A},

--- a/Wflow/test/groundwater.jl
+++ b/Wflow/test/groundwater.jl
@@ -49,6 +49,8 @@ function homogenous_aquifer(nrow, ncol)
         conductance = fill(0.0, connectivity.nconnection),
         storage = fill(0.0, ncell),
         q_net = fill(0.0, ncell),
+        exfiltwater = fill(0.0, ncell),
+        exfiltwater_av = fill(0.0, ncell),
     )
     conf_aqf = Wflow.ConfinedAquifer(; parameters, variables)
 
@@ -66,6 +68,8 @@ function homogenous_aquifer(nrow, ncol)
         conductance = fill(0.0, connectivity.nconnection),
         storage = fill(0.0, ncell),
         q_net = fill(0.0, ncell),
+        exfiltwater = fill(0.0, ncell),
+        exfiltwater_av = fill(0.0, ncell),
     )
     unconf_aqf = Wflow.UnconfinedAquifer(; parameters, variables)
     return (connectivity, conf_aqf, unconf_aqf)
@@ -461,6 +465,8 @@ end
             conductance = fill(0.0, connectivity.nconnection),
             storage = fill(0.0, ncell),
             q_net = fill(0.0, ncell),
+            exfiltwater = fill(0.0, ncell),
+            exfiltwater_av = fill(0.0, ncell),
         )
         parameters = Wflow.UnconfinedAquiferParameters(;
             k = fill(conductivity, ncell),
@@ -541,6 +547,8 @@ end
             conductance = fill(0.0, connectivity.nconnection),
             storage = fill(0.0, ncell),
             q_net = fill(0.0, ncell),
+            exfiltwater = fill(0.0, ncell),
+            exfiltwater_av = fill(0.0, ncell),
         )
         parameters = Wflow.UnconfinedAquiferParameters(;
             k = fill(conductivity, ncell),
@@ -632,6 +640,8 @@ end
             conductance = fill(0.0, connectivity.nconnection),
             storage = fill(0.0, ncell),
             q_net = fill(0.0, ncell),
+            exfiltwater = fill(0.0, ncell),
+            exfiltwater_av = fill(0.0, ncell),
         )
         aquifer = Wflow.ConfinedAquifer(; parameters, variables)
 

--- a/Wflow/test/run_sbm_gwf_piave.jl
+++ b/Wflow/test/run_sbm_gwf_piave.jl
@@ -31,11 +31,11 @@ Wflow.run_timestep!(model)
     @test domestic.demand.demand_net[[1, end]] ≈ [0.3802947998046875, 0.0]
     @test domestic.variables.returnflow[[1, end]] ≈ [0.2209725379943848, 0.0]
     @test reservoir.variables.waterlevel_av ≈
-          [23.956777464091655, 32.68528833371174, 39.96881815487859]
+          [23.95914400555985, 32.68535935572136, 39.969135230891744]
     @test reservoir.variables.storage_av ≈
-          [1.5523991796731403e8, 4.279896636165852e7, 7.159755286167501e7]
+          [1.5525525315602788e8, 4.27990593597248e7, 7.15981208511133e7]
     @test reservoir.variables.outflow_av ≈
-          [3.248031210948757, 5.04778640418958, 14.259912531748482]
+          [3.248673046140208, 8.352196766583088, 29.02990124474297]
 end
 
 Wflow.run_timestep!(model)
@@ -52,11 +52,11 @@ Wflow.run_timestep!(model)
     @test nonpaddy.variables.demand_gross[[32, 38, 41]] ≈
           [0.0, 3.9965040974684207, 5.44810857188258]
     @test reservoir.variables.waterlevel_av ≈
-          [23.946156606576015, 32.68503511233224, 39.968913991701285]
+          [23.95845092987531, 32.68554507549814, 39.96988968054929]
     @test reservoir.variables.storage_av ≈
-          [1.5517109481061247e8, 4.2798634787000515e7, 7.159772453755285e7]
+          [1.552507620255922e8, 4.2799302546029136e7, 7.159947232337902e7]
     @test reservoir.variables.outflow_av ≈
-          [3.2451518657160476, 4.654493902558098, 13.362835228238662]
+          [3.2484850081729024, 9.328049956914716, 38.06870720301024]
 end
 
 Wflow.close_files(model; delete_output = false)

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -14,6 +14,11 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   sub-daily model timestep.
 - Introduced in v1.0.0-rc1, fixed Rutter interception by correctly extracting the vegetation
   parameters.
+- Introduced in v1.0.0-rc1, fixed computation of exfiltration rate for `GroundwaterFlow`.
+  Before the exfiltration rate was computed (function `get_exfiltwater`), the maximum
+  groundwater head was adjusted to the surface level (function `get_water_depth`), resulting
+  in zero exfiltration rates. The exfiltration rate computation has been moved to the
+  `update_head!` function of `GroundwaterFlow`.
 
 ### Changed
 - Refactor `SimpleReservoir` and `Lake` structs by introducing a `Reservoir` struct that
@@ -23,7 +28,7 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   `reservoir` is used, also for the standard names of associated model variables and
   parameters.
 - The numerical stability coefficient for groundwater flow was set at a fixed value of 0.25
-  as recommended by Chu and Willis (1984. This has been changed to a configurable model
+  as recommended by Chu and Willis (1984). This has been changed to a configurable model
   setting (`subsurface_water_flow__alpha_coefficient`), so this can be lowered easily in
   case of numerical instabilities. Additionally, internal timestepping for groundwater flow
   is now supported.


### PR DESCRIPTION
This issue has been introduced in `v1.0.0-rc1`. Before the exfiltration rate computation the maximum groundwater head was adjusted to the surface level resulting in zero exfiltration rates. This has been fixed and the exfiltration rate computation has been moved to the `update_head!` function of `GroundwaterFlow`.