### PR TITLE
Rename `project` to `workspace` in pixi.toml

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -1,4 +1,4 @@
-[project]
+[workspace]
 name = "Wflow.jl"
 authors = [
 	"Joost Buitink <joost.buitink@deltares.nl>",


### PR DESCRIPTION
The `project` field is deprecated.
