### PR TITLE
Don't test for persistent tasks

### DIFF
--- a/Wflow/test/aqua.jl
+++ b/Wflow/test/aqua.jl
@@ -1,4 +1,4 @@
 @testitem "Aqua" begin
     import Aqua
-    Aqua.test_all(Wflow)
+    Aqua.test_all(Wflow; persistent_tasks = false)
 end

--- a/server/test/aqua.jl
+++ b/server/test/aqua.jl
@@ -1,4 +1,4 @@
 @testitem "Aqua" begin
     import Aqua
-    Aqua.test_all(WflowServer)
+    Aqua.test_all(WflowServer; persistent_tasks = false)
 end


### PR DESCRIPTION
Tests kept randomly failing on CI because of this. @visr activated these tests in https://github.com/Deltares/Wflow.jl/pull/842 but advised to deactivate them because of these failures.
