### PR TITLE
Kinematic wave performance improvement

### DIFF
--- a/Wflow/src/routing/surface/surface_kinwave.jl
+++ b/Wflow/src/routing/surface/surface_kinwave.jl
@@ -13,7 +13,6 @@ end
 "Struct for storing Manning flow parameters"
 @with_kw struct ManningFlowParameters
     n::Int
-    beta::Float64                 # constant in Manning's equation [-]
     slope::Vector{Float64}        # Slope [m m⁻¹]
     mannings_n::Vector{Float64}   # Manning's roughness [s m⁻⅓]
     alpha_pow::Float64            # Used in the power part of alpha [-]
@@ -26,10 +25,9 @@ function ManningFlowParameters(mannings_n::Vector{Float64}, slope::Vector{Float6
     n = length(slope)
     parameters = ManningFlowParameters(;
         n,
-        beta = Float64(0.6),
         slope,
         mannings_n,
-        alpha_pow = Float64((2.0 / 3.0) * 0.6),
+        alpha_pow=Float64((2.0 / 3.0) * 0.6),
     )
     return parameters
 end
@@ -60,18 +58,18 @@ function RiverFlowParameters(dataset::NCDataset, config::Config, domain::DomainR
         config,
         "river_water_flow__manning_n_parameter",
         Routing;
-        sel = indices,
+        sel=indices,
     )
     bankfull_depth =
-        ncread(dataset, config, "river_bank_water__depth", Routing; sel = indices)
+        ncread(dataset, config, "river_bank_water__depth", Routing; sel=indices)
 
     flow_params = ManningFlowParameters(mannings_n, slope)
-    parameters = RiverFlowParameters(; flow = flow_params, bankfull_depth)
+    parameters = RiverFlowParameters(; flow=flow_params, bankfull_depth)
     return parameters
 end
 
 "Struct for storing river flow model boundary conditions"
-@with_kw struct RiverFlowBC{R <: Union{ReservoirModel, Nothing}}
+@with_kw struct RiverFlowBC{R<:Union{ReservoirModel,Nothing}}
     n::Int
     inwater::Vector{Float64} = zeros(n)                         # Lateral inflow [m³ s⁻¹]
     external_inflow::Vector{Float64} = zeros(n)                 # External inflow (abstraction/supply/demand) [m³ s⁻¹]
@@ -85,7 +83,7 @@ function RiverFlowBC(
     dataset::NCDataset,
     config::Config,
     network::NetworkRiver,
-    reservoir::Union{ReservoirModel, Nothing},
+    reservoir::Union{ReservoirModel,Nothing},
 )
     (; indices) = network
     external_inflow = ncread(
@@ -93,7 +91,7 @@ function RiverFlowBC(
         config,
         "river_water__external_inflow_volume_flow_rate",
         Routing;
-        sel = indices,
+        sel=indices,
     )
     n = length(indices)
     bc = RiverFlowBC(; n, external_inflow, reservoir)
@@ -101,7 +99,7 @@ function RiverFlowBC(
 end
 
 "River flow model using the kinematic wave method and the Manning flow equation"
-@with_kw struct KinWaveRiverFlowModel{R <: RiverFlowBC, A <: AbstractAllocationModel} <:
+@with_kw struct KinWaveRiverFlowModel{R<:RiverFlowBC,A<:AbstractAllocationModel} <:
                 AbstractRiverFlowModel
     timestepping::TimeStepping
     boundary_conditions::R
@@ -115,12 +113,12 @@ function KinWaveRiverFlowModel(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    reservoir::Union{ReservoirModel, Nothing},
+    reservoir::Union{ReservoirModel,Nothing},
 )
     (; indices) = domain.network
     n = length(indices)
 
-    timestepping = init_kinematic_wave_timestepping(config, n; domain = "river")
+    timestepping = init_kinematic_wave_timestepping(config, n; domain="river")
 
     allocation =
         do_water_demand(config) ? AllocationRiverModel(; n) : NoAllocationRiverModel(n)
@@ -181,11 +179,11 @@ function KinWaveOverlandFlowModel(dataset::NCDataset, config::Config, domain::Do
         config,
         "land_surface_water_flow__manning_n_parameter",
         Routing;
-        sel = indices,
+        sel=indices,
     )
 
     n = length(indices)
-    timestepping = init_kinematic_wave_timestepping(config, n; domain = "land")
+    timestepping = init_kinematic_wave_timestepping(config, n; domain="land")
 
     variables = OverLandFlowVariables(; n)
     parameters = ManningFlowParameters(mannings_n, slope)
@@ -264,14 +262,14 @@ function kinwave_land_update!(
     (; order_of_subdomains, order_subdomain, subdomain_indices, upstream_nodes) =
         domain.network
 
-    (; beta, alpha) = overland_flow_model.parameters
+    (; alpha) = overland_flow_model.parameters
     (; h, q, q_av, storage, qin, qin_av, qlat, to_river) = overland_flow_model.variables
     (; surface_flow_width, flow_length, flow_fraction_to_river) = domain.parameters
 
     ns = length(order_of_subdomains)
     qin .= 0.0
     for k in 1:ns
-        threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
+        threaded_foreach(eachindex(order_of_subdomains[k]); basesize=1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 # for a river cell without a reservoir part of the upstream surface flow
@@ -287,15 +285,8 @@ function kinwave_land_update!(
                     )
                 end
 
-                q[v], crossarea = kinematic_wave(
-                    qin[v],
-                    q[v],
-                    qlat[v],
-                    alpha[v],
-                    beta,
-                    dt,
-                    flow_length[v],
-                )
+                q[v], crossarea =
+                    kinematic_wave(qin[v], q[v], qlat[v], alpha[v], dt, flow_length[v])
 
                 # update h, only if flow width > 0.0
                 if surface_flow_width[v] > 0.0
@@ -321,12 +312,12 @@ function update_overland_flow_model!(
     dt::Float64,
 )
     (; inwater) = overland_flow_model.boundary_conditions
-    (; alpha_term, mannings_n, beta, alpha_pow, alpha) = overland_flow_model.parameters
+    (; alpha_term, mannings_n, alpha_pow, alpha) = overland_flow_model.parameters
     (; surface_flow_width, flow_length, slope) = domain.parameters
     (; q_av, qlat, qin_av, to_river) = overland_flow_model.variables
     (; adaptive) = overland_flow_model.timestepping
 
-    @. alpha_term = pow(mannings_n / sqrt(slope), beta)
+    @. alpha_term = pow(mannings_n / sqrt(slope), BETA_KINWAVE)
     # use fixed alpha value based flow width
     @. alpha = alpha_term * pow(surface_flow_width, alpha_pow)
     @. qlat = inwater / flow_length
@@ -416,14 +407,14 @@ function kinwave_river_update!(
     (; reservoir, external_inflow, actual_external_abstraction_av, abstraction) =
         river_flow_model.boundary_conditions
 
-    (; beta, alpha) = river_flow_model.parameters
+    (; alpha) = river_flow_model.parameters
     (; flow_width, flow_length) = domain.parameters
     (; h, q, q_av, storage, qin, qin_av, qlat) = river_flow_model.variables
 
     ns = length(order_of_subdomains)
     qin .= 0.0
     for k in 1:ns
-        threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
+        threaded_foreach(eachindex(order_of_subdomains[k]); basesize=1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 # qin by outflow from upstream reservoir location is added
@@ -446,7 +437,6 @@ function kinwave_river_update!(
                     q[v],
                     qlat[v] + _inflow,
                     alpha[v],
-                    beta,
                     dt,
                     flow_length[v],
                 )
@@ -483,13 +473,13 @@ function update_river_flow_model!(
     clock::Clock,
 )
     (; reservoir, inwater) = river_flow_model.boundary_conditions
-    (; alpha_term, mannings_n, beta, alpha_pow, alpha, bankfull_depth) =
+    (; alpha_term, mannings_n, alpha_pow, alpha, bankfull_depth) =
         river_flow_model.parameters
     (; slope, flow_width, flow_length) = domain.river.parameters
     (; qlat, qin_av) = river_flow_model.variables
     (; adaptive) = river_flow_model.timestepping
 
-    @. alpha_term = pow(mannings_n / sqrt(slope), beta)
+    @. alpha_term = pow(mannings_n / sqrt(slope), BETA_KINWAVE)
     # use fixed alpha value based on 0.5 * bankfull_depth
     @. alpha = alpha_term * pow(flow_width + bankfull_depth, alpha_pow)
     @. qlat = inwater / flow_length
@@ -516,6 +506,8 @@ function update_river_flow_model!(
     return nothing
 end
 
+const BETA_KINWAVE = 0.6
+
 """
 Compute a stable timestep size for the kinematice wave method for a river or overland flow
 model using a nonlinear scheme (Chow et al., 1988).
@@ -530,9 +522,9 @@ function stable_timestep(
     flow_model::S,
     flow_length::Vector{Float64},
     p::Float64,
-) where {S <: Union{KinWaveOverlandFlowModel, KinWaveRiverFlowModel}}
+) where {S<:Union{KinWaveOverlandFlowModel,KinWaveRiverFlowModel}}
     (; q) = flow_model.variables
-    (; alpha, beta) = flow_model.parameters
+    (; alpha) = flow_model.parameters
     (; stable_timesteps) = flow_model.timestepping
 
     n = length(q)
@@ -541,7 +533,7 @@ function stable_timestep(
     for i in 1:n
         if q[i] > 0.0
             k += 1
-            c = 1.0 / (alpha[i] * beta * pow(q[i], (beta - 1.0)))
+            c = 1.0 / (alpha[i] * BETA_KINWAVE * pow(q[i], (BETA_KINWAVE - 1.0)))
             stable_timesteps[k] = (flow_length[i] / c)
         end
     end
@@ -621,7 +613,7 @@ Update overland and subsurface flow contribution to inflow of a reservoir model 
 flow model `AbstractRiverFlowModel` for a single timestep.
 """
 function update_inflow!(
-    reservoir_model::Union{ReservoirModel, Nothing},
+    reservoir_model::Union{ReservoirModel,Nothing},
     river_flow_model::AbstractRiverFlowModel,
     external_models::NamedTuple,
     network::NetworkReservoir,

--- a/Wflow/src/routing/surface/surface_kinwave.jl
+++ b/Wflow/src/routing/surface/surface_kinwave.jl
@@ -27,7 +27,7 @@ function ManningFlowParameters(mannings_n::Vector{Float64}, slope::Vector{Float6
         n,
         slope,
         mannings_n,
-        alpha_pow=Float64((2.0 / 3.0) * 0.6),
+        alpha_pow = Float64((2.0 / 3.0) * 0.6),
     )
     return parameters
 end
@@ -58,18 +58,18 @@ function RiverFlowParameters(dataset::NCDataset, config::Config, domain::DomainR
         config,
         "river_water_flow__manning_n_parameter",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     bankfull_depth =
-        ncread(dataset, config, "river_bank_water__depth", Routing; sel=indices)
+        ncread(dataset, config, "river_bank_water__depth", Routing; sel = indices)
 
     flow_params = ManningFlowParameters(mannings_n, slope)
-    parameters = RiverFlowParameters(; flow=flow_params, bankfull_depth)
+    parameters = RiverFlowParameters(; flow = flow_params, bankfull_depth)
     return parameters
 end
 
 "Struct for storing river flow model boundary conditions"
-@with_kw struct RiverFlowBC{R<:Union{ReservoirModel,Nothing}}
+@with_kw struct RiverFlowBC{R <: Union{ReservoirModel, Nothing}}
     n::Int
     inwater::Vector{Float64} = zeros(n)                         # Lateral inflow [m³ s⁻¹]
     external_inflow::Vector{Float64} = zeros(n)                 # External inflow (abstraction/supply/demand) [m³ s⁻¹]
@@ -83,7 +83,7 @@ function RiverFlowBC(
     dataset::NCDataset,
     config::Config,
     network::NetworkRiver,
-    reservoir::Union{ReservoirModel,Nothing},
+    reservoir::Union{ReservoirModel, Nothing},
 )
     (; indices) = network
     external_inflow = ncread(
@@ -91,7 +91,7 @@ function RiverFlowBC(
         config,
         "river_water__external_inflow_volume_flow_rate",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     n = length(indices)
     bc = RiverFlowBC(; n, external_inflow, reservoir)
@@ -99,7 +99,7 @@ function RiverFlowBC(
 end
 
 "River flow model using the kinematic wave method and the Manning flow equation"
-@with_kw struct KinWaveRiverFlowModel{R<:RiverFlowBC,A<:AbstractAllocationModel} <:
+@with_kw struct KinWaveRiverFlowModel{R <: RiverFlowBC, A <: AbstractAllocationModel} <:
                 AbstractRiverFlowModel
     timestepping::TimeStepping
     boundary_conditions::R
@@ -113,12 +113,12 @@ function KinWaveRiverFlowModel(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    reservoir::Union{ReservoirModel,Nothing},
+    reservoir::Union{ReservoirModel, Nothing},
 )
     (; indices) = domain.network
     n = length(indices)
 
-    timestepping = init_kinematic_wave_timestepping(config, n; domain="river")
+    timestepping = init_kinematic_wave_timestepping(config, n; domain = "river")
 
     allocation =
         do_water_demand(config) ? AllocationRiverModel(; n) : NoAllocationRiverModel(n)
@@ -179,11 +179,11 @@ function KinWaveOverlandFlowModel(dataset::NCDataset, config::Config, domain::Do
         config,
         "land_surface_water_flow__manning_n_parameter",
         Routing;
-        sel=indices,
+        sel = indices,
     )
 
     n = length(indices)
-    timestepping = init_kinematic_wave_timestepping(config, n; domain="land")
+    timestepping = init_kinematic_wave_timestepping(config, n; domain = "land")
 
     variables = OverLandFlowVariables(; n)
     parameters = ManningFlowParameters(mannings_n, slope)
@@ -269,7 +269,7 @@ function kinwave_land_update!(
     ns = length(order_of_subdomains)
     qin .= 0.0
     for k in 1:ns
-        threaded_foreach(eachindex(order_of_subdomains[k]); basesize=1) do i
+        threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 # for a river cell without a reservoir part of the upstream surface flow
@@ -414,7 +414,7 @@ function kinwave_river_update!(
     ns = length(order_of_subdomains)
     qin .= 0.0
     for k in 1:ns
-        threaded_foreach(eachindex(order_of_subdomains[k]); basesize=1) do i
+        threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 # qin by outflow from upstream reservoir location is added
@@ -506,6 +506,7 @@ function update_river_flow_model!(
     return nothing
 end
 
+# constant in Manning's equation [-]
 const BETA_KINWAVE = 0.6
 
 """
@@ -522,7 +523,7 @@ function stable_timestep(
     flow_model::S,
     flow_length::Vector{Float64},
     p::Float64,
-) where {S<:Union{KinWaveOverlandFlowModel,KinWaveRiverFlowModel}}
+) where {S <: Union{KinWaveOverlandFlowModel, KinWaveRiverFlowModel}}
     (; q) = flow_model.variables
     (; alpha) = flow_model.parameters
     (; stable_timesteps) = flow_model.timestepping
@@ -613,7 +614,7 @@ Update overland and subsurface flow contribution to inflow of a reservoir model 
 flow model `AbstractRiverFlowModel` for a single timestep.
 """
 function update_inflow!(
-    reservoir_model::Union{ReservoirModel,Nothing},
+    reservoir_model::Union{ReservoirModel, Nothing},
     river_flow_model::AbstractRiverFlowModel,
     external_models::NamedTuple,
     network::NetworkReservoir,

--- a/Wflow/src/routing/surface/surface_kinwave.jl
+++ b/Wflow/src/routing/surface/surface_kinwave.jl
@@ -287,7 +287,7 @@ function kinwave_land_update!(
                     )
                 end
 
-                q[v] = kinematic_wave(
+                q[v], crossarea = kinematic_wave(
                     qin[v],
                     q[v],
                     qlat[v],
@@ -299,7 +299,6 @@ function kinwave_land_update!(
 
                 # update h, only if flow width > 0.0
                 if surface_flow_width[v] > 0.0
-                    crossarea = alpha[v] * pow(q[v], beta)
                     h[v] = crossarea / surface_flow_width[v]
                 end
                 storage[v] = flow_length[v] * surface_flow_width[v] * h[v]
@@ -442,7 +441,7 @@ function kinwave_river_update!(
                 # negative external inflow as part of water allocation computations.
                 _inflow -= abstraction[v] / flow_length[v]
 
-                q[v] = kinematic_wave(
+                q[v], crossarea = kinematic_wave(
                     qin[v],
                     q[v],
                     qlat[v] + _inflow,
@@ -463,7 +462,6 @@ function kinwave_river_update!(
                     )
                 end
                 # update h and storage
-                crossarea = alpha[v] * pow(q[v], beta)
                 h[v] = crossarea / flow_width[v]
                 storage[v] = flow_length[v] * flow_width[v] * h[v]
 

--- a/Wflow/src/routing/surface/surface_process.jl
+++ b/Wflow/src/routing/surface/surface_process.jl
@@ -17,7 +17,7 @@ end
 lateral_snow_transport!(snow::NoSnowModel, domain::DomainLand) = nothing
 
 "Kinematic wave surface flow rate for a single cell and timestep"
-function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
+function kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx)
     if q_in + q_prev + q_lat ≈ 0.0
         return 0.0, 0.0
     else
@@ -71,11 +71,11 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
 end
 
 "Kinematic wave surface flow rate over the whole network for a single timestep"
-function kin_wave!(q, graph, toposort, q_prev, q_lat, alpha, beta, flow_length, dt)
+function kin_wave!(q, graph, toposort, q_prev, q_lat, alpha, flow_length, dt)
     for v in toposort
         upstream_nodes = inneighbors(graph, v)
         q_in = sum_at(q, upstream_nodes)
-        q[v], _ = kinematic_wave(q_in, q_prev[v], q_lat, alpha[v], beta, dt, flow_length[v])
+        q[v], _ = kinematic_wave(q_in, q_prev[v], q_lat, alpha[v], dt, flow_length[v])
     end
     return q
 end

--- a/Wflow/src/routing/surface/surface_process.jl
+++ b/Wflow/src/routing/surface/surface_process.jl
@@ -22,34 +22,49 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
         return 0.0
     else
         dt_dx = dt / dx
-        exponent = beta - 1.0
-        # initial estimate using linear scheme
-        alpha_beta = alpha * beta
-        ab_pq = alpha_beta * pow(((q_prev + q_in) / 2.0), exponent)
-        q = (dt_dx * q_in + q_prev * ab_pq + dt * q_lat) / (dt_dx + ab_pq)
-        if isnan(q)
-            q = 0.0
+        # constant_term = (dt/dx)*q_in + alpha*q_prev^(3/5) + dt*q_lat
+        # Use q_prev^(3/5) = (q_prev^(1/5))^3
+        u_prev = q_prev >= 0.0 ? Wflow.pow(q_prev, 0.2) : 0.0
+        constant_term = dt_dx * q_in + alpha * u_prev * u_prev * u_prev + dt * q_lat
+
+        # Initial estimate: use u_prev as starting point (cheap, no pow calls)
+        # Since q changes smoothly between timesteps, u_prev is already close to the root.
+        # For the case q_prev == 0, use C/alpha as a rough estimate for u^3, so u ≈ cbrt(C/alpha)
+        u = if u_prev > 0.0
+            u_prev
+        else
+            cbrt(constant_term / alpha)
         end
-        q = max(q, KIN_WAVE_MIN_FLOW)
-        # newton-raphson
+
+        # Halley's method on f(u) = dt_dx * u^5 + alpha * u^3 - C = 0
+        # f'(u)  = 5*dt_dx * u^4 + 3*alpha * u^2
+        # f''(u) = 20*dt_dx * u^3 + 6*alpha * u
         max_iters = 3000
         epsilon = 1.0e-12
         count = 0
-        constant_term = dt_dx * q_in + alpha * pow(q_prev, beta) + dt * q_lat
-        while true
-            f_q = dt_dx * q + alpha * pow(q, beta) - constant_term
-            df_q = dt_dx + alpha * beta * pow(q, exponent)
-            q -= (f_q / df_q)
-            if isnan(q)
-                q = 0.0
+
+        const_1 = 5.0 * dt_dx
+        const_2 = 3.0 * alpha
+        const_3 = 20.0 * dt_dx
+        const_4 = 6.0 * alpha
+
+        for _ in 1:max_iters
+            u2 = u * u
+            u3 = u2 * u
+            f_u = u3 * (dt_dx * u2 + alpha) - constant_term
+            df_u = u2 * (const_1 * u2 + const_2)
+            d2f_u = u * (const_3 * u2 + const_4)
+            # Halley's correction: u -= 2*f*f' / (2*f'^2 - f*f'')
+            u -= (2.0 * f_u * df_u) / (2.0 * df_u * df_u - f_u * d2f_u)
+            if isnan(u) || u <= 0.0
+                u = KIN_WAVE_MIN_FLOW_QROOT
             end
-            q = max(q, KIN_WAVE_MIN_FLOW)
-            if (abs(f_q) <= epsilon) || (count >= max_iters)
+            if (abs(f_u) <= epsilon)
                 break
             end
-            count += 1
         end
-        return q
+        q = u * u * u * u * u
+        return max(q, KIN_WAVE_MIN_FLOW)
     end
 end
 

--- a/Wflow/src/routing/surface/surface_process.jl
+++ b/Wflow/src/routing/surface/surface_process.jl
@@ -19,7 +19,7 @@ lateral_snow_transport!(snow::NoSnowModel, domain::DomainLand) = nothing
 "Kinematic wave surface flow rate for a single cell and timestep"
 function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
     if q_in + q_prev + q_lat ≈ 0.0
-        return 0.0
+        return 0.0, 0.0
     else
         dt_dx = dt / dx
         # constant_term = (dt/dx)*q_in + alpha*q_prev^(3/5) + dt*q_lat
@@ -41,7 +41,6 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
         # f''(u) = 20*dt_dx * u^3 + 6*alpha * u
         max_iters = 3000
         epsilon = 1.0e-12
-        count = 0
 
         const_1 = 5.0 * dt_dx
         const_2 = 3.0 * alpha
@@ -54,8 +53,8 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
             f_u = u3 * (dt_dx * u2 + alpha) - constant_term
             df_u = u2 * (const_1 * u2 + const_2)
             d2f_u = u * (const_3 * u2 + const_4)
-            # Halley's correction: u -= 2*f*f' / (2*f'^2 - f*f'')
-            u -= (2.0 * f_u * df_u) / (2.0 * df_u * df_u - f_u * d2f_u)
+            # Halley's correction: u -= f*f' / (f'^2 - f*f''/2)
+            u -= (f_u * df_u) / (df_u * df_u - f_u * d2f_u / 2)
             if isnan(u) || u <= 0.0
                 u = KIN_WAVE_MIN_FLOW_QROOT
             end
@@ -63,8 +62,11 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
                 break
             end
         end
-        q = u * u * u * u * u
-        return max(q, KIN_WAVE_MIN_FLOW)
+        u = max(u, KIN_WAVE_MIN_FLOW_QROOT)
+        u3 = u * u * u
+        crossarea = alpha * u3
+        q = u3 * u * u
+        return q, crossarea
     end
 end
 
@@ -73,7 +75,7 @@ function kin_wave!(q, graph, toposort, q_prev, q_lat, alpha, beta, flow_length, 
     for v in toposort
         upstream_nodes = inneighbors(graph, v)
         q_in = sum_at(q, upstream_nodes)
-        q[v] = kinematic_wave(q_in, q_prev[v], q_lat, alpha[v], beta, dt, flow_length[v])
+        q[v], _ = kinematic_wave(q_in, q_prev[v], q_lat, alpha[v], beta, dt, flow_length[v])
     end
     return q
 end

--- a/Wflow/src/routing/utils.jl
+++ b/Wflow/src/routing/utils.jl
@@ -1,4 +1,5 @@
 const KIN_WAVE_MIN_FLOW = 1e-30 # [m³ s⁻¹]
+const KIN_WAVE_MIN_FLOW_QROOT = KIN_WAVE_MIN_FLOW^0.2
 
 "Convert a gridded drainage direction to a directed graph"
 function flowgraph(ldd::AbstractVector, indices::AbstractVector, PCR_DIR::AbstractVector)

--- a/Wflow/test/routing_process.jl
+++ b/Wflow/test/routing_process.jl
@@ -9,7 +9,7 @@
     q_prev = 0.0
     q_lat = 1.142e-6
 
-    q, crossarea = Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
+    q, crossarea = Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx)
     @test q ≈ 1.09308660753423e-6
     @test crossarea ≈ 0.0006852061693892164
 
@@ -17,7 +17,7 @@
     q_in = 0.0
     q_prev = 0.0
     q_lat = 0.0
-    @test Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx) == (0.0, 0.0)
+    @test Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx) == (0.0, 0.0)
 end
 
 @testitem "unit: ssf_celerity" begin
@@ -49,6 +49,7 @@ end
 @testitem "kinematic wave overland flow" begin
     using NCDatasets: NCDataset
     using Graphs: topological_sort_by_dfs
+    using BenchmarkTools
 
     dt_sec = 86400.0
     ldd_MISSING_VALUE = 255
@@ -81,14 +82,18 @@ end
 
     # calculate parameters of kinematic wave
     q = 0.000001
-    beta = 0.6
+    beta = Wflow.BETA_KINWAVE
     AlpPow = (2.0 / 3.0) * beta
     AlpTermR = (N ./ sqrt.(slope)) .^ beta
     P = Bw + (2.0 * waterlevel)
     alpha = AlpTermR .* P .^ AlpPow
 
     Q = zeros(n)
-    Q = Wflow.kin_wave!(Q, graph, toposort, Qold, q, alpha, beta, DCL, dt_sec)
+    # Warm-up call
+    Q = Wflow.kin_wave!(Q, graph, toposort, Qold, q, alpha, DCL, dt_sec)
+    # Benchmark
+    b = @benchmark Wflow.kin_wave!($Q, $graph, $toposort, $Qold, $q, $alpha, $DCL, $dt_sec)
+    display(b)
 
     @test sum(Q) ≈ 2.957806043289641e6
     @test Q[toposort[1]] ≈ 0.007260052312634069
@@ -305,7 +310,6 @@ end
         parameters = Wflow.RiverFlowParameters(;
             flow = Wflow.ManningFlowParameters(;
                 n,
-                beta = 0.6,
                 slope = [0.017522206529974937, 0.01738094352185726],
                 mannings_n = [0.03, 0.03],
                 alpha_pow = 0.4,

--- a/Wflow/test/routing_process.jl
+++ b/Wflow/test/routing_process.jl
@@ -8,14 +8,16 @@
     q_in = 1.104e-6
     q_prev = 0.0
     q_lat = 1.142e-6
-    @test Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx) ≈
-          1.09308660753423e-6
+
+    q, crossarea = Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx)
+    @test q ≈ 1.09308660753423e-6
+    @test crossarea ≈ 0.0006852061693892164
 
     # Case q_in + q_prev + q_lat ≈ 0.0
     q_in = 0.0
     q_prev = 0.0
     q_lat = 0.0
-    @test Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx) == 0.0
+    @test Wflow.kinematic_wave(q_in, q_prev, q_lat, alpha, beta, dt, dx) == (0.0, 0.0)
 end
 
 @testitem "unit: ssf_celerity" begin
@@ -52,7 +54,7 @@ end
     ldd_MISSING_VALUE = 255
 
     # read the staticmaps into memory
-    nc = NCDataset("data/input/staticmaps-rhine.nc")
+    nc = NCDataset(normpath(@__DIR__, "data/input/staticmaps-rhine.nc"))
     # helper function to get the axis order and directionality right
     read_right(nc, var) = reverse(permutedims(Array(nc[var])); dims = 2)
     ldd_2d = read_right(nc, "ldd")
@@ -541,36 +543,36 @@ end
                 profile = Wflow.FloodPlainProfile(;
                     depth = [0.0, 0.5, 1.0, 1.5, 2.0, 2.5],
                     storage = [
-                        0.0 0.0 0.0;
-                        77602.0 281141.0 111313.0;
-                        189506.0 609512.0 256357.0;
-                        346960.0 981178.0 420515.0;
-                        526346.0 1.39783e6 602100.0;
-                        747343.0 1.87239e6 814606.0;
+                        0.0 0.0 0.0
+                        77602.0 281141.0 111313.0
+                        189506.0 609512.0 256357.0
+                        346960.0 981178.0 420515.0
+                        526346.0 1.39783e6 602100.0
+                        747343.0 1.87239e6 814606.0
                     ],
                     width = [
-                        149.178 149.178 149.178;
-                        341.577 666.779 758.764;
-                        492.562 778.794 988.691;
-                        693.057 881.476 1118.98;
-                        789.594 988.161 1237.77;
-                        972.752 1125.52 1448.54;
+                        149.178 149.178 149.178
+                        341.577 666.779 758.764
+                        492.562 778.794 988.691
+                        693.057 881.476 1118.98
+                        789.594 988.161 1237.77
+                        972.752 1125.52 1448.54
                     ],
                     a = [
-                        0.0 0.0 0.0;
-                        170.788 333.389 379.382;
-                        417.07 722.786 873.727;
-                        763.598 1163.52 1433.22;
-                        1158.4 1657.6 2052.1;
-                        1644.77 2220.36 2776.38;
+                        0.0 0.0 0.0
+                        170.788 333.389 379.382
+                        417.07 722.786 873.727
+                        763.598 1163.52 1433.22
+                        1158.4 1657.6 2052.1
+                        1644.77 2220.36 2776.38
                     ],
                     p = [
-                        192.399 517.6 609.585;
-                        193.399 518.6 610.585;
-                        345.384 631.615 841.512;
-                        546.879 735.297 972.803;
-                        644.416 842.983 1092.59;
-                        828.573 981.337 1304.37;
+                        192.399 517.6 609.585
+                        193.399 518.6 610.585
+                        345.384 631.615 841.512
+                        546.879 735.297 972.803
+                        644.416 842.983 1092.59
+                        828.573 981.337 1304.37
                     ],
                 ),
                 mannings_n = [0.072, 0.072, 0.072],
@@ -747,7 +749,7 @@ end
     )
     n_river = 1
     river_flow_model = Wflow.LocalInertialRiverFlowModel(;
-        timestepping = Wflow.TimeStepping(alpha_coefficient = 0.7),
+        timestepping = Wflow.TimeStepping(; alpha_coefficient = 0.7),
         boundary_conditions = Wflow.RiverFlowBC(; n = n_river, reservoir = nothing),
         parameters = Wflow.LocalInertialRiverFlowParameters(;
             n = n_river,

--- a/Wflow/test/routing_process.jl
+++ b/Wflow/test/routing_process.jl
@@ -21,7 +21,7 @@
 end
 
 @testitem "unit: ssf_celerity" begin
-    zi = 0.3
+    water_table_depth = 0.3
     theta_e = 0.274
     slope = 0.00586
     i = 1
@@ -49,7 +49,6 @@ end
 @testitem "kinematic wave overland flow" begin
     using NCDatasets: NCDataset
     using Graphs: topological_sort_by_dfs
-    using BenchmarkTools
 
     dt_sec = 86400.0
     ldd_MISSING_VALUE = 255
@@ -91,9 +90,6 @@ end
     Q = zeros(n)
     # Warm-up call
     Q = Wflow.kin_wave!(Q, graph, toposort, Qold, q, alpha, DCL, dt_sec)
-    # Benchmark
-    b = @benchmark Wflow.kin_wave!($Q, $graph, $toposort, $Qold, $q, $alpha, $DCL, $dt_sec)
-    display(b)
 
     @test sum(Q) ≈ 2.957806043289641e6
     @test Q[toposort[1]] ≈ 0.007260052312634069

--- a/Wflow/test/routing_process.jl
+++ b/Wflow/test/routing_process.jl
@@ -21,7 +21,7 @@
 end
 
 @testitem "unit: ssf_celerity" begin
-    water_table_depth = 0.3
+    zi = 0.3
     theta_e = 0.274
     slope = 0.00586
     i = 1
@@ -88,7 +88,6 @@ end
     alpha = AlpTermR .* P .^ AlpPow
 
     Q = zeros(n)
-    # Warm-up call
     Q = Wflow.kin_wave!(Q, graph, toposort, Qold, q, alpha, DCL, dt_sec)
 
     @test sum(Q) ≈ 2.957806043289641e6

--- a/docs/changelog.qmd
+++ b/docs/changelog.qmd
@@ -35,6 +35,12 @@ subsurface_water__instantaneous_volume_flow_rate = "ssf"
 ### Fixed
 
 ### Changed
+- Improved kinematic wave solver performance by replacing Newton-Raphson with
+  Halley's method, substituting `pow` calls with direct arithmetic on the 5th
+  root of discharge, and computing cross-sectional area as a byproduct of the
+  solve instead of a separate `pow` call. The `beta` parameter has been removed
+  from `ManningFlowParameters` and is now a module-level constant
+  `BETA_KINWAVE` (#898).
 - Drainable porosity or specific yield, defined as the difference between `theta_s`
   (saturated water content) and `theta_fc` (water content at field capacity) is now used to
   compute the change of a falling water table for subsurface flow concepts `LateralSSF` and


### PR DESCRIPTION
## Issue addressed
Fixes https://github.com/Deltares/Wflow.jl/issues/851

## Explanation
I went a different route than I suggested in the issue. The equation being solved per cell per timestep is of the form 

$$
aq + bq^\beta = C,
$$

where it is hardcoded that $\beta = \frac{3}{5}$. This means that via the substitution $u = q^\frac{1}{5}$ the above equation can be reformulated as

$$
au^5 + bu^3 = C;
$$

a polynomial equation which is much cheaper to evaluate. The solution is then found with [Halley's method](https://en.wikipedia.org/wiki/Halley%27s_method) instead of Newton's method for faster convergence. The resulting $u$ can then be used to compute both `q` and the `crossarea`.

Performance comparison on the test data:

```
alpha = 2.586
beta = 0.6
dt = 600.0
dx = 1061.375
q_in = 1.104e-6
q_prev = 0.0
q_lat = 1.142e-6


Original average kinematic_wave time: 225.440 ns
New implementation average time:       54.536 ns 
				                       ~4x speedup
```

Performance on the `sbm_piave` model:

```
Before:
- runtime: 19.2 seconds
- % total run time spend on `kinematic_wave` in `kinwave_river_update!`: 36%

After:
- runtime: 12.5 seconds
- % total run time spend on `kinematic_wave` in `kinwave_river_update!`: 18%
```

An open question is whether we still want to support the general $\beta$ case.