### PR TITLE
Configurable floating point precision

### DIFF
--- a/Wflow/src/Wflow.jl
+++ b/Wflow/src/Wflow.jl
@@ -69,12 +69,28 @@ using Statistics: mean, median, quantile!, quantile
 using TerminalLoggers
 using TOML: TOML
 
-const CFDataset = Union{NCDataset,NCDatasets.MFDataset}
-const CFVariable_MF = Union{NCDatasets.CFVariable,NCDatasets.MFCFVariable}
+const CFDataset = Union{NCDataset, NCDatasets.MFDataset}
+const CFVariable_MF = Union{NCDatasets.CFVariable, NCDatasets.MFCFVariable}
 const VERSION =
     VersionNumber(TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))["version"])
 
-const GRAVITATIONAL_ACCELERATION = 9.80665 # m s⁻²
+const PRECISION = begin
+    precision = get(ENV, "WFLOW_PRECISION", "DOUBLE")
+    if precision == "DOUBLE"
+        Float64
+    elseif precision == "SINGLE"
+        Float32
+    else
+        error("Invalid precision `$precision`, choose from `SINGLE`, `DOUBLE`.")
+    end
+end
+
+to_precision(x::AbstractFloat) = PRECISION(x)
+
+const ZERO = to_precision(0.0)
+const ONE = to_precision(1.0)
+const GRAVITATIONAL_ACCELERATION = to_precision(9.80665) # m s⁻²
+const MISSING_VALUE = to_precision(NaN)
 
 mutable struct Clock{T}
     time::T
@@ -119,15 +135,15 @@ function Clock(config, reader)
     return Clock(starttime, 0, dt)
 end
 
-abstract type AbstractModel{T} end
-abstract type AbstractLandModel end
-abstract type AbstractMassBalance end
-
 # different model types (used for dispatch)
 abstract type AbstractModelType end
 struct SbmModel <: AbstractModelType end         # "sbm" type / sbm_model.jl
 struct SbmGwfModel <: AbstractModelType end      # "sbm_gwf" type / sbm_gwf_model.jl
 struct SedimentModel <: AbstractModelType end    # "sediment" type / sediment_model.jl
+
+abstract type AbstractModel{T <: AbstractModelType} end
+abstract type AbstractLandModel end
+abstract type AbstractMassBalance end
 
 include("units.jl")
 include("config_structure.jl")
@@ -145,13 +161,13 @@ Composite type that represents all different aspects of a Wflow Model, such as t
 parameters, clock, configuration and input and output.
 """
 struct Model{
-    R<:Routing,
-    L<:AbstractLandModel,
-    M<:AbstractMassBalance,
-    T<:AbstractModelType,
+    R <: Routing,
+    L <: AbstractLandModel,
+    M <: AbstractMassBalance,
+    T <: AbstractModelType,
 } <: AbstractModel{T}
     config::Config                  # all configuration options
-    domain::Domain                  # domain connectivity (network) and shared parameters
+    domain::Domain               # domain connectivity (network) and shared parameters
     routing::R                      # routing model (horizontal fluxes), moves along network
     land::L                         # land model simulating vertical fluxes, independent of each other
     mass_balance::M                 # mass balance error
@@ -185,8 +201,6 @@ end
 
 # prevent a large printout of model components and arrays
 Base.show(io::IO, ::AbstractModel{T}) where {T} = print(io, "model of type ", T)
-
-const MISSING_VALUE = Float64(NaN)
 
 include("forcing.jl")
 include("vegetation/parameters.jl")
@@ -267,7 +281,7 @@ This makes it easier to start a run from the command line without having to esca
 
     julia -e "using Wflow; Wflow.run()" "path/to/config.toml"
 """
-function run(tomlpath::AbstractString; silent=nothing)
+function run(tomlpath::AbstractString; silent = nothing)
     config = Config(tomlpath)
     # if the silent kwarg is not set, check if it is set in the TOML
     if isnothing(silent)
@@ -303,7 +317,7 @@ function run(config::Config)
     return model
 end
 
-function run_timestep!(model::Model; update_func=update_model!, write_model_output=true)
+function run_timestep!(model::Model; update_func = update_model!, write_model_output = true)
     (; mass_balance) = model
     advance!(model.clock)
     load_dynamic_input!(model)
@@ -316,7 +330,7 @@ function run_timestep!(model::Model; update_func=update_model!, write_model_outp
     return nothing
 end
 
-function run!(model::Model; close_files=true)
+function run!(model::Model; close_files = true)
     (; config, writer, clock) = model
 
     model_type = config.model.type
@@ -325,7 +339,7 @@ function run!(model::Model; close_files=true)
     starttime = clock.time
     dt = clock.dt
     endtime = cftime(config.time.endtime, config.time.calendar)
-    times = range(starttime + dt, endtime; step=dt)
+    times = range(starttime + dt, endtime; step = dt)
 
     @info "Run information" model_type = String(Symbol(model_type)) starttime dt endtime nthreads()
     runstart_time = now()
@@ -346,7 +360,7 @@ function run!(model::Model; close_files=true)
     # option to support running function twice without re-initializing
     # and thus opening the netCDF files
     if close_files
-        Wflow.close_files(model; delete_output=false)
+        Wflow.close_files(model; delete_output = false)
     end
 
     # copy TOML to dir_output, to archive what settings were used
@@ -355,7 +369,7 @@ function run!(model::Model; close_files=true)
         dst = output_path(config, basename(src))
         if src != dst
             @debug "Copying TOML file." src dst
-            cp(src, dst; force=true)
+            cp(src, dst; force = true)
         end
     end
     return nothing

--- a/Wflow/src/Wflow.jl
+++ b/Wflow/src/Wflow.jl
@@ -86,6 +86,8 @@ const PRECISION = begin
 end
 
 to_precision(x::AbstractFloat) = PRECISION(x)
+to_precision(x::AbstractVector{<:AbstractFloat}) = PRECISION.(x)
+to_precision(x::Any) = x
 
 const ZERO = to_precision(0.0)
 const ONE = to_precision(1.0)

--- a/Wflow/src/bmi.jl
+++ b/Wflow/src/bmi.jl
@@ -48,7 +48,7 @@ function BMI.update(model::Model)
     return nothing
 end
 
-function BMI.update_until(model::Model, time::Float64)
+function BMI.update_until(model::Model, time::PRECISION)
     t = BMI.get_current_time(model)
     _div, _rem = divrem(time - t, model.clock.dt.value)
     steps = Int(_div)
@@ -175,18 +175,18 @@ function BMI.get_current_time(model::Model)
     (; config, clock) = model
     (; starttime, calendar) = config.time
     starttime = cftime(starttime, calendar)
-    return 0.001 * Dates.value(clock.time - starttime)
+    return Dates.value(clock.time - starttime) / 1000
 end
 
 function BMI.get_start_time(::Model)
-    return 0.0
+    return ZERO
 end
 
 function BMI.get_end_time(model::Model)
     (; starttime, endtime, calendar) = model.config.time
     starttime_ = cftime(starttime, calendar)
     endtime_ = cftime(endtime, calendar)
-    return 0.001 * Dates.value(endtime_ - starttime_)
+    return Dates.value(endtime_ - starttime_) / 1000
 end
 
 function BMI.get_time_units(model::Model)
@@ -197,7 +197,7 @@ function BMI.get_time_step(model::Model)
     return model.config.time.timestepsecs
 end
 
-function BMI.get_value(model::Model, name::String, dest::Vector{Float64})
+function BMI.get_value(model::Model, name::String, dest::Vector{PRECISION})
     dest .= copy(BMI.get_value_ptr(model, name))
     return dest
 end
@@ -226,7 +226,7 @@ end
 function BMI.get_value_at_indices(
     model::Model,
     name::String,
-    dest::Vector{Float64},
+    dest::Vector{PRECISION},
     inds::Vector{Int},
 )
     dest .= BMI.get_value_ptr(model, name)[inds]
@@ -234,17 +234,17 @@ function BMI.get_value_at_indices(
 end
 
 """
-    BMI.set_value(model::Model, name::String, src::Vector{Float64})
+    BMI.set_value(model::Model, name::String, src::Vector{PRECISION})
 
 Set a model variable `name` to the values in vector `src`, overwriting the current contents.
 The type and size of `src` must match the model's internal array.
 """
-function BMI.set_value(model::Model, name::String, src::Vector{Float64})
+function BMI.set_value(model::Model, name::String, src::Vector{PRECISION})
     return BMI.get_value_ptr(model, name) .= src
 end
 
 """
-    BMI.set_value_at_indices(model::Model, name::String, inds::Vector{Int}, src::Vector{Float64})
+    BMI.set_value_at_indices(model::Model, name::String, inds::Vector{Int}, src::Vector{PRECISION})
 
     Set a model variable `name` to the values in vector `src`, at indices `inds`.
 """
@@ -252,7 +252,7 @@ function BMI.set_value_at_indices(
     model::Model,
     name::String,
     inds::Vector{Int},
-    src::Vector{Float64},
+    src::Vector{PRECISION},
 )
     return BMI.get_value_ptr(model, name)[inds] .= src
 end
@@ -275,7 +275,7 @@ function BMI.get_grid_rank(model::Model, grid::Int)
     end
 end
 
-function BMI.get_grid_x(model::Model, grid::Int, x::Vector{Float64})
+function BMI.get_grid_x(model::Model, grid::Int, x::Vector{PRECISION})
     (; reader, domain) = model
     (; dataset) = reader
     sel = active_indices(domain, GRIDS[grid])
@@ -285,7 +285,7 @@ function BMI.get_grid_x(model::Model, grid::Int, x::Vector{Float64})
     return x
 end
 
-function BMI.get_grid_y(model::Model, grid::Int, y::Vector{Float64})
+function BMI.get_grid_y(model::Model, grid::Int, y::Vector{PRECISION})
     (; reader, domain) = model
     (; dataset) = reader
     sel = active_indices(domain, GRIDS[grid])

--- a/Wflow/src/config_structure.jl
+++ b/Wflow/src/config_structure.jl
@@ -84,13 +84,13 @@ end
     kinematic_wave__adaptive_time_step_flag::Bool = false
     river_kinematic_wave__time_step::Float64 = 900.0
     land_kinematic_wave__time_step::Float64 = 3600.0
-    subsurface_kinematic_wave__time_step::Float64 = 1.0
-    subsurface_kinematic_wave__alpha_coefficient::Float64 = 1.0
+    subsurface_kinematic_wave__time_step::Float64 = ONE
+    subsurface_kinematic_wave__alpha_coefficient::Float64 = ONE
     river_subsurface_exchange_head_based__flag::Bool = false
     # Local inertial routing
     river_local_inertial_flow__alpha_coefficient::Float64 = 0.7
     land_local_inertial_flow__alpha_coefficient::Float64 = 0.7
-    land_local_inertial_flow__theta_coefficient::Float64 = 1.0
+    land_local_inertial_flow__theta_coefficient::Float64 = ONE
     river_water_flow_threshold__depth = 1e-3
     land_surface_water_flow_threshold__depth = 1e-3
     river_water_flow__froude_limit_flag = true
@@ -130,7 +130,7 @@ end
 @kwdef mutable struct InputEntry <: AbstractConfigSection
     # Option 1
     netcdf_variable_name::Union{Nothing, String} = nothing
-    scale::Vector{Float64} = [1.0]
+    scale::Vector{Float64} = [ONE]
     do_scaling::Bool = !all(isone, scale)
     scale_scalar = isone(length(scale))
     offset::Vector{Float64} = [0.0]

--- a/Wflow/src/config_utils.jl
+++ b/Wflow/src/config_utils.jl
@@ -49,7 +49,7 @@ end
 function Base.show(io::IO, input_entry::InputEntry)
     (; netcdf_variable_name, scale, offset, value, external_name) = input_entry
     if !isnothing(netcdf_variable_name)
-        if scale == [1.0] && offset == [0.0]
+        if scale == [ONE] && offset == [0.0]
             print(io, netcdf_variable_name)
         else
             print(io, netcdf_variable_name * " (scale = $scale, offset = $offset)")

--- a/Wflow/src/demand/water_demand.jl
+++ b/Wflow/src/demand/water_demand.jl
@@ -69,7 +69,7 @@ function NonIrrigationDemandModel(
     demand = PrescribedDemand(; demand_gross, demand_net)
     vars = NonIrrigationDemandVariables(;
         returnflow_fraction = returnflow_f,
-        returnflow = fill(PRECISION(0), n),
+        returnflow = zeros(PRECISION, n),
     )
     non_irrigation_demand = NonIrrigationDemandModel(; demand, variables = vars)
 
@@ -651,13 +651,13 @@ function surface_water_allocation_local!(
                 available_volume = max(available_volume - max_river_abstraction, ZERO)
             end
             # satisfy surface water demand with available local river volume
-            surfacewater_demand_vol = surfacewater_demand[i] * 0.001 * area[i]
+            surfacewater_demand_vol = surfacewater_demand[i] * area[i] / 1000
             abstraction_vol = min(surfacewater_demand_vol, available_volume)
             act_surfacewater_abst_vol[index_river] = abstraction_vol
             # remaining available surface water and demand
             available_surfacewater[index_river] =
                 max(available_volume - abstraction_vol, ZERO)
-            abstraction = (abstraction_vol / area[i]) * 1000.0
+            abstraction = (abstraction_vol / area[i]) * 1000
             surfacewater_demand[i] = max(surfacewater_demand[i] - abstraction, ZERO)
             # update actual abstraction from river and surface water allocation (land cell)
             act_surfacewater_abst[index_river] = abstraction
@@ -718,8 +718,7 @@ function surface_water_allocation_area!(
         for j in inds_river[i]
             act_surfacewater_abst_vol[j] += frac_abstract_sw * available_surfacewater[j]
             act_surfacewater_abst[j] =
-                (act_surfacewater_abst_vol[j] / domain.river.parameters.cell_area[j]) *
-                1000.0
+                (act_surfacewater_abst_vol[j] / domain.river.parameters.cell_area[j]) * 1000
         end
 
         # water allocated to each land cell.
@@ -790,7 +789,7 @@ function groundwater_allocation_local!(
             act_groundwater_abst_vol[i] = abstraction_vol
             # remaining available groundwater and demand
             available_groundwater[i] = max(available_volume - abstraction_vol, ZERO)
-            abstraction = (abstraction_vol / area[i]) * 1000.0
+            abstraction = (abstraction_vol / area[i]) * 1000
             groundwater_demand[i] = max(groundwater_demand[i] - abstraction, ZERO)
             # update actual abstraction from groundwater and groundwater allocation (land cell)
             act_groundwater_abst[i] = abstraction

--- a/Wflow/src/demand/water_demand.jl
+++ b/Wflow/src/demand/water_demand.jl
@@ -18,14 +18,14 @@ end
 
 "Struct to store non-irrigation water demand variables"
 @with_kw struct NonIrrigationDemandVariables
-    returnflow::Vector{Float64}               # return flow [mm Δt⁻¹]
-    returnflow_fraction::Vector{Float64}      # return flow fraction [-]
+    returnflow::Vector{PRECISION}                     # return flow [mm Δt⁻¹]
+    returnflow_fraction::Vector{PRECISION}            # return flow fraction [-]
 end
 
 "Struct to store prescribed water demand variables"
 @with_kw struct PrescribedDemand
-    demand_gross::Vector{Float64}     # gross water demand [mm Δt⁻¹]
-    demand_net::Vector{Float64}       # net water demand [mm Δt⁻¹]
+    demand_gross::Vector{PRECISION}     # gross water demand [mm Δt⁻¹]
+    demand_net::Vector{PRECISION}       # net water demand [mm Δt⁻¹]
 end
 
 "Non-irrigation water demand model"
@@ -36,7 +36,8 @@ end
 
 # wrapper methods
 get_demand_gross(demand_model::NonIrrigationDemandModel) = demand_model.demand.demand_gross
-get_demand_gross(demand_model::NoNonIrrigationDemandModel) = Zeros(demand_model.n)
+get_demand_gross(demand_model::NoNonIrrigationDemandModel) =
+    Zeros{PRECISION}(demand_model.n)
 
 "Initialize non-irrigation water demand model for a water use `sector`"
 function NonIrrigationDemandModel(
@@ -68,7 +69,7 @@ function NonIrrigationDemandModel(
     demand = PrescribedDemand(; demand_gross, demand_net)
     vars = NonIrrigationDemandVariables(;
         returnflow_fraction = returnflow_f,
-        returnflow = fill(Float64(0), n),
+        returnflow = fill(PRECISION(0), n),
     )
     non_irrigation_demand = NonIrrigationDemandModel(; demand, variables = vars)
 
@@ -78,13 +79,13 @@ end
 "Struct to store non-paddy irrigation model variables"
 @with_kw struct NonPaddyVariables
     n::Int
-    demand_gross::Vector{Float64} = fill(MISSING_VALUE, n)     # irrigation gross demand [mm Δt⁻¹]
+    demand_gross::Vector{PRECISION} = fill(MISSING_VALUE, n)     # irrigation gross demand [mm Δt⁻¹]
 end
 
 "Struct to store non-paddy irrigation model parameters"
 @with_kw struct NonPaddyParameters
-    irrigation_efficiency::Vector{Float64}        # irrigation efficiency [-]
-    maximum_irrigation_rate::Vector{Float64}      # maximum irrigation rate [mm Δt⁻¹]
+    irrigation_efficiency::Vector{PRECISION}        # irrigation efficiency [-]
+    maximum_irrigation_rate::Vector{PRECISION}      # maximum irrigation rate [mm Δt⁻¹]
     irrigation_areas::Vector{Bool}          # irrigation areas [-]
     irrigation_trigger::Vector{Bool}        # irrigation on or off [-]
 end
@@ -170,7 +171,7 @@ function update_demand_gross!(nonpaddy_model::NonPaddyModel, soil_model::SbmSoil
 
     for i in eachindex(irrigation_areas)
         if irrigation_areas[i] && irrigation_trigger[i]
-            irri_dem_gross = 0.0
+            irri_dem_gross = ZERO
             for k in 1:n_unsatlayers[i]
                 depletion, readily_available_water =
                     water_demand_root_zone(soil_model, i, k)
@@ -181,14 +182,14 @@ function update_demand_gross!(nonpaddy_model::NonPaddyModel, soil_model::SbmSoil
                     irri_dem_gross += depletion
                     # add depletion to irrigation gross demand when the maximum irrigation rate has been
                     # applied at the previous time step (to get volumetric water content at field capacity)
-                elseif depletion > 0.0 && max_irri_rate_applied # continue irrigation
+                elseif depletion > ZERO && max_irri_rate_applied # continue irrigation
                     irri_dem_gross += depletion
                 end
             end
             demand_gross[i] =
                 compute_demand_gross(nonpaddy_model, soil_model, irri_dem_gross, i)
         else
-            demand_gross[i] = 0.0
+            demand_gross[i] = ZERO
         end
     end
     return nothing
@@ -204,8 +205,10 @@ function water_demand_root_zone(soil_model::SbmSoilModel, i::Int, k::Int)
 
     rootingdepth = get_rootingdepth(soil_model)
 
-    rootfrac =
-        min(1.0, (max(0.0, rootingdepth[i] - sumlayers[i][k]) / ustorelayerthickness[i][k]))
+    rootfrac = min(
+        ONE,
+        (max(ZERO, rootingdepth[i] - sumlayers[i][k]) / ustorelayerthickness[i][k]),
+    )
     # vwc_h3 can be precalculated.
     vwc_h3 = vwc_brooks_corey(h3[i], hb[i], theta_s[i], theta_r[i], c[i][k])
     depletion =
@@ -221,7 +224,7 @@ end
 function compute_demand_gross(
     nonpaddy_model::NonPaddyModel,
     soil_model::SbmSoilModel,
-    irri_dem_gross::Float64,
+    irri_dem_gross::PRECISION,
     i::Int,
 )
     (; pathfrac, infiltcapsoil) = soil_model.parameters
@@ -229,7 +232,7 @@ function compute_demand_gross(
     (; irrigation_efficiency, maximum_irrigation_rate) = nonpaddy_model.parameters
 
     infiltration_capacity =
-        f_infiltration_reduction[i] * (1.0 - pathfrac[i]) * infiltcapsoil[i]
+        f_infiltration_reduction[i] * (ONE - pathfrac[i]) * infiltcapsoil[i]
     irri_dem_gross = min(irri_dem_gross, infiltration_capacity)
     irri_dem_gross /= irrigation_efficiency[i]
     # limit irrigation demand to the maximum irrigation rate
@@ -241,20 +244,20 @@ end
 "Struct to store paddy irrigation model variables"
 @with_kw struct PaddyVariables
     n::Int
-    demand_gross::Vector{Float64} = fill(MISSING_VALUE, n) # irrigation gross demand [mm Δt⁻¹]
-    h::Vector{Float64} = zeros(n)                          # actual water depth in rice field [mm]
-    evaporation::Vector{Float64} = zeros(n)                # evaporation rate [mm Δt⁻¹]
+    demand_gross::Vector{PRECISION} = fill(MISSING_VALUE, n) # irrigation gross demand [mm Δt⁻¹]
+    h::Vector{PRECISION} = zeros(n)                          # actual water depth in rice field [mm]
+    evaporation::Vector{PRECISION} = zeros(n)                # evaporation rate [mm Δt⁻¹]
 end
 
 "Struct to store paddy irrigation model parameters"
 @with_kw struct PaddyParameters
-    irrigation_efficiency::Vector{Float64}        # irrigation efficiency [-]
-    maximum_irrigation_rate::Vector{Float64}      # maximum irrigation rate [mm Δt⁻¹]
+    irrigation_efficiency::Vector{PRECISION}        # irrigation efficiency [-]
+    maximum_irrigation_rate::Vector{PRECISION}      # maximum irrigation rate [mm Δt⁻¹]
     irrigation_areas::Vector{Bool}          # irrigation areas [-]
     irrigation_trigger::Vector{Bool}        # irrigation on or off [-]
-    h_min::Vector{Float64}                        # minimum required water depth in the irrigated rice field [mm]
-    h_opt::Vector{Float64}                        # optimal water depth in the irrigated rice fields [mm]
-    h_max::Vector{Float64}                        # water depth when rice field starts spilling water (overflow) [mm]
+    h_min::Vector{PRECISION}                        # minimum required water depth in the irrigated rice field [mm]
+    h_opt::Vector{PRECISION}                        # optimal water depth in the irrigated rice fields [mm]
+    h_max::Vector{PRECISION}                        # water depth when rice field starts spilling water (overflow) [mm]
 end
 
 "PaddyModel (flooded rice) irrigation model"
@@ -372,7 +375,7 @@ the water depth `h` of the paddy irrigation model for a single timestep.
 function update_runoff!(paddy_model::PaddyModel, runoff)
     for i in eachindex(paddy_model.parameters.irrigation_areas)
         if paddy_model.parameters.irrigation_areas[i]
-            paddy_runoff = max(runoff[i] - paddy_model.parameters.h_max[i], 0.0)
+            paddy_runoff = max(runoff[i] - paddy_model.parameters.h_max[i], ZERO)
             paddy_model.variables.h[i] = runoff[i] - paddy_runoff
             runoff[i] = paddy_runoff
         end
@@ -410,7 +413,7 @@ function update_demand_gross!(paddy_model::PaddyModel)
             irri_dem_gross = min(irri_dem_gross, maximum_irrigation_rate[i])
             demand_gross[i] = irri_dem_gross
         else
-            demand_gross[i] = 0.0
+            demand_gross[i] = ZERO
         end
     end
 end
@@ -427,7 +430,7 @@ function compute_irrigation_depth(paddy_model::PaddyModel, i::Int)
     elseif h[i] < h_opt[i] && max_irri_rate_applied # continue irrigation
         h_opt[i] - h[i]
     else
-        0.0
+        ZERO
     end
 
     return irr_depth_paddy
@@ -438,11 +441,11 @@ update_demand_gross!(::NoIrrigationPaddyModel) = nothing
 "Struct to store water demand model variables"
 @with_kw struct DemandVariables
     n::Int
-    irri_demand_gross::Vector{Float64} = zeros(n)        # irrigation gross demand [mm Δt⁻¹]
-    nonirri_demand_gross::Vector{Float64} = zeros(n)     # non-irrigation gross demand [mm Δt⁻¹]
-    total_gross_demand::Vector{Float64} = zeros(n)       # total gross demand [mm Δt⁻¹]
-    surfacewater_demand::Vector{Float64} = zeros(n)      # demand from surface water [mm Δt⁻¹]
-    groundwater_demand::Vector{Float64} = zeros(n)       # demand from groundwater [mm Δt⁻¹]
+    irri_demand_gross::Vector{PRECISION} = zeros(n)        # irrigation gross demand [mm Δt⁻¹]
+    nonirri_demand_gross::Vector{PRECISION} = zeros(n)     # non-irrigation gross demand [mm Δt⁻¹]
+    total_gross_demand::Vector{PRECISION} = zeros(n)       # total gross demand [mm Δt⁻¹]
+    surfacewater_demand::Vector{PRECISION} = zeros(n)      # demand from surface water [mm Δt⁻¹]
+    groundwater_demand::Vector{PRECISION} = zeros(n)       # demand from groundwater [mm Δt⁻¹]
 end
 
 "Water demand model"
@@ -508,10 +511,10 @@ end
 "Struct to store river allocation model variables"
 @with_kw struct AllocationRiverVariables
     n::Int
-    act_surfacewater_abst::Vector{Float64} = zeros(n)        # actual surface water abstraction [mm Δt⁻¹]
-    act_surfacewater_abst_vol::Vector{Float64} = zeros(n)    # actual surface water abstraction [m³ Δt⁻¹]
-    available_surfacewater::Vector{Float64} = zeros(n)       # available surface water [m³]
-    nonirri_returnflow::Vector{Float64} = zeros(n)           # return flow from non irrigation [mm Δt⁻¹]
+    act_surfacewater_abst::Vector{PRECISION} = zeros(n)        # actual surface water abstraction [mm Δt⁻¹]
+    act_surfacewater_abst_vol::Vector{PRECISION} = zeros(n)    # actual surface water abstraction [m³ Δt⁻¹]
+    available_surfacewater::Vector{PRECISION} = zeros(n)       # available surface water [m³]
+    nonirri_returnflow::Vector{PRECISION} = zeros(n)           # return flow from non irrigation [mm Δt⁻¹]
 end
 
 "River allocation model"
@@ -527,22 +530,22 @@ get_nonirrigation_returnflow(allocation_model::NoAllocationRiverModel) =
 
 "Struct to store land allocation allocation model parameters"
 @with_kw struct AllocationLandParameters
-    frac_sw_used::Vector{Float64}     # fraction surface water used [-]
+    frac_sw_used::Vector{PRECISION}     # fraction surface water used [-]
     areas::Vector{Int}          # allocation areas [-]
 end
 
 "Struct to store land allocation model variables"
 @with_kw struct AllocationLandVariables
     n::Int
-    surfacewater_alloc::Vector{Float64} = zeros(n)           # allocation from surface water [mm Δt⁻¹]
-    act_groundwater_abst::Vector{Float64} = zeros(n)         # actual groundwater abstraction [mm Δt⁻¹]
-    act_groundwater_abst_vol::Vector{Float64} = zeros(n)     # actual groundwater abstraction [m³ Δt⁻¹]
-    available_groundwater::Vector{Float64} = zeros(n)        # available groundwater [m³]
-    groundwater_alloc::Vector{Float64} = zeros(n)            # allocation from groundwater [mm Δt⁻¹]
-    irri_alloc::Vector{Float64} = zeros(n)                   # allocated water for irrigation [mm Δt⁻¹]
-    nonirri_alloc::Vector{Float64} = zeros(n)                # allocated water for non-irrigation [mm Δt⁻¹]
-    total_alloc::Vector{Float64} = zeros(n)                  # total allocated water [mm Δt⁻¹]
-    nonirri_returnflow::Vector{Float64} = zeros(n)           # return flow from non irrigation [mm Δt⁻¹]
+    surfacewater_alloc::Vector{PRECISION} = zeros(n)           # allocation from surface water [mm Δt⁻¹]
+    act_groundwater_abst::Vector{PRECISION} = zeros(n)         # actual groundwater abstraction [mm Δt⁻¹]
+    act_groundwater_abst_vol::Vector{PRECISION} = zeros(n)     # actual groundwater abstraction [m³ Δt⁻¹]
+    available_groundwater::Vector{PRECISION} = zeros(n)        # available groundwater [m³]
+    groundwater_alloc::Vector{PRECISION} = zeros(n)            # allocation from groundwater [mm Δt⁻¹]
+    irri_alloc::Vector{PRECISION} = zeros(n)                   # allocated water for irrigation [mm Δt⁻¹]
+    nonirri_alloc::Vector{PRECISION} = zeros(n)                # allocated water for non-irrigation [mm Δt⁻¹]
+    total_alloc::Vector{PRECISION} = zeros(n)                  # total allocated water [mm Δt⁻¹]
+    nonirri_returnflow::Vector{PRECISION} = zeros(n)           # return flow from non irrigation [mm Δt⁻¹]
 end
 
 "Land allocation model"
@@ -598,9 +601,9 @@ get_groundwater_abstraction_flux(allocation_model::NoAllocationLandModel) =
 Return return flow fraction based on gross water demand `demand_gross` and net water demand
 `demand_net`
 """
-function return_flow_fraction(demand_gross::Float64, demand_net::Float64)
+function return_flow_fraction(demand_gross::PRECISION, demand_net::PRECISION)
     fraction = bounded_divide(demand_net, demand_gross)
-    returnflow_fraction = 1.0 - fraction
+    returnflow_fraction = ONE - fraction
     return returnflow_fraction
 end
 
@@ -624,7 +627,7 @@ function surface_water_allocation_local!(
     demand_variables::DemandVariables,
     river_flow_model::AbstractRiverFlowModel,
     domain::DomainLand,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; surfacewater_alloc) = allocation_model.variables
     (; surfacewater_demand) = demand_variables
@@ -642,10 +645,10 @@ function surface_water_allocation_local!(
             # rivers completely drying out. check for abstraction through negative external
             # inflow first and adjust available volume.
             available_volume = storage[index_river] * 0.80
-            if external_inflow[index_river] < 0.0
+            if external_inflow[index_river] < ZERO
                 max_river_abstraction =
                     min(-external_inflow[index_river] * dt, available_volume)
-                available_volume = max(available_volume - max_river_abstraction, 0.0)
+                available_volume = max(available_volume - max_river_abstraction, ZERO)
             end
             # satisfy surface water demand with available local river volume
             surfacewater_demand_vol = surfacewater_demand[i] * 0.001 * area[i]
@@ -653,9 +656,9 @@ function surface_water_allocation_local!(
             act_surfacewater_abst_vol[index_river] = abstraction_vol
             # remaining available surface water and demand
             available_surfacewater[index_river] =
-                max(available_volume - abstraction_vol, 0.0)
+                max(available_volume - abstraction_vol, ZERO)
             abstraction = (abstraction_vol / area[i]) * 1000.0
-            surfacewater_demand[i] = max(surfacewater_demand[i] - abstraction, 0.0)
+            surfacewater_demand[i] = max(surfacewater_demand[i] - abstraction, ZERO)
             # update actual abstraction from river and surface water allocation (land cell)
             act_surfacewater_abst[index_river] = abstraction
             surfacewater_alloc[i] = abstraction
@@ -673,7 +676,7 @@ function surface_water_allocation_area!(
     demand_variables::DemandVariables,
     river_flow_model::AbstractRiverFlowModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     inds_river = domain.river.network.allocation_area_indices
     inds_land = domain.land.network.allocation_area_indices
@@ -727,13 +730,13 @@ function surface_water_allocation_area!(
 end
 
 function available_surface_water!(
-    available_surfacewater::Vector{Float64},
+    available_surfacewater::Vector{PRECISION},
     reservoir_model,
     indices_river::Vector{Int},
     indices_reservoir::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
-    sw_available = 0.0
+    sw_available = ZERO
     for j in indices_river
         k = indices_reservoir[j]
         if k > 0
@@ -741,11 +744,11 @@ function available_surface_water!(
             # through external negative inflow first and adjust available volume.
             external_inflow = reservoir_model.boundary_conditions.external_inflow[k]
             available_volume = reservoir_model.variables.storage[k] * 0.98
-            if external_inflow < 0.0
+            if external_inflow < ZERO
                 if available_volume > -external_inflow * dt
                     available_volume += external_inflow * dt
                 else
-                    available_volume = 0.0
+                    available_volume = ZERO
                 end
             end
             available_surfacewater[j] = available_volume
@@ -762,7 +765,7 @@ end
 function groundwater_allocation_local!(
     allocation_model::AllocationLandModel,
     demand_variables::DemandVariables,
-    groundwater_storage::Vector{Float64},
+    groundwater_storage::Vector{PRECISION},
     parameters::LandParameters,
 )
     (;
@@ -777,7 +780,7 @@ function groundwater_allocation_local!(
 
     for i in eachindex(groundwater_demand)
         # groundwater demand based on allocation from surface water.
-        groundwater_demand[i] = max(total_gross_demand[i] - surfacewater_alloc[i], 0.0)
+        groundwater_demand[i] = max(total_gross_demand[i] - surfacewater_alloc[i], ZERO)
         # excluding reservoirs
         if !reservoir_coverage[i]
             # satisfy groundwater demand with available local groundwater volume
@@ -786,9 +789,9 @@ function groundwater_allocation_local!(
             abstraction_vol = min(groundwater_demand_vol, available_volume)
             act_groundwater_abst_vol[i] = abstraction_vol
             # remaining available groundwater and demand
-            available_groundwater[i] = max(available_volume - abstraction_vol, 0.0)
+            available_groundwater[i] = max(available_volume - abstraction_vol, ZERO)
             abstraction = (abstraction_vol / area[i]) * 1000.0
-            groundwater_demand[i] = max(groundwater_demand[i] - abstraction, 0.0)
+            groundwater_demand[i] = max(groundwater_demand[i] - abstraction, ZERO)
             # update actual abstraction from groundwater and groundwater allocation (land cell)
             act_groundwater_abst[i] = abstraction
             groundwater_alloc[i] = abstraction
@@ -822,8 +825,8 @@ function groundwater_allocation_area!(
     # loop over allocation areas
     for i in eachindex(inds_river)
         # groundwater demand and availability (allocation area)
-        gw_demand_vol = 0.0
-        gw_available = 0.0
+        gw_demand_vol = ZERO
+        gw_available = ZERO
         for j in inds_land[i]
             gw_demand_vol += groundwater_demand[j] * 0.001 * area[j]
             gw_available += available_groundwater[j]
@@ -851,8 +854,8 @@ end
 "Return and update non-irrigation sector (domestic, livestock, industry) return flow"
 function return_flow(
     demand_model::NonIrrigationDemandModel,
-    nonirri_demand_gross::Vector{Float64},
-    nonirri_alloc::Vector{Float64},
+    nonirri_demand_gross::Vector{PRECISION},
+    nonirri_alloc::Vector{PRECISION},
 )
     for i in eachindex(demand_model.variables.returnflow)
         frac = bounded_divide(demand_model.demand.demand_gross[i], nonirri_demand_gross[i])
@@ -866,9 +869,9 @@ end
 # return zero (return flow) if non-irrigation sector is not defined
 return_flow(
     demand_model::NoNonIrrigationDemandModel,
-    nonirri_demand_gross::Vector{Float64},
-    nonirri_alloc::Vector{Float64},
-) = 0.0
+    nonirri_demand_gross::Vector{PRECISION},
+    nonirri_alloc::Vector{PRECISION},
+) = ZERO
 
 """
     update_water_allocation_model!(
@@ -876,7 +879,7 @@ return_flow(
     demand_model::DemandModel,
     routing::Routing,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
 
 Update water allocation for the land domain `AllocationLandModel` and water allocation for the
@@ -892,7 +895,7 @@ function update_water_allocation_model!(
     demand_model::DemandModel,
     routing::Routing,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     river = routing.river_flow
     inds_river = domain.land.network.river_inds_excl_reservoir
@@ -915,9 +918,9 @@ function update_water_allocation_model!(
     (; act_surfacewater_abst, act_surfacewater_abst_vol) = river.allocation.variables
     (; abstraction, reservoir) = river.boundary_conditions
 
-    surfacewater_alloc .= 0.0
-    act_surfacewater_abst .= 0.0
-    act_surfacewater_abst_vol .= 0.0
+    surfacewater_alloc .= ZERO
+    act_surfacewater_abst .= ZERO
+    act_surfacewater_abst_vol .= ZERO
     # total surface water demand for each land cell
     @. surfacewater_demand =
         frac_sw_used * nonirri_demand_gross + frac_sw_used * irri_demand_gross
@@ -944,7 +947,7 @@ function update_water_allocation_model!(
     # for reservoir locations set river abstraction at zero and abstract volume
     # from reservoir, including an update of waterlevel
     if !isnothing(reservoir)
-        @. abstraction[inds_reservoir] = 0.0
+        @. abstraction[inds_reservoir] = ZERO
         @. reservoir.variables.storage -= act_surfacewater_abst_vol[inds_reservoir]
         @. reservoir.variables.waterlevel = waterlevel(
             reservoir.parameters.storfunc,
@@ -954,9 +957,9 @@ function update_water_allocation_model!(
         )
     end
 
-    groundwater_alloc .= 0.0
-    act_groundwater_abst_vol .= 0.0
-    act_groundwater_abst .= 0.0
+    groundwater_alloc .= ZERO
+    act_groundwater_abst_vol .= ZERO
+    act_groundwater_abst .= ZERO
     # local groundwater demand and allocation
     groundwater_allocation_local!(
         allocation_model,
@@ -986,10 +989,10 @@ function update_water_allocation_model!(
     @. nonirri_returnflow = returnflow_livestock + returnflow_domestic + returnflow_industry
 
     for i in eachindex(nonirri_returnflow)
-        if inds_river[i] > 0.0
+        if inds_river[i] > ZERO
             k = inds_river[i]
             river.allocation.variables.nonirri_returnflow[k] = nonirri_returnflow[i]
-            nonirri_returnflow[i] = 0.0
+            nonirri_returnflow[i] = ZERO
         else
             nonirri_returnflow[i] = nonirri_returnflow[i]
         end
@@ -1001,7 +1004,7 @@ update_water_allocation_model!(
     demand_model::NoDemandModel,
     routing::Routing,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 ) = nothing
 
 """

--- a/Wflow/src/domain.jl
+++ b/Wflow/src/domain.jl
@@ -321,7 +321,7 @@ function get_river_fraction(
         river_fraction[i] = if river_location[i]
             min((river_length[i] * river_width[i]) / (area[i]), ONE)
         else
-            0.0
+            ZERO
         end
     end
     return river_fraction

--- a/Wflow/src/domain.jl
+++ b/Wflow/src/domain.jl
@@ -1,21 +1,21 @@
 "Struct to store (shared) land parameters"
 @with_kw struct LandParameters
     # cell length x direction [m]
-    x_length::Vector{Float64} = Float64[]
+    x_length::Vector{PRECISION} = PRECISION[]
     # cell length y direction [m]
-    y_length::Vector{Float64} = Float64[]
+    y_length::Vector{PRECISION} = PRECISION[]
     # cell area [m²]
-    area::Vector{Float64} = Float64[]
+    area::Vector{PRECISION} = PRECISION[]
     # flow width [m]
-    flow_width::Vector{Float64} = Float64[]
+    flow_width::Vector{PRECISION} = PRECISION[]
     # surface flow width [m]
-    surface_flow_width::Vector{Float64} = Float64[]
+    surface_flow_width::Vector{PRECISION} = PRECISION[]
     # flow length [m]
-    flow_length::Vector{Float64} = Float64[]
+    flow_length::Vector{PRECISION} = PRECISION[]
     # flow fraction to river [-]
-    flow_fraction_to_river::Vector{Float64} = Float64[]
+    flow_fraction_to_river::Vector{PRECISION} = PRECISION[]
     # slope [-]
-    slope::Vector{Float64} = Float64[]
+    slope::Vector{PRECISION} = PRECISION[]
     # reservoir location [-]
     reservoir_outlet::Vector{Bool} = Bool[]
     # reservoir coverage [-]
@@ -23,25 +23,25 @@
     # river location [-]
     river_location::Vector{Bool} = Bool[]
     # fraction of river [-]
-    river_fraction::Vector{Float64} = Float64[]
+    river_fraction::Vector{PRECISION} = PRECISION[]
     # fraction of open water (excluding rivers) [-]
-    water_fraction::Vector{Float64} = Float64[]
+    water_fraction::Vector{PRECISION} = PRECISION[]
 end
 
 "Struct to store (shared) river parameters"
 @with_kw struct RiverParameters
     # river flow width [m]
-    flow_width::Vector{Float64} = Float64[]
+    flow_width::Vector{PRECISION} = PRECISION[]
     # river flow length [m]
-    flow_length::Vector{Float64} = Float64[]
+    flow_length::Vector{PRECISION} = PRECISION[]
     # slope [-]
-    slope::Vector{Float64} = Float64[]
+    slope::Vector{PRECISION} = PRECISION[]
     # reservoir location
     reservoir_outlet::Vector{Bool} = Bool[]
     # reservoir coverage [-]
     reservoir_coverage::Vector{Bool} = Bool[]
     # grid cell area [m²]
-    cell_area::Vector{Float64} = Float64[]
+    cell_area::Vector{PRECISION} = PRECISION[]
 end
 
 @kwdef struct DomainLand
@@ -77,7 +77,7 @@ each domain that can used by different model components.
 end
 
 "Initialize `Domain` for model types `sbm` and `sbm_gwf`"
-function Domain(dataset::NCDataset, config::Config, ::Union{SbmModel,SbmGwfModel})
+function Domain(dataset::NCDataset, config::Config, ::Union{SbmModel, SbmGwfModel})
     (; land_routing, river_routing) = config.model
 
     network_land = NetworkLand(dataset, config)
@@ -87,7 +87,7 @@ function Domain(dataset::NCDataset, config::Config, ::Union{SbmModel,SbmGwfModel
     end
 
     network_river =
-        NetworkRiver(dataset, config, network_land; do_pits=config.model.pit__flag)
+        NetworkRiver(dataset, config, network_land; do_pits = config.model.pit__flag)
     if river_routing == RoutingType.kinematic_wave
         network_river = network_subdomains(config, network_river)
     end
@@ -125,13 +125,13 @@ function Domain(dataset::NCDataset, config::Config, ::Union{SbmModel,SbmGwfModel
             network_river.reverse_indices[network_land.indices]
     end
 
-    domain_land = DomainLand(; network=network_land)
-    domain_river = DomainRiver(; network=network_river)
+    domain_land = DomainLand(; network = network_land)
+    domain_river = DomainRiver(; network = network_river)
 
     domain = Domain(;
-        land=domain_land,
-        river=domain_river,
-        reservoir=DomainReservoir(; network=network_reservoir),
+        land = domain_land,
+        river = domain_river,
+        reservoir = DomainReservoir(; network = network_reservoir),
     )
 
     land_params, river_params = initialize_shared_parameters(dataset, config, domain)
@@ -176,10 +176,10 @@ function Domain(dataset::NCDataset, config::Config, ::SedimentModel)
     network_land = NetworkLand(dataset, config)
     network_river = NetworkRiver(dataset, config, network_land)
 
-    domain_land = DomainLand(; network=network_land)
-    domain_river = DomainRiver(; network=network_river)
+    domain_land = DomainLand(; network = network_land)
+    domain_river = DomainRiver(; network = network_river)
 
-    domain = Domain(; land=domain_land, river=domain_river)
+    domain = Domain(; land = domain_land, river = domain_river)
 
     land_params, river_params = initialize_shared_parameters(dataset, config, domain)
     @reset domain.land.parameters = land_params
@@ -193,7 +193,7 @@ function LandParameters(dataset::NCDataset, config::Config, network::NetworkLand
     flow_width = map(get_flow_width, network.local_drain_direction, x_length, y_length)
     slope = get_landsurface_slope(dataset, config, network)
     reservoir_outlet = reservoir_mask(dataset, config, network)
-    reservoir_coverage = reservoir_mask(dataset, config, network; region="area")
+    reservoir_coverage = reservoir_mask(dataset, config, network; region = "area")
     river_location = river_mask(dataset, config, network)
 
     land_parameters = LandParameters(;
@@ -221,7 +221,7 @@ function LandParameters(dataset::NCDataset, config::Config, domain::Domain)
 
     water_fraction = get_water_fraction(dataset, config, network, river_fraction)
 
-    land_area = @. (1.0 - river_fraction) * area
+    land_area = @. (ONE - river_fraction) * area
     surface_flow_width =
         map(get_surface_width, flow_width, flow_length, land_area, river_location)
 
@@ -233,7 +233,7 @@ function LandParameters(dataset::NCDataset, config::Config, domain::Domain)
     )
 
     reservoir_outlet = reservoir_mask(dataset, config, network)
-    reservoir_coverage = reservoir_mask(dataset, config, network; region="area")
+    reservoir_coverage = reservoir_mask(dataset, config, network; region = "area")
 
     land_parameters = LandParameters(;
         x_length,
@@ -256,13 +256,13 @@ end
 "Initialize (shared) river parameters"
 function RiverParameters(dataset::NCDataset, config::Config, network::NetworkRiver)
     (; indices) = network
-    flow_length = ncread(dataset, config, "river__length", Routing; sel=indices)
+    flow_length = ncread(dataset, config, "river__length", Routing; sel = indices)
     minimum(flow_length) > 0 || error("river length must be positive on river cells")
 
-    flow_width = ncread(dataset, config, "river__width", Routing; sel=indices)
+    flow_width = ncread(dataset, config, "river__width", Routing; sel = indices)
     minimum(flow_width) > 0 || error("river width must be positive on river cells")
 
-    slope = ncread(dataset, config, "river__slope", Routing; sel=indices)
+    slope = ncread(dataset, config, "river__slope", Routing; sel = indices)
     clamp!(slope, 0.00001, Inf)
 
     river_parameters = RiverParameters(; flow_width, flow_length, slope)
@@ -288,16 +288,16 @@ function get_water_fraction(
     dataset::NCDataset,
     config::Config,
     network::NetworkLand,
-    river_fraction::Vector{Float64},
+    river_fraction::Vector{<:AbstractFloat},
 )
     water_fraction = ncread(
         dataset,
         config,
         "land_water_covered__area_fraction",
         LandHydrologySBM;
-        sel=network.indices,
+        sel = network.indices,
     )
-    water_fraction = max.(water_fraction .- river_fraction, 0.0)
+    water_fraction = max.(water_fraction .- river_fraction, ZERO)
     return water_fraction
 end
 
@@ -307,19 +307,19 @@ function get_river_fraction(
     config::Config,
     network::NetworkLand,
     river_location::Vector{Bool},
-    area::Vector{Float64},
+    area::Vector{<:AbstractFloat},
 )
-    river_width_2d = ncread(dataset, config, "river__width", Routing; logging=false)
+    river_width_2d = ncread(dataset, config, "river__width", Routing; logging = false)
     river_width = river_width_2d[network.indices]
 
-    river_length_2d = ncread(dataset, config, "river__length", Routing; logging=false)
+    river_length_2d = ncread(dataset, config, "river__length", Routing; logging = false)
     river_length = river_length_2d[network.indices]
 
     n = length(river_location)
     river_fraction = fill(MISSING_VALUE, n)
     for i in 1:n
         river_fraction[i] = if river_location[i]
-            min((river_length[i] * river_width[i]) / (area[i]), 1.0)
+            min((river_length[i] * river_width[i]) / (area[i]), ONE)
         else
             0.0
         end
@@ -331,7 +331,7 @@ end
 function get_cell_lengths(dataset::NCDataset, config::Config, network::NetworkLand)
     y_coords = read_y_axis(dataset)
     x_coords = read_x_axis(dataset)
-    y = permutedims(repeat(y_coords; outer=(1, length(x_coords))))[network.indices]
+    y = permutedims(repeat(y_coords; outer = (1, length(x_coords))))[network.indices]
     celllength = abs(mean(diff(x_coords)))
 
     x_length, y_length =
@@ -341,7 +341,7 @@ end
 
 "Return land surface slope"
 function get_landsurface_slope(dataset::NCDataset, config::Config, network::NetworkLand)
-    slope = ncread(dataset, config, "land_surface__slope", Routing; sel=network.indices)
+    slope = ncread(dataset, config, "land_surface__slope", Routing; sel = network.indices)
     clamp!(slope, 0.00001, Inf)
     return slope
 end
@@ -358,7 +358,7 @@ function reservoir_mask(
     dataset::NCDataset,
     config::Config,
     network::NetworkLand;
-    region::String="location",
+    region::String = "location",
 )
     reservoirs = fill(0, length(network.indices))
     if config.model.reservoir__flag
@@ -367,7 +367,7 @@ function reservoir_mask(
             config,
             "reservoir_$(region)__count",
             Routing;
-            sel=network.indices,
+            sel = network.indices,
         )
         replace!(x -> ismissing(x) ? 0 : x, reservoirs)
     end
@@ -392,8 +392,8 @@ function get_allocation_area_indices(dataset::NCDataset, config::Config, domain:
         config,
         "land_water_allocation_area__count",
         Domain;
-        sel=indices,
-        logging=false,
+        sel = indices,
+        logging = false,
     )
     unique_areas = unique(areas)
     allocation_area_inds = Vector{Int}[]

--- a/Wflow/src/erosion.jl
+++ b/Wflow/src/erosion.jl
@@ -50,7 +50,7 @@ end
 function update_soil_loss_model!(
     soil_loss_model::SoilLossModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (;
         atmospheric_forcing,

--- a/Wflow/src/forcing.jl
+++ b/Wflow/src/forcing.jl
@@ -2,24 +2,24 @@
 @with_kw struct AtmosphericForcing
     n::Int
     # Precipitation [mm Δt⁻¹]
-    precipitation::Vector{Float64} = fill(MISSING_VALUE, n)
+    precipitation::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Potential reference evapotranspiration [mm Δt⁻¹]
-    potential_evaporation::Vector{Float64} = fill(MISSING_VALUE, n)
+    potential_evaporation::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Temperature [ᵒC]
-    temperature::Vector{Float64} = fill(MISSING_VALUE, n)
+    temperature::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store hydrological forcing variables"
 @with_kw struct HydrologicalForcing
     n::Int
     # Rainfall interception by the vegetation [mm]
-    interception::Vector{Float64} = fill(MISSING_VALUE, n)
+    interception::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Overland flow depth [m]
-    waterlevel_land::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel_land::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Overland flow discharge [m3 s-1]
-    q_land::Vector{Float64} = fill(MISSING_VALUE, n)
+    q_land::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # River depth [m]
-    waterlevel_river::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel_river::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # River discharge [m3 s-1]
-    q_river::Vector{Float64} = fill(MISSING_VALUE, n)
+    q_river::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end

--- a/Wflow/src/glacier/glacier.jl
+++ b/Wflow/src/glacier/glacier.jl
@@ -4,9 +4,9 @@ abstract type AbstractGlacierModel end
 @with_kw struct GlacierVariables
     n::Int
     # Water within the glacier [mm]
-    glacier_store::Vector{Float64}
+    glacier_store::Vector{PRECISION}
     # Glacier melt [mm Δt⁻¹]
-    glacier_melt::Vector{Float64} = fill(MISSING_VALUE, n)
+    glacier_melt::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Initialize glacier model variables"
@@ -30,21 +30,21 @@ end
 "Struct for storing boundary condition (snow storage from a snow model) of a glacier model"
 @with_kw struct SnowStateBC
     # Snow storage [mm]
-    snow_storage::Vector{Float64}
+    snow_storage::Vector{PRECISION}
 end
 
 "Struct for storing glacier HBV model parameters"
 @with_kw struct GlacierHbvParameters
     # Threshold temperature for glacier melt [ᵒC]
-    g_ttm::Vector{Float64}
+    g_ttm::Vector{PRECISION}
     # Degree-day factor [mm ᵒC⁻¹ Δt⁻¹] for glacier
-    g_cfmax::Vector{Float64}
+    g_cfmax::Vector{PRECISION}
     # Fraction of the snowpack on top of the glacier converted into ice [Δt⁻¹]
-    g_sifrac::Vector{Float64}
+    g_sifrac::Vector{PRECISION}
     # Fraction covered by a glacier [-]
-    glacier_frac::Vector{Float64}
+    glacier_frac::Vector{PRECISION}
     # Maximum snow to glacier conversion rate [mm Δt⁻¹]
-    max_snow_to_glacier::Float64
+    max_snow_to_glacier::PRECISION
 end
 
 "Glacier HBV model"

--- a/Wflow/src/glacier/glacier_process.jl
+++ b/Wflow/src/glacier/glacier_process.jl
@@ -36,10 +36,10 @@ function glacier_hbv(
 )
 
     # Fraction of the snow transformed into ice (HBV-light model)
-    snow_to_glacier = if glacier_frac > 0.0
+    snow_to_glacier = if glacier_frac > ZERO
         g_sifrac * snow_storage
     else
-        0.0
+        ZERO
     end
 
     # Restrict snow_to_glacier conversion
@@ -49,10 +49,10 @@ function glacier_hbv(
     glacier_store += snow_to_glacier
 
     # Potential snow melt, based on temperature
-    potential_melt = temperature > ttm ? cfmax * (temperature - ttm) : 0.0
+    potential_melt = temperature > ttm ? cfmax * (temperature - ttm) : ZERO
 
     # actual Glacier melt
-    glacier_melt = snow_storage < 10.0 ? min(potential_melt, glacier_store) : 0.0
+    glacier_melt = snow_storage < 10.0 ? min(potential_melt, glacier_store) : ZERO
     glacier_store -= glacier_melt
 
     return snow_storage, snow_to_glacier, glacier_store, glacier_melt

--- a/Wflow/src/io.jl
+++ b/Wflow/src/io.jl
@@ -246,7 +246,7 @@ function setup_scalar_netcdf(
     defVar(
         ds,
         "time",
-        Float64,
+        PRECISION,
         ("time",);
         attrib = ["units" => time_units, "calendar" => convert(String, calendar)],
     )
@@ -307,10 +307,10 @@ function set_extradim_netcdf(
     extra_dim::NamedTuple{
         (:name, :value),
         Tuple{String, Vector{T}},
-    } where {T <: Union{String, Float64}},
+    } where {T <: Union{String, PRECISION}},
 )
     # the axis attribute `Z` is required to import this type of 3D data by Delft-FEWS the
-    # values of this dimension `extra_dim.value` should be of type Float64
+    # values of this dimension `extra_dim.value` should be of type PRECISION
     if extra_dim.name == "layer"
         attributes =
             ["long_name" => "layer_index", "standard_name" => "layer_index", "axis" => "Z"]
@@ -395,7 +395,7 @@ function setup_grid_netcdf(
     defVar(
         ds,
         "time",
-        Float64,
+        PRECISION,
         ("time",);
         attrib = ["units" => time_units, "calendar" => convert(String, calendar)],
         deflatelevel,
@@ -742,7 +742,7 @@ function Writer(config, modelmap, domain, nc_static; extra_dim = nothing)
             config.time.time_units,
             extra_dim,
             config.model.cell_length_in_meter__flag;
-            float_type = Float64,
+            float_type = PRECISION,
         )
     else
         ds_outstate = nothing
@@ -856,7 +856,7 @@ function write_netcdf_timestep(model, dataset, parameters)
 
     time_index = add_time(dataset, clock.time)
 
-    buffer = zeros(Union{Float64, Missing}, domain.land.network.modelsize)
+    buffer = zeros(Union{PRECISION, Missing}, domain.land.network.modelsize)
     for (key, val) in parameters
         (; par, vector) = val
         sel = active_indices(domain, par)
@@ -1118,7 +1118,7 @@ end
 
 "Read a rating curve from CSV into a NamedTuple of vectors"
 function read_sh_csv(path)
-    data, header = readdlm(path, ',', Float64; header = true)
+    data, header = readdlm(path, ',', PRECISION; header = true)
     names = vec(uppercase.(header))
     idx_h = findfirst(==("H"), names)
     idx_s = findfirst(==("S"), names)
@@ -1132,14 +1132,14 @@ end
 
 "Read a specific storage curve from CSV into a NamedTuple of vectors"
 function read_hq_csv(path)
-    data = readdlm(path, ',', Float64; skipstart = 1)
+    data = readdlm(path, ',', PRECISION; skipstart = 1)
     # Q is a matrix with 365 columns, one for each day in the year
     return (H = data[:, 1], Q = data[:, 2:366])
 end
 
 # these represent the type of the rating curve and specific storage data
-const SH = NamedTuple{(:H, :S), Tuple{Vector{Float64}, Vector{Float64}}}
-const HQ = NamedTuple{(:H, :Q), Tuple{Vector{Float64}, Matrix{Float64}}}
+const SH = NamedTuple{(:H, :S), Tuple{Vector{PRECISION}, Vector{PRECISION}}}
+const HQ = NamedTuple{(:H, :Q), Tuple{Vector{PRECISION}, Matrix{PRECISION}}}
 
 is_increasing(v) = last(v) > first(v)
 
@@ -1345,14 +1345,14 @@ end
 """
     read_x_axis(ds::CFDataset)
 
-Return the x coordinate Vector{Float64}, whether it is called x, lon or longitude.
+Return the x coordinate Vector{PRECISION}, whether it is called x, lon or longitude.
 Also sorts the vector to be increasing, to match `read_standardized`.
 """
-function read_x_axis(ds::CFDataset)::Vector{Float64}
+function read_x_axis(ds::CFDataset)::Vector{PRECISION}
     candidates = ("x", "lon", "longitude")
     for candidate in candidates
         if haskey(ds.dim, candidate)
-            return sort!(Float64.(ds[candidate][:]))
+            return sort!(PRECISION.(ds[candidate][:]))
         end
     end
     return error("no x axis found in $(path(ds))")
@@ -1361,14 +1361,14 @@ end
 """
     read_y_axis(ds::CFDataset)
 
-Return the y coordinate Vector{Float64}, whether it is called y, lat or latitude.
+Return the y coordinate Vector{PRECISION}, whether it is called y, lat or latitude.
 Also sorts the vector to be increasing, to match `read_standardized`.
 """
-function read_y_axis(ds::CFDataset)::Vector{Float64}
+function read_y_axis(ds::CFDataset)::Vector{PRECISION}
     candidates = ("y", "lat", "latitude")
     for candidate in candidates
         if haskey(ds.dim, candidate)
-            return sort!(Float64.(ds[candidate][:]))
+            return sort!(PRECISION.(ds[candidate][:]))
         end
     end
     return error("no y axis found in $(path(ds))")

--- a/Wflow/src/mass_balance.jl
+++ b/Wflow/src/mass_balance.jl
@@ -7,9 +7,9 @@ time step `storage_prev` required for mass balance computation.
 """
 @with_kw struct MassBalance <: AbstractMassBalance
     n::Int # number of cells/nodes
-    storage_prev::Vector{Float64} = zeros(n)
-    error::Vector{Float64} = zeros(n)
-    relative_error::Vector{Float64} = zeros(n)
+    storage_prev::Vector{PRECISION} = zeros(n)
+    error::Vector{PRECISION} = zeros(n)
+    relative_error::Vector{PRECISION} = zeros(n)
 end
 
 function MassBalance(::AbstractSubsurfaceFlowModel, n::Int)
@@ -82,13 +82,13 @@ end
 
 "Compute mass balance error and relative error."
 function compute_mass_balance_error(
-    total_in::Float64,
-    total_out::Float64,
-    storage_rate::Float64,
+    total_in::PRECISION,
+    total_out::PRECISION,
+    storage_rate::PRECISION,
 )
     error = total_in - total_out - storage_rate
-    average_flow_rate = (total_in + total_out) / 2.0
-    relative_error = iszero(average_flow_rate) ? 0.0 : error / average_flow_rate
+    average_flow_rate = (total_in + total_out) / 2
+    relative_error = iszero(average_flow_rate) ? ZERO : error / average_flow_rate
     return error, relative_error
 end
 
@@ -258,15 +258,15 @@ function compute_land_hydrology_balance!(
 end
 
 """
-    compute_flow_balance!(reservoir_model::ReservoirModel, water_balance::MassBalance, dt::Float64)
-    compute_flow_balance!(reservoir_model::Nothing, water_balance::NoMassBalance, dt::Float64)
+    compute_flow_balance!(reservoir_model::ReservoirModel, water_balance::MassBalance, dt::PRECISION)
+    compute_flow_balance!(reservoir_model::Nothing, water_balance::NoMassBalance, dt::PRECISION)
 
 Compute reservoir water mass balance error and relative error if reservoirs are included.
 """
 function compute_flow_balance!(
     reservoir_model::ReservoirModel,
     water_balance::MassBalance,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; storage_prev, error, relative_error) = water_balance
     (; storage, outflow_av, actevap) = reservoir_model.variables
@@ -283,15 +283,18 @@ function compute_flow_balance!(
     return nothing
 end
 
-compute_flow_balance!(reservoir_model::Nothing, water_balance::NoMassBalance, dt::Float64) =
-    nothing
+compute_flow_balance!(
+    reservoir_model::Nothing,
+    water_balance::NoMassBalance,
+    dt::PRECISION,
+) = nothing
 
 "Compute water mass balance error and relative error for river kinematic wave routing."
 function compute_flow_balance!(
     river_flow_model::KinWaveRiverFlowModel,
     water_balance::MassBalance,
     network::NetworkRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; storage_prev, error, relative_error) = water_balance
     (; inwater, external_inflow, actual_external_abstraction_av, abstraction) =
@@ -316,7 +319,7 @@ function compute_flow_balance!(
     river_flow_model::LocalInertialRiverFlowModel,
     water_balance::MassBalance,
     network::NetworkRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; storage_prev, error, relative_error) = water_balance
     (; inwater, external_inflow, actual_external_abstraction_av, abstraction) =
@@ -324,11 +327,11 @@ function compute_flow_balance!(
     (; edges_at_node) = network
 
     for i in river_flow_model.parameters.active_n
-        total_in = 0.0
-        total_out = 0.0
+        total_in = ZERO
+        total_out = ZERO
         q_src = sum_at(river_flow_model.variables.q_av, edges_at_node.src[i])
         total_in, total_out = add_inflow(total_in, total_out, [q_src, inwater[i]])
-        total_in += max(0.0, external_inflow[i])
+        total_in += max(ZERO, external_inflow[i])
         q_dst = sum_at(river_flow_model.variables.q_av, edges_at_node.dst[i])
         total_in, total_out = add_outflow(total_in, total_out, q_dst)
         total_out += actual_external_abstraction_av[i] + abstraction[i]
@@ -346,7 +349,7 @@ end
 "Helper function to add `inflow` to incoming flow `qin` or outgoing flow `qout`"
 function add_inflow(qin, qout, inflow)
     for q in inflow
-        if q > 0.0
+        if q > ZERO
             qin += q
         else
             qout -= q
@@ -358,7 +361,7 @@ end
 "Helper function to add `outflow` to incoming flow `qin` or outgoing flow `qout`"
 function add_outflow(qin, qout, outflow)
     for q in outflow
-        if q > 0.0
+        if q > ZERO
             qout += q
         else
             qin -= q
@@ -374,7 +377,7 @@ routing.
 function compute_flow_balance!(
     overland_flow_model::KinWaveOverlandFlowModel,
     water_balance::MassBalance,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; storage_prev, error, relative_error) = water_balance
     (; inwater) = overland_flow_model.boundary_conditions
@@ -400,7 +403,7 @@ function compute_flow_balance!(
     overland_flow_model::LocalInertialOverlandFlowModel,
     water_balance::MassBalance,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     indices = domain.land.network.edge_indices
     inds_river = domain.land.network.river_indices
@@ -415,8 +418,8 @@ function compute_flow_balance!(
     for i in 1:(overland_flow_model.parameters.n)
         yd = indices.yd[i]
         xd = indices.xd[i]
-        total_in = 0.0
-        total_out = 0.0
+        total_in = ZERO
+        total_out = ZERO
         total_in, total_out =
             add_inflow(total_in, total_out, [qx_av[xd], qy_av[yd], runoff[i]])
         total_in, total_out = add_outflow(total_in, total_out, [qx_av[i], qy_av[i]])
@@ -425,7 +428,7 @@ function compute_flow_balance!(
             k = inds_river[i]
             q_src = sum_at(river_flow_model.variables.q_av, edges_at_node.src[k])
             total_in, total_out = add_inflow(total_in, total_out, q_src)
-            total_in += max(0.0, external_inflow[k])
+            total_in += max(ZERO, external_inflow[k])
             q_dst = sum_at(river_flow_model.variables.q_av, edges_at_node.dst[k])
             total_in, total_out = add_outflow(total_in, total_out, q_dst)
             total_out += actual_external_abstraction_av[k] + abstraction[k]
@@ -443,8 +446,8 @@ function constant_head_boundary_error!(
     (; error, relative_error) = water_balance
 
     index_const_head = model.constanthead.index
-    error[index_const_head] .= 0.0
-    relative_error[index_const_head] .= 0.0
+    error[index_const_head] .= ZERO
+    relative_error[index_const_head] .= ZERO
     return nothing
 end
 
@@ -455,7 +458,7 @@ function compute_flow_balance!(
     subsurface_flow_model::AbstractSubsurfaceFlowModel,
     water_balance::MassBalance,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; error, relative_error) = water_balance
     (; q_in_av, q_av, q_net_av) = subsurface_flow_model.variables

--- a/Wflow/src/network.jl
+++ b/Wflow/src/network.jl
@@ -350,7 +350,7 @@ function NetworkDrain(
     dataset::NCDataset,
     config::Config,
     indices::Vector{CartesianIndex{2}},
-    surface_flow_width::Vector{Float64},
+    surface_flow_width::Vector{PRECISION},
 )
     n_cells = length(indices)
     drain_2d = ncread(dataset, config, "land_drain_location__mask", Routing)
@@ -359,7 +359,7 @@ function NetworkDrain(
     # check if drain occurs where overland flow is not possible (surface_flow_width = 0.0)
     # and correct if this is the case
     false_drain =
-        filter(i -> !isequal(drain[i], 0) && surface_flow_width[i] == 0.0, 1:n_cells)
+        filter(i -> !isequal(drain[i], 0) && iszero(surface_flow_width[i]), 1:n_cells)
     n_false_drain = length(false_drain)
     if n_false_drain > 0
         drain_2d[indices[false_drain]] .= 0

--- a/Wflow/src/routing/subsurface/boundary_conditions.jl
+++ b/Wflow/src/routing/subsurface/boundary_conditions.jl
@@ -1,4 +1,8 @@
-function check_flux(flux::Float64, subsurface_flow_model::GroundwaterFlowModel, index::Int)
+function check_flux(
+    flux::PRECISION,
+    subsurface_flow_model::GroundwaterFlowModel,
+    index::Int,
+)
     # Check if cell is dry
     if subsurface_flow_model.variables.head[index] <=
        subsurface_flow_model.parameters.bottom[index]
@@ -9,7 +13,7 @@ function check_flux(flux::Float64, subsurface_flow_model::GroundwaterFlowModel, 
     end
 end
 
-function check_flux(flux::Float64, subsurface_flow_model::LateralSSFModel, index::Int)
+function check_flux(flux::PRECISION, subsurface_flow_model::LateralSSFModel, index::Int)
     # Check if cell is dry
     if subsurface_flow_model.variables.zi[index] >=
        subsurface_flow_model.parameters.soilthickness[index]
@@ -21,17 +25,17 @@ function check_flux(flux::Float64, subsurface_flow_model::LateralSSFModel, index
 end
 
 @with_kw struct GwfRiverParameters
-    infiltration_conductance::Vector{Float64} # [m² d⁻¹]
-    exfiltration_conductance::Vector{Float64} # [m² d⁻¹]
-    bottom::Vector{Float64} # [m]
+    infiltration_conductance::Vector{PRECISION} # [m² d⁻¹]
+    exfiltration_conductance::Vector{PRECISION} # [m² d⁻¹]
+    bottom::Vector{PRECISION} # [m]
 end
 
 @with_kw struct GwfRiverVariables
     n::Int
-    stage::Vector{Float64} = fill(MISSING_VALUE, n) # [m]
-    storage::Vector{Float64} = fill(MISSING_VALUE, n) # [m³]
-    flux::Vector{Float64} = fill(MISSING_VALUE, n)  # [m³ d⁻¹]
-    flux_av::Vector{Float64} = fill(MISSING_VALUE, n)  # [m³ d⁻¹]
+    stage::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m]
+    storage::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m³]
+    flux::Vector{PRECISION} = fill(MISSING_VALUE, n)  # [m³ d⁻¹]
+    flux_av::Vector{PRECISION} = fill(MISSING_VALUE, n)  # [m³ d⁻¹]
 end
 
 @with_kw struct GwfRiverModel <: AbstractSubsurfaceFlowBC
@@ -49,22 +53,16 @@ function GwfRiverModel(
         config,
         "river_water__infiltration_conductance",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     exfiltration_conductance = ncread(
         dataset,
         config,
         "river_water__exfiltration_conductance",
         Routing;
-        sel=indices,
+        sel = indices,
     )
-    bottom = ncread(
-        dataset,
-        config,
-        "river_bottom__elevation",
-        Routing;
-        sel=indices,
-    )
+    bottom = ncread(dataset, config, "river_bottom__elevation", Routing; sel = indices)
 
     parameters =
         GwfRiverParameters(infiltration_conductance, exfiltration_conductance, bottom)
@@ -78,7 +76,7 @@ function flux!(
     gwf_river_model::GwfRiverModel,
     subsurface_flow_model::AbstractSubsurfaceFlowModel,
     indices::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
     for (i, index) in enumerate(indices)
         head = subsurface_flow_model.variables.head[index]
@@ -102,14 +100,14 @@ function flux!(
 end
 
 @with_kw struct DrainageParameters
-    elevation::Vector{Float64} # [m]
-    conductance::Vector{Float64} # [m² d⁻¹]
+    elevation::Vector{PRECISION} # [m]
+    conductance::Vector{PRECISION} # [m² d⁻¹]
 end
 
 @with_kw struct DrainageVariables
     n::Int
-    flux::Vector{Float64} = fill(MISSING_VALUE, n) # [m³ d⁻¹]
-    flux_av::Vector{Float64} = fill(MISSING_VALUE, n) # [m³ d⁻¹]
+    flux::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m³ d⁻¹]
+    flux_av::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m³ d⁻¹]
 end
 
 @with_kw struct DrainageModel <: AbstractSubsurfaceFlowBC
@@ -122,20 +120,8 @@ function DrainageModel(
     config::Config,
     indices::Vector{CartesianIndex{2}},
 )
-    elevation = ncread(
-        dataset,
-        config,
-        "land_drain__elevation",
-        Routing;
-        sel=indices,
-    )
-    conductance = ncread(
-        dataset,
-        config,
-        "land_drain__conductance",
-        Routing;
-        sel=indices,
-    )
+    elevation = ncread(dataset, config, "land_drain__elevation", Routing; sel = indices)
+    conductance = ncread(dataset, config, "land_drain__conductance", Routing; sel = indices)
     parameters = DrainageParameters(; elevation, conductance)
     n = length(indices)
     variables = DrainageVariables(; n)
@@ -148,7 +134,7 @@ function flux!(
     drainage_model::DrainageModel,
     subsurface_flow_model::AbstractSubsurfaceFlowModel,
     indices::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
     for (i, index) in enumerate(indices)
         cond = drainage_model.parameters.conductance[i]
@@ -166,13 +152,13 @@ function flux!(
 end
 
 @with_kw struct HeadBoundaryParameters
-    conductance::Vector{Float64} # [m² d⁻¹]
+    conductance::Vector{PRECISION} # [m² d⁻¹]
 end
 
 @with_kw struct HeadBoundaryVariables
-    head::Vector{Float64} # [m]
-    flux::Vector{Float64} # [m³ d⁻¹]
-    flux_av::Vector{Float64} # [m³ d⁻¹]
+    head::Vector{PRECISION} # [m]
+    flux::Vector{PRECISION} # [m³ d⁻¹]
+    flux_av::Vector{PRECISION} # [m³ d⁻¹]
 end
 
 @with_kw struct HeadBoundary <: AbstractSubsurfaceFlowBC
@@ -184,7 +170,7 @@ function flux!(
     headboundary::HeadBoundary,
     subsurface_flow_model::GroundwaterFlowModel,
     indices::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
     for (i, index) in enumerate(indices)
         cond = headboundary.parameters.conductance[i]
@@ -200,9 +186,9 @@ end
 
 @with_kw struct RechargeVariables
     n::Int
-    rate::Vector{Float64} = fill(MISSING_VALUE, n) # [m d⁻¹]
-    flux::Vector{Float64} = zeros(n) # [m³ d⁻¹]
-    flux_av::Vector{Float64} = zeros(n) # [m³ d⁻¹]
+    rate::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m d⁻¹]
+    flux::Vector{PRECISION} = zeros(n) # [m³ d⁻¹]
+    flux_av::Vector{PRECISION} = zeros(n) # [m³ d⁻¹]
 end
 
 @with_kw struct RechargeModel <: AbstractSubsurfaceFlowBC
@@ -214,7 +200,7 @@ function flux!(
     recharge_model::RechargeModel,
     subsurface_flow_model::AbstractSubsurfaceFlowModel,
     indices::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
     for (i, index) in enumerate(indices)
         flux = check_flux(
@@ -230,9 +216,9 @@ function flux!(
 end
 
 @with_kw struct WellVariables
-    volumetric_rate::Vector{Float64} # [m³ d⁻¹]
-    flux::Vector{Float64} # [m³ d⁻¹]
-    flux_av::Vector{Float64} # [m³ d⁻¹]
+    volumetric_rate::Vector{PRECISION} # [m³ d⁻¹]
+    flux::Vector{PRECISION} # [m³ d⁻¹]
+    flux_av::Vector{PRECISION} # [m³ d⁻¹]
 end
 
 @with_kw struct WellModel <: AbstractSubsurfaceFlowBC
@@ -243,7 +229,7 @@ function flux!(
     well_model::WellModel,
     subsurface_flow_model::GroundwaterFlowModel,
     indices::Vector{Int},
-    dt::Float64,
+    dt::PRECISION,
 )
     for (i, index) in enumerate(indices)
         flux = check_flux(
@@ -275,7 +261,7 @@ update_river_storage_stage!(
     river_flow_model::AbstractRiverFlowModel,
 ) = nothing
 
-flux!(::Nothing, ::AbstractSubsurfaceFlowModel, ::Vector{Int}, ::Float64) = nothing
+flux!(::Nothing, ::AbstractSubsurfaceFlowModel, ::Vector{Int}, ::PRECISION) = nothing
 
 get_boundary_index(::RechargeModel, domain::Domain) = domain.land.network.land_indices
 get_boundary_index(::GwfRiverModel, domain::Domain) = domain.river.network.land_indices

--- a/Wflow/src/routing/subsurface/connectivity.jl
+++ b/Wflow/src/routing/subsurface/connectivity.jl
@@ -22,9 +22,9 @@ non-zero values).
 struct Connectivity
     ncell::Int
     nconnection::Int
-    length1::Vector{Float64}
-    length2::Vector{Float64}
-    width::Vector{Float64}
+    length1::Vector{PRECISION}
+    length2::Vector{PRECISION}
+    width::Vector{PRECISION}
     colptr::Vector{Int}
     rowval::Vector{Int}
 end
@@ -69,8 +69,8 @@ const NEIGHBORS = (
 function Connectivity(
     indices::Vector{CartesianIndex{2}},
     reverse_indices::Matrix{Int},
-    dx::Vector{Float64},
-    dy::Vector{Float64},
+    dx::Vector{PRECISION},
+    dy::Vector{PRECISION},
 )
     # indices: These map from the 1D internal domain to the 2D external domain.
     # reverse_indices: from the 2D external domain to the 1D internal domain,
@@ -80,9 +80,9 @@ function Connectivity(
     ncell = length(indices)
     colptr = Vector{Int}(undef, ncell + 1)
     rowval = Vector{Int}(undef, ncell * 4)
-    length1 = similar(rowval, Float64)
-    length2 = similar(rowval, Float64)
-    width = similar(rowval, Float64)
+    length1 = similar(rowval, PRECISION)
+    length2 = similar(rowval, PRECISION)
+    width = similar(rowval, PRECISION)
 
     i = 1  # column index of sparse matrix
     j = 1  # row index of sparse matrix

--- a/Wflow/src/routing/subsurface/groundwater.jl
+++ b/Wflow/src/routing/subsurface/groundwater.jl
@@ -230,7 +230,7 @@ function GroundwaterFlowModel(
     connectivity = Connectivity(indices, reverse_indices, x_length, y_length)
 
     # cold state for groundwater head based on water table depth zi
-    initial_head = elevation .- soil.variables.zi / 1000.0
+    initial_head = elevation .- soil.variables.zi / 1000
     initial_head[river.network.land_indices] = elevation[river.network.land_indices]
     if config.model.constanthead__flag
         initial_head[constanthead.index] = constanthead.variables.head
@@ -248,7 +248,7 @@ function GroundwaterFlowModel(
         (; theta_s, theta_r, soilthickness, soilwatercapacity, sumlayers, act_thickl) =
             soil.parameters
 
-        @. zi = (elevation - min(elevation, initial_head)) * 1000.0
+        @. zi = (elevation - min(elevation, initial_head)) * 1000
         @. satwaterdepth = (soilthickness - zi) * (theta_s - theta_r)
         @. ustorecapacity = soilwatercapacity - satwaterdepth
         @. ustorelayerthickness = set_layerthickness(zi, sumlayers, act_thickl)
@@ -256,10 +256,10 @@ function GroundwaterFlowModel(
         @. total_soilwater_storage = satwaterdepth
     end
 
-    bottom = elevation .- soil.parameters.soilthickness ./ 1000.0
+    bottom = elevation .- soil.parameters.soilthickness ./ 1000
     specific_yield =
         @. lower_bound_drainable_porosity(soil.parameters.theta_s, soil.parameters.theta_fc)
-    conductance = zeros(connectivity.nconnection)
+    conductance = zeros(PRECISION, connectivity.nconnection)
     parameters = GroundwaterFlowParameters(
         dataset,
         config,

--- a/Wflow/src/routing/subsurface/groundwater.jl
+++ b/Wflow/src/routing/subsurface/groundwater.jl
@@ -73,24 +73,24 @@ instead.
 
 @with_kw struct GroundwaterFlowVariables
     n::Int
-    head::Vector{Float64}                          # hydraulic head [m]
-    conductance::Vector{Float64}                   # conductance [m² d⁻¹]
-    storage::Vector{Float64}                       # total storage of water that can be released [m³]
-    q_net::Vector{Float64} = zeros(n)              # net flow (groundwater and boundaries) [m³ d⁻¹]
-    q_net_av::Vector{Float64} = zeros(n)           # average net flow (groundwater and boundaries) [m³ d⁻¹]
-    q_net_bnds::Vector{Float64} = zeros(n)         # net flow boundaries [m³ d⁻¹]
-    q_in_av::Vector{Float64} = zeros(n)            # average groundwater (lateral) inflow for model timestep Δt [m³ d⁻¹]
-    q_av::Vector{Float64} = zeros(n)               # average groundwater (lateral) outflow for model timestep Δt [m³ d⁻¹]
-    exfiltwater::Vector{Float64} = zeros(n)        # Exfiltration [m Δt⁻¹] (groundwater above surface level, saturated excess conditions)
+    head::Vector{PRECISION}                          # hydraulic head [m]
+    conductance::Vector{PRECISION}                   # conductance [m² d⁻¹]
+    storage::Vector{PRECISION}                       # total storage of water that can be released [m³]
+    q_net::Vector{PRECISION} = zeros(n)              # net flow (groundwater and boundaries) [m³ d⁻¹]
+    q_net_av::Vector{PRECISION} = zeros(n)           # average net flow (groundwater and boundaries) [m³ d⁻¹]
+    q_net_bnds::Vector{PRECISION} = zeros(n)         # net flow boundaries [m³ d⁻¹]
+    q_in_av::Vector{PRECISION} = zeros(n)            # average groundwater (lateral) inflow for model timestep Δt [m³ d⁻¹]
+    q_av::Vector{PRECISION} = zeros(n)               # average groundwater (lateral) outflow for model timestep Δt [m³ d⁻¹]
+    exfiltwater::Vector{PRECISION} = zeros(n)        # Exfiltration [m Δt⁻¹] (groundwater above surface level, saturated excess conditions)
 end
 
 @with_kw struct GroundwaterFlowParameters
-    k::Vector{Float64}                  # reference horizontal conductivity [m d⁻¹]
-    top::Vector{Float64}                # top of groundwater layer [m]
-    bottom::Vector{Float64}             # bottom of groundwater layer [m]
-    area::Vector{Float64}               # area of cell [m²]
-    specific_yield::Vector{Float64}     # specific yield (theta_s - theta_fc) [m m⁻¹]
-    f::Vector{Float64}                  # factor controlling the reduction of reference horizontal conductivity [-]
+    k::Vector{PRECISION}                  # reference horizontal conductivity [m d⁻¹]
+    top::Vector{PRECISION}                # top of groundwater layer [m]
+    bottom::Vector{PRECISION}             # bottom of groundwater layer [m]
+    area::Vector{PRECISION}               # area of cell [m²]
+    specific_yield::Vector{PRECISION}     # specific yield (theta_s - theta_fc) [m m⁻¹]
+    f::Vector{PRECISION}                  # factor controlling the reduction of reference horizontal conductivity [-]
     # Unconfined aquifer conductance is computed with degree of saturation (only when
     # conductivity_profile is set to "exponential")
 end
@@ -99,17 +99,17 @@ function GroundwaterFlowParameters(
     dataset::NCDataset,
     config::Config,
     indices::Vector{CartesianIndex{2}},
-    top::Vector{Float64},
-    bottom::Vector{Float64},
-    area::Vector{Float64},
-    specific_yield::Vector{Float64},
+    top::Vector{PRECISION},
+    bottom::Vector{PRECISION},
+    area::Vector{PRECISION},
+    specific_yield::Vector{PRECISION},
 )
     k = ncread(
         dataset,
         config,
         "subsurface_surface_water__horizontal_saturated_hydraulic_conductivity",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     if config.model.conductivity_profile == GwfConductivityProfileType.exponential
         f = ncread(
@@ -117,17 +117,17 @@ function GroundwaterFlowParameters(
             config,
             "subsurface__horizontal_saturated_hydraulic_conductivity_scale_parameter",
             Routing;
-            sel=indices,
+            sel = indices,
         )
     else
-        f = Float64[]
+        f = PRECISION[]
     end
     parameters = GroundwaterFlowParameters(; k, top, bottom, area, specific_yield, f)
     return parameters
 end
 
 @with_kw struct ConstantHeadVariables
-    head::Vector{Float64} # [m]
+    head::Vector{PRECISION} # [m]
 end
 
 @with_kw struct ConstantHead
@@ -145,21 +145,21 @@ function ConstantHead(
         config,
         "model_constant_boundary_condition__hydraulic_head",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     n = length(indices)
     index_constanthead = filter(i -> !isequal(constanthead[i], MISSING_VALUE), 1:n)
     head = constanthead[index_constanthead]
     variables = ConstantHeadVariables(head)
-    constant_head = ConstantHead(; variables, index=index_constanthead)
+    constant_head = ConstantHead(; variables, index = index_constanthead)
     return constant_head
 end
 
 @kwdef struct SubsurfaceFlowBC{
-    Re<:Union{Nothing,AbstractSubsurfaceFlowBC},
-    Ri<:Union{Nothing,AbstractSubsurfaceFlowBC},
-    D<:Union{Nothing,AbstractSubsurfaceFlowBC},
-    W<:Union{Nothing,AbstractSubsurfaceFlowBC},
+    Re <: Union{Nothing, AbstractSubsurfaceFlowBC},
+    Ri <: Union{Nothing, AbstractSubsurfaceFlowBC},
+    D <: Union{Nothing, AbstractSubsurfaceFlowBC},
+    W <: Union{Nothing, AbstractSubsurfaceFlowBC},
 }
     recharge::Re = nothing
     river::Ri = nothing
@@ -174,7 +174,7 @@ get_boundaries(boundary_conditions::SubsurfaceFlowBC) = (
     boundary_conditions.well,
 )
 
-@kwdef struct GroundwaterFlowModel{B<:SubsurfaceFlowBC} <: AbstractSubsurfaceFlowModel
+@kwdef struct GroundwaterFlowModel{B <: SubsurfaceFlowBC} <: AbstractSubsurfaceFlowModel
     timestepping::TimeStepping
     parameters::GroundwaterFlowParameters
     variables::GroundwaterFlowVariables
@@ -188,7 +188,7 @@ get_boundaries(boundary_conditions::SubsurfaceFlowBC) = (
         connectivity::Connectivity,
         constanthead::ConstantHead,
         boundary_conditions::B,
-    ) where {B<:SubsurfaceFlowBC}
+    ) where {B <: SubsurfaceFlowBC}
         initialize_conductance!(parameters, variables, connectivity)
         new{B}(
             timestepping,
@@ -217,20 +217,14 @@ function GroundwaterFlowModel(
 
     n_cells = length(indices)
 
-    elevation = ncread(
-        dataset,
-        config,
-        "land_surface__elevation",
-        Routing;
-        sel=indices,
-    )
+    elevation = ncread(dataset, config, "land_surface__elevation", Routing; sel = indices)
 
     # unconfined aquifer
     if config.model.constanthead__flag
         constanthead = ConstantHead(dataset, config, indices)
     else
-        variables = ConstantHeadVariables(; head=Float64[])
-        constanthead = ConstantHead(; variables, index=Int64[])
+        variables = ConstantHeadVariables(; head = PRECISION[])
+        constanthead = ConstantHead(; variables, index = Int64[])
     end
 
     connectivity = Connectivity(indices, reverse_indices, x_length, y_length)
@@ -277,24 +271,25 @@ function GroundwaterFlowModel(
     )
     storage = @. (min(elevation, initial_head) - bottom) * area * parameters.specific_yield
     n = length(storage)
-    variables = GroundwaterFlowVariables(; n, head=initial_head, conductance, storage)
+    variables = GroundwaterFlowVariables(; n, head = initial_head, conductance, storage)
 
     # river boundary of unconfined aquifer
     gwf_river_model = GwfRiverModel(dataset, config, river.network.indices)
 
     # recharge boundary of unconfined aquifer
-    recharge_model = RechargeModel(; n=n_cells)
+    recharge_model = RechargeModel(; n = n_cells)
 
     # drain boundary of unconfined aquifer (optional)
     if config.model.drain__flag
         drainage_model = DrainageModel(dataset, config, drain.network.indices)
         boundary_conditions = SubsurfaceFlowBC(;
-            recharge=recharge_model,
-            river=gwf_river_model,
-            drain=drainage_model,
+            recharge = recharge_model,
+            river = gwf_river_model,
+            drain = drainage_model,
         )
     else
-        boundary_conditions = SubsurfaceFlowBC(; recharge=recharge_model, river=gwf_river_model)
+        boundary_conditions =
+            SubsurfaceFlowBC(; recharge = recharge_model, river = gwf_river_model)
     end
 
     alpha_coefficient = config.model.subsurface_water_flow__alpha_coefficient
@@ -327,10 +322,10 @@ Refer to:
     Water-resources investigations report, 92, 4124.
 """
 function harmonicmean_conductance(kH1, kH2, l1, l2, width)
-    if (kH1 * kH2) > 0.0
+    if (kH1 * kH2) > ZERO
         return width * kH1 * kH2 / (kH1 * l2 + kH2 * l1)
     else
-        return 0.0
+        return ZERO
     end
 end
 
@@ -372,7 +367,7 @@ end
 """
     initialize_conductance!(parameters::GroundwaterFlowParameters, variables::GroundwaterFlowVariables, connectivity::Connectivity)
 
-Conductance is computed per timestep by multiplying by degree of saturation [0.0 - 1.0].
+Conductance is computed per timestep by multiplying by degree of saturation ∈ [0.0, 1.0].
 """
 function initialize_conductance!(
     parameters::GroundwaterFlowParameters,
@@ -461,7 +456,7 @@ end
 function flux!(
     gwf::GroundwaterFlowModel,
     conductivity_profile::GwfConductivityProfileType.T,
-    dt::Float64,
+    dt::PRECISION,
 )
     for i in 1:(gwf.connectivity.ncell)
         # Loop over connections for cell j
@@ -472,7 +467,7 @@ function flux!(
             cond = conductance(gwf, i, j, nzi, conductivity_profile)
             flow = cond * delta_head
             gwf.variables.q_net[i] -= flow
-            if flow > 0.0
+            if flow > ZERO
                 gwf.variables.q_av[i] += flow * dt
             else
                 gwf.variables.q_in_av[i] -= flow * dt
@@ -483,7 +478,7 @@ function flux!(
 end
 
 """
-    stable_timestep(gwf::GroundwaterFlowModel, conductivity_profile::GwfConductivityProfileType.T, alpha_coefficient::Float64)
+    stable_timestep(gwf::GroundwaterFlowModel, conductivity_profile::GwfConductivityProfileType.T, alpha_coefficient::PRECISION)
 
 Compute a stable timestep size given the forward-in-time, central in space scheme.
 The following criterion can be found in Chu & Willis (1984):
@@ -493,7 +488,7 @@ The following criterion can be found in Chu & Willis (1984):
 function stable_timestep(
     gwf::GroundwaterFlowModel,
     conductivity_profile::GwfConductivityProfileType.T,
-    alpha_coefficient::Float64,
+    alpha_coefficient::PRECISION,
 )
     dt_min = Inf
     for i in eachindex(gwf.variables.head)
@@ -521,7 +516,7 @@ function update_fluxes!(
     gwf::GroundwaterFlowModel,
     domain::Domain,
     conductivity_profile::GwfConductivityProfileType.T,
-    dt::Float64,
+    dt::PRECISION,
 )
     flux!(gwf, conductivity_profile, dt)
     for bc in get_boundaries(gwf.boundary_conditions)
@@ -533,7 +528,7 @@ function update_fluxes!(
     return nothing
 end
 
-function update_head!(gwf::GroundwaterFlowModel, soil::SbmSoilModel, dt::Float64)
+function update_head!(gwf::GroundwaterFlowModel, soil::SbmSoilModel, dt::PRECISION)
     (; head, exfiltwater, q_net) = gwf.variables
     (; area, specific_yield) = gwf.parameters
 
@@ -548,7 +543,7 @@ function update_head!(gwf::GroundwaterFlowModel, soil::SbmSoilModel, dt::Float64
     # Make sure no heads ends up below an unconfined aquifer bottom
     gwf.variables.head .= minimum_head(gwf)
     # Adjust exfiltration rate for constant head boundaries
-    exfiltwater[gwf.constanthead.index] .= 0.0
+    exfiltwater[gwf.constanthead.index] .= ZERO
     gwf.variables.storage .=
         saturated_thickness(gwf) .* gwf.parameters.area .* storativity(gwf)
     return nothing
@@ -556,27 +551,27 @@ end
 
 function set_flux_vars_bc!(gwf::AbstractSubsurfaceFlowModel)
     for bc in get_boundaries(gwf.boundary_conditions)
-        !isnothing(bc) && (bc.variables.flux_av .= 0.0)
+        !isnothing(bc) && (bc.variables.flux_av .= ZERO)
     end
     return nothing
 end
 
 function set_flux_vars!(gwf::AbstractSubsurfaceFlowModel)
     set_flux_vars_bc!(gwf)
-    gwf.variables.exfiltwater .= 0.0
-    gwf.variables.q_in_av .= 0.0
-    gwf.variables.q_av .= 0.0
-    gwf.variables.q_net_av .= 0.0
+    gwf.variables.exfiltwater .= ZERO
+    gwf.variables.q_in_av .= ZERO
+    gwf.variables.q_av .= ZERO
+    gwf.variables.q_net_av .= ZERO
     return nothing
 end
 
-function average_flux_vars_bc!(gwf::AbstractSubsurfaceFlowModel, dt::Float64)
+function average_flux_vars_bc!(gwf::AbstractSubsurfaceFlowModel, dt::PRECISION)
     for bc in get_boundaries(gwf.boundary_conditions)
         !isnothing(bc) && (bc.variables.flux_av ./= dt)
     end
 end
 
-function average_flux_vars!(gwf::AbstractSubsurfaceFlowModel, dt::Float64)
+function average_flux_vars!(gwf::AbstractSubsurfaceFlowModel, dt::PRECISION)
     average_flux_vars_bc!(gwf, dt)
     gwf.variables.q_in_av ./= dt
     gwf.variables.q_av ./= dt
@@ -588,16 +583,16 @@ function update_subsurface_flow_model!(
     gwf_model::GroundwaterFlowModel,
     soil_model::SbmSoilModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
     conductivity_profile::GwfConductivityProfileType.T,
 )
     (; alpha_coefficient) = gwf_model.timestepping
 
     set_flux_vars!(gwf_model)
-    t = 0.0
+    t = ZERO
     while t < dt
-        gwf_model.variables.q_net .= 0.0
-        gwf_model.variables.q_net_bnds .= 0.0
+        gwf_model.variables.q_net .= ZERO
+        gwf_model.variables.q_net_bnds .= ZERO
         dt_s = stable_timestep(gwf_model, conductivity_profile, alpha_coefficient)
         dt_s = check_timestepsize(dt_s, t, dt)
         update_fluxes!(gwf_model, domain, conductivity_profile, dt_s)
@@ -621,7 +616,7 @@ end
 function sum_boundary_fluxes(
     gwf_model::AbstractSubsurfaceFlowModel,
     domain::Domain;
-    exclude=nothing,
+    exclude = nothing,
 )
     (; boundary_conditions) = gwf_model
     n = length(gwf_model.variables.storage)
@@ -633,7 +628,7 @@ function sum_boundary_fluxes(
         indices = get_boundary_index(bc, domain)
         for (i, index) in enumerate(indices)
             flux = bc.variables.flux_av[i]
-            if flux > 0.0
+            if flux > ZERO
                 flux_in[index] += flux
             else
                 flux_out[index] -= flux

--- a/Wflow/src/routing/subsurface/lateral_subsurface_flow.jl
+++ b/Wflow/src/routing/subsurface/lateral_subsurface_flow.jl
@@ -73,20 +73,20 @@ function LateralSsfParameters(
     )
 
     (; theta_s, theta_fc, soilthickness) = soil
-    soilthickness = soilthickness .* 0.001
+    soilthickness = soilthickness / 1000
 
     kh_profile_type = config.model.saturated_hydraulic_conductivity_profile
     factor_dt = BASETIMESTEP / Second(config.time.timestepsecs)
     if kh_profile_type == VerticalConductivityProfile.exponential
         (; kv_0, f) = soil.kv_profile
-        kh_0 = khfrac .* kv_0 .* 0.001 .* factor_dt
-        kh_profile = KhExponential(kh_0, f .* 1000.0)
+        kh_0 = khfrac .* kv_0 .* factor_dt / 1000
+        kh_profile = KhExponential(kh_0, f .* 1000)
     elseif kh_profile_type == VerticalConductivityProfile.exponential_constant
         (; z_exp) = soil.kv_profile
         (; kv_0, f) = soil.kv_profile.exponential
         kh_0 = khfrac .* kv_0 .* 0.001 .* factor_dt
-        exp_profile = KhExponential(kh_0, f .* 1000.0)
-        kh_profile = KhExponentialConstant(exp_profile, z_exp .* 0.001)
+        exp_profile = KhExponential(kh_0, f .* 1000)
+        kh_profile = KhExponentialConstant(exp_profile, z_exp ./ 1000)
     elseif kh_profile_type == VerticalConductivityProfile.layered ||
            kh_profile_type == VerticalConductivityProfile.layered_exponential
         n_cells = length(khfrac)
@@ -126,7 +126,7 @@ function LateralSSFModel(
     n = length(indices)
     timestepping = init_kinematic_wave_timestepping(config, n; domain = "subsurface")
     parameters = LateralSsfParameters(dataset, config, indices, soil.parameters, area)
-    zi = 0.001 * soil.variables.zi
+    zi = soil.variables.zi / 1000
     variables = LateralSsfVariables(parameters, zi)
     recharge = RechargeModel(; n)
     if config.model.river_subsurface_exchange_head_based__flag

--- a/Wflow/src/routing/subsurface/lateral_subsurface_flow.jl
+++ b/Wflow/src/routing/subsurface/lateral_subsurface_flow.jl
@@ -1,32 +1,32 @@
 "Struct for storing lateral subsurface flow model variables"
 @with_kw struct LateralSsfVariables
     n::Int
-    zi::Vector{Float64}                                     # Pseudo-water table depth [m] (top of the saturated zone)
-    head::Vector{Float64}                                   # Hydraulic head [m]
-    exfiltwater::Vector{Float64} = fill(MISSING_VALUE, n)   # Exfiltration [m Δt⁻¹] (groundwater above surface level, saturated excess conditions)
-    q::Vector{Float64} = fill(MISSING_VALUE, n)             # Subsurface flow [m³ d⁻¹]
-    q_av::Vector{Float64} = fill(MISSING_VALUE, n)          # Average subsurface flow [m³ d⁻¹] for model timestep Δt
-    q_in::Vector{Float64} = fill(MISSING_VALUE, n)          # Inflow from upstream cells [m³ d⁻¹]
-    q_in_av::Vector{Float64} = fill(MISSING_VALUE, n)       # Average inflow from upstream cells [m³ d⁻¹] for model timestep Δt
-    q_max::Vector{Float64} = fill(MISSING_VALUE, n)         # Maximum subsurface flow [m² d⁻¹]
-    to_river::Vector{Float64} = fill(MISSING_VALUE, n)      # Part of subsurface flow [m³ d⁻¹] that flows to the river
-    q_net_bnds::Vector{Float64} = fill(MISSING_VALUE, n)    # Net flow for boundaries subsurface flow [m³ d⁻¹]
-    q_net_av::Vector{Float64} = fill(MISSING_VALUE, n)      # Average net flow (total) [m³ d⁻¹]
-    storage::Vector{Float64}                                # Subsurface storage that can be released [m³]
+    zi::Vector{PRECISION}                                     # Pseudo-water table depth [m] (top of the saturated zone)
+    head::Vector{PRECISION}                                   # Hydraulic head [m]
+    exfiltwater::Vector{PRECISION} = fill(MISSING_VALUE, n)   # Exfiltration [m Δt⁻¹] (groundwater above surface level, saturated excess conditions)
+    q::Vector{PRECISION} = fill(MISSING_VALUE, n)             # Subsurface flow [m³ d⁻¹]
+    q_av::Vector{PRECISION} = fill(MISSING_VALUE, n)          # Average subsurface flow [m³ d⁻¹] for model timestep Δt
+    q_in::Vector{PRECISION} = fill(MISSING_VALUE, n)          # Inflow from upstream cells [m³ d⁻¹]
+    q_in_av::Vector{PRECISION} = fill(MISSING_VALUE, n)       # Average inflow from upstream cells [m³ d⁻¹] for model timestep Δt
+    q_max::Vector{PRECISION} = fill(MISSING_VALUE, n)         # Maximum subsurface flow [m² d⁻¹]
+    to_river::Vector{PRECISION} = fill(MISSING_VALUE, n)      # Part of subsurface flow [m³ d⁻¹] that flows to the river
+    q_net_bnds::Vector{PRECISION} = fill(MISSING_VALUE, n)    # Net flow for boundaries subsurface flow [m³ d⁻¹]
+    q_net_av::Vector{PRECISION} = fill(MISSING_VALUE, n)      # Average net flow (total) [m³ d⁻¹]
+    storage::Vector{PRECISION}                                # Subsurface storage that can be released [m³]
 end
 
 "Struct for storing lateral subsurface flow model parameters"
 @with_kw struct LateralSsfParameters{Kh}
     kh_profile::Kh                      # Horizontal hydraulic conductivity profile type [-]
-    khfrac::Vector{Float64}             # A multiplication factor applied to vertical hydraulic conductivity `kv` [-]
-    soilthickness::Vector{Float64}      # Soil thickness [m]
-    specific_yield::Vector{Float64}     # Specific yield (theta_s - theta_fc) [-]
-    area::Vector{Float64}               # Area of cell [m²]
-    top::Vector{Float64}                # Top of subsurface flow layer [m]
+    khfrac::Vector{PRECISION}             # A multiplication factor applied to vertical hydraulic conductivity `kv` [-]
+    soilthickness::Vector{PRECISION}      # Soil thickness [m]
+    specific_yield::Vector{PRECISION}     # Specific yield (theta_s - theta_fc) [-]
+    area::Vector{PRECISION}               # Area of cell [m²]
+    top::Vector{PRECISION}                # Top of subsurface flow layer [m]
 end
 
 "Lateral subsurface flow model"
-@with_kw struct LateralSSFModel{Kh,B<:SubsurfaceFlowBC} <: AbstractSubsurfaceFlowModel
+@with_kw struct LateralSSFModel{Kh, B <: SubsurfaceFlowBC} <: AbstractSubsurfaceFlowModel
     timestepping::TimeStepping
     boundary_conditions::B
     parameters::LateralSsfParameters{Kh}
@@ -36,9 +36,9 @@ end
 "Exponential depth profile of horizontal hydraulic conductivity at the soil surface"
 struct KhExponential
     # Horizontal hydraulic conductivity at soil surface [m d⁻¹]
-    kh_0::Vector{Float64}
+    kh_0::Vector{PRECISION}
     # A scaling parameter [m⁻¹] (controls exponential decline of kh_0)
-    f::Vector{Float64}
+    f::Vector{PRECISION}
 end
 
 "Exponential constant depth profile of horizontal hydraulic conductivity"
@@ -46,13 +46,13 @@ struct KhExponentialConstant
     # Exponential horizontal hydraulic conductivity profile type
     exponential::KhExponential
     # Depth [m] from soil surface for which exponential decline of kv_0 is valid
-    z_exp::Vector{Float64}
+    z_exp::Vector{PRECISION}
 end
 
 "Layered depth profile of horizontal hydraulic conductivity"
 struct KhLayered
     # Horizontal hydraulic conductivity [m d⁻¹]
-    kh::Vector{Float64}
+    kh::Vector{PRECISION}
 end
 
 "Initialize lateral subsurface flow model parameters"
@@ -61,21 +61,15 @@ function LateralSsfParameters(
     config::Config,
     indices::Vector{CartesianIndex{2}},
     soil::SbmSoilParameters,
-    area::Vector{Float64},
+    area::Vector{PRECISION},
 )
-    elevation = ncread(
-        dataset,
-        config,
-        "land_surface__elevation",
-        Routing;
-        sel=indices,
-    )
+    elevation = ncread(dataset, config, "land_surface__elevation", Routing; sel = indices)
     khfrac = ncread(
         dataset,
         config,
         "subsurface_water__horizontal_to_vertical_saturated_hydraulic_conductivity_ratio",
         Routing;
-        sel=indices,
+        sel = indices,
     )
 
     (; theta_s, theta_fc, soilthickness) = soil
@@ -105,13 +99,13 @@ function LateralSsfParameters(
         soilthickness,
         specific_yield,
         area,
-        top=elevation,
+        top = elevation,
     )
     return ssf_parameters
 end
 
 "Initialize lateral subsurface flow model variables"
-function LateralSsfVariables(ssf::LateralSsfParameters, zi::Vector{Float64})
+function LateralSsfVariables(ssf::LateralSsfParameters, zi::Vector{PRECISION})
     n = length(zi)
     storage = @. ssf.specific_yield * (ssf.soilthickness - zi) * ssf.area
     head = @. ssf.top - zi
@@ -120,12 +114,17 @@ function LateralSsfVariables(ssf::LateralSsfParameters, zi::Vector{Float64})
 end
 
 "Initialize lateral subsurface flow model"
-function LateralSSFModel(dataset::NCDataset, config::Config, domain::Domain, soil::SbmSoilModel)
+function LateralSSFModel(
+    dataset::NCDataset,
+    config::Config,
+    domain::Domain,
+    soil::SbmSoilModel,
+)
     (; land, river, drain) = domain
     (; indices) = land.network
     (; area) = domain.land.parameters
     n = length(indices)
-    timestepping = init_kinematic_wave_timestepping(config, n; domain="subsurface")
+    timestepping = init_kinematic_wave_timestepping(config, n; domain = "subsurface")
     parameters = LateralSsfParameters(dataset, config, indices, soil.parameters, area)
     zi = 0.001 * soil.variables.zi
     variables = LateralSsfVariables(parameters, zi)
@@ -145,7 +144,11 @@ function LateralSSFModel(dataset::NCDataset, config::Config, domain::Domain, soi
     return ssf_model
 end
 
-function update_fluxes!(subsurface_flow_model::LateralSSFModel, domain::Domain, dt::Float64)
+function update_fluxes!(
+    subsurface_flow_model::LateralSSFModel,
+    domain::Domain,
+    dt::PRECISION,
+)
     for bc in get_boundaries(subsurface_flow_model.boundary_conditions)
         indices = get_boundary_index(bc, domain)
         flux!(bc, subsurface_flow_model, indices, dt)
@@ -156,7 +159,7 @@ end
 function flux_to_river!(
     subsurface_flow_model::LateralSSFModel,
     domain::NetworkRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; to_river) = subsurface_flow_model.variables
     (; river) = subsurface_flow_model.boundary_conditions
@@ -173,7 +176,7 @@ function kinwave_subsurface_update!(
     subsurface_flow_model::LateralSSFModel,
     soil_model::SbmSoilModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; order_of_subdomains, order_subdomain, subdomain_indices, upstream_nodes) =
         domain.land.network
@@ -199,16 +202,16 @@ function kinwave_subsurface_update!(
 
     ns = length(order_of_subdomains)
     for k in 1:ns
-        threaded_foreach(eachindex(order_of_subdomains[k]); basesize=1) do i
+        threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 if isnothing(river)
                     # for a river cell without a reservoir part of the upstream subsurface flow
                     # goes to the river (flow_fraction_to_river) and part goes to the subsurface
-                    # flow reservoir (1.0 - flow_fraction_to_river) upstream nodes with a
+                    # flow reservoir (ONE - flow_fraction_to_river) upstream nodes with a
                     # reservoir are excluded
                     q_in[v] = sum_at(
-                        i -> q[i] * (1.0 - flow_fraction_to_river[i]),
+                        i -> q[i] * (ONE - flow_fraction_to_river[i]),
                         upstream_nodes[n],
                     )
                     to_river[v] +=
@@ -253,16 +256,16 @@ function update_subsurface_flow_model!(
     subsurface_flow_model::LateralSSFModel,
     soil_model::SbmSoilModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; to_river) = subsurface_flow_model.variables
     (; adaptive) = subsurface_flow_model.timestepping
 
-    to_river .= 0.0
+    to_river .= ZERO
     set_flux_vars!(subsurface_flow_model)
-    t = 0.0
+    t = ZERO
     while t < dt
-        subsurface_flow_model.variables.q_net_bnds .= 0.0
+        subsurface_flow_model.variables.q_net_bnds .= ZERO
         dt_s =
             adaptive ? stable_timestep(subsurface_flow_model, domain.land) :
             subsurface_flow_model.timestepping.dt_fixed
@@ -294,7 +297,7 @@ function stable_timestep(subsurface_flow_model::LateralSSFModel, domain::DomainL
     stable_timesteps .= Inf
     k = 0
     for i in 1:n
-        if zi[i] > 0.0
+        if zi[i] > ZERO
             k += 1
             c = ssf_celerity(zi[i], slope[i], specific_yield[i], kh_profile, i)
             stable_timesteps[k] = (flow_length[i] / c)

--- a/Wflow/src/routing/subsurface/subsurface_process.jl
+++ b/Wflow/src/routing/subsurface/subsurface_process.jl
@@ -86,7 +86,7 @@ function kinematic_wave_ssf(
         return ZERO, d, ZERO
     else
         # initial estimate
-        q = (q_prev + q_in) / 2.0
+        q = (q_prev + q_in) / 2
         # newton-raphson
         celerity = ssf_celerity(zi_prev, slope, sy, kh_profile, i)
         constant_term =
@@ -107,7 +107,7 @@ function kinematic_wave_ssf(
         zi = clamp(zi, ZERO, d)
         # constrain water table depth change to 0.1 m per (sub) timestep based on first `zi`
         # computation
-        max_delta_zi = 0.1
+        max_delta_zi = to_precision(0.1)
         its = Int(cld(abs(max(zi, ZERO) - zi_prev), max_delta_zi))
         if its > 1
             dt_s = dt / its
@@ -133,8 +133,8 @@ function kinematic_wave_ssf(
                 end
                 zi = clamp(zi, ZERO, d)
                 # update unsaturated zone
-                zi_prev_mm = zi_prev * 1000.0
-                zi_mm = zi * 1000.0
+                zi_prev_mm = zi_prev * 1000
+                zi_mm = zi * 1000
                 update_ustorelayerdepth!(soil, zi_prev_mm, zi_mm, i)
                 exfilt_sum += exfilt
                 net_flux_sum += net_flux
@@ -147,8 +147,8 @@ function kinematic_wave_ssf(
             net_flux = net_flux_sum
             dh = zi_start - zi
         else
-            zi_prev_mm = zi_prev * 1000.0
-            zi_mm = zi * 1000.0
+            zi_prev_mm = zi_prev * 1000
+            zi_mm = zi * 1000
             update_ustorelayerdepth!(soil, zi_prev_mm, zi_mm, i)
         end
         return q, zi, exfilt, net_flux
@@ -205,8 +205,8 @@ function kinematic_wave_ssf(
         zi = clamp(zi, ZERO, d)
 
         # update unsaturated zone
-        zi_prev_mm = zi_prev * 1000.0
-        zi_mm = zi * 1000.0
+        zi_prev_mm = zi_prev * 1000
+        zi_mm = zi * 1000
         update_ustorelayerdepth!(soil, zi_prev_mm, zi_mm, i)
 
         return q, zi, exfilt, net_flux

--- a/Wflow/src/routing/subsurface/subsurface_process.jl
+++ b/Wflow/src/routing/subsurface/subsurface_process.jl
@@ -36,7 +36,7 @@ Return kinematic wave subsurface flow `q` for a single cell and timestep using t
 Raphson method.
 """
 function kw_ssf_newton_raphson(q, constant_term, celerity, dt, dx)
-    epsilon = 1.0e-12
+    epsilon = 1e-12
     max_iters = 3000
     count = 0
     dt_dx = dt / dx
@@ -46,7 +46,7 @@ function kw_ssf_newton_raphson(q, constant_term, celerity, dt, dx)
         df = dt_dx + celerity_inv
         q -= (f / df)
         if isnan(q)
-            q = 0.0
+            q = ZERO
         end
         q = max(q, KIN_WAVE_MIN_FLOW)
         if (abs(f) <= epsilon) || (count >= max_iters)
@@ -82,15 +82,15 @@ function kinematic_wave_ssf(
     soil::SbmSoilModel,
     i,
 )
-    if q_in + q_prev ≈ 0.0 && r <= 0.0
-        return 0.0, d, 0.0
+    if q_in + q_prev ≈ ZERO && r <= ZERO
+        return ZERO, d, ZERO
     else
         # initial estimate
         q = (q_prev + q_in) / 2.0
         # newton-raphson
         celerity = ssf_celerity(zi_prev, slope, sy, kh_profile, i)
         constant_term =
-            (dt / dx) * q_in + (1.0 / celerity) * q_prev + q_net_bnds * (dt / dx)
+            (dt / dx) * q_in + (ONE / celerity) * q_prev + q_net_bnds * (dt / dx)
         q = kw_ssf_newton_raphson(q, constant_term, celerity, dt, dx)
 
         # constrain maximum lateral subsurface flow rate q
@@ -104,16 +104,16 @@ function kinematic_wave_ssf(
             q_excess = (dw * dx) * sy * (zi - d) / dt
             q = max(q - q_excess, KIN_WAVE_MIN_FLOW)
         end
-        zi = clamp(zi, 0.0, d)
+        zi = clamp(zi, ZERO, d)
         # constrain water table depth change to 0.1 m per (sub) timestep based on first `zi`
         # computation
         max_delta_zi = 0.1
-        its = Int(cld(abs(max(zi, 0.0) - zi_prev), max_delta_zi))
+        its = Int(cld(abs(max(zi, ZERO) - zi_prev), max_delta_zi))
         if its > 1
             dt_s = dt / its
-            q_sum = 0.0
-            exfilt_sum = 0.0
-            net_flux_sum = 0.0
+            q_sum = ZERO
+            exfilt_sum = ZERO
+            net_flux_sum = ZERO
             zi_start = zi_prev
             for _ in 1:its
                 celerity = ssf_celerity(zi_prev, slope, sy, kh_profile, i)
@@ -131,7 +131,7 @@ function kinematic_wave_ssf(
                     q_excess = (dw * dx) * sy * (zi - d) / dt_s
                     q = max(q - q_excess, KIN_WAVE_MIN_FLOW)
                 end
-                zi = clamp(zi, 0.0, d)
+                zi = clamp(zi, ZERO, d)
                 # update unsaturated zone
                 zi_prev_mm = zi_prev * 1000.0
                 zi_mm = zi * 1000.0
@@ -180,11 +180,11 @@ function kinematic_wave_ssf(
     soil::SbmSoilModel,
     i,
 )
-    if q_in + q_prev ≈ 0.0 && r <= 0.0
-        return 0.0, d, 0.0
+    if q_in + q_prev ≈ ZERO && r <= ZERO
+        return ZERO, d, ZERO
     else
         # initial estimate
-        q_ini = (q_prev + q_in) / 2.0
+        q_ini = (q_prev + q_in) / 2
         # newton-raphson
         celerity = ssf_celerity(zi_prev, slope, sy, kh_profile, i)
         constant_term = (dt / dx) * q_in + q_prev / celerity + q_net_bnds * (dt / dx)
@@ -197,12 +197,12 @@ function kinematic_wave_ssf(
         net_flux = (q_in * dt + q_net_bnds * dt - q * dt) / (dw * dx)
         dh, exfilt = water_table_change(soil, net_flux, sy, i)
         zi = zi_prev - dh
-        sy_d = dh > 0.0 ? (net_flux - exfilt) / dh : sy
+        sy_d = dh > ZERO ? (net_flux - exfilt) / dh : sy
         if zi > d
             q_excess = (dw * dx) * sy_d * (zi - d) / dt
             q = max(q - q_excess, KIN_WAVE_MIN_FLOW)
         end
-        zi = clamp(zi, 0.0, d)
+        zi = clamp(zi, ZERO, d)
 
         # update unsaturated zone
         zi_prev_mm = zi_prev * 1000.0

--- a/Wflow/src/routing/surface/reservoir.jl
+++ b/Wflow/src/routing/surface/reservoir.jl
@@ -570,7 +570,7 @@ function update_reservoir_model!(
     # average variables (here accumulated for model timestep Δt)
     res_bc.inflow[i] += inflow * dt
     res_v.outflow_av[i] += outflow * dt
-    res_v.actevap[i] += 1000.0 * (actevap / res_p.area[i])
+    res_v.actevap[i] += 1000 * (actevap / res_p.area[i])
 
     return nothing
 end

--- a/Wflow/src/routing/surface/reservoir.jl
+++ b/Wflow/src/routing/surface/reservoir.jl
@@ -13,17 +13,17 @@
     # General Q = b(H - H₀)ᵉ, 3: Case of Puls Approach Q = b(H - H₀)², 4: Simple reservoir
     outflowfunc::Vector{ReservoirOutflowType.T}
     # reservoir area [m²]
-    area::Vector{Float64}
+    area::Vector{PRECISION}
     # index of lower reservoir (linked reservoirs) [-]
     lower_reservoir_ind::Vector{Int} = zeros(Int, length(area))
     # reservoir maximum storage for rating curve types 1 and 4 [m³]
-    maxstorage::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    maxstorage::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # water level threshold H₀ [m] below that level outflow is zero
-    threshold::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    threshold::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # rating curve coefficient [m3/2 s-1] (if e=3/2)
-    b::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    b::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # rating curve exponent [-]
-    e::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    e::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # data for storage curve
     sh::Vector{Union{SH, Missing}} = Vector{Union{SH, Missing}}(missing, length(area))
     # data for rating curve
@@ -31,14 +31,14 @@
     # column index of rating curve data hq
     col_index_hq::Vector{Int} = [1]
     # maximum amount that can be released if below spillway for rating curve type 4 [m³ s⁻¹]
-    maxrelease::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    maxrelease::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # minimum (environmental) flow requirement downstream of the reservoir for rating curve
     # type 4 [m³ s⁻¹]
-    demand::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    demand::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # target minimum full fraction (of max storage) for rating curve type 4 [-]
-    targetminfrac::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    targetminfrac::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
     # target fraction full (of max storage) for rating curve type 4 [-]
-    targetfullfrac::Vector{Float64} = fill(MISSING_VALUE, length(area))
+    targetfullfrac::Vector{PRECISION} = fill(MISSING_VALUE, length(area))
 end
 
 "Initialize reservoir model parameters"
@@ -197,17 +197,17 @@ end
 "Struct for storing reservoir model variables"
 @with_kw struct ReservoirVariables
     # waterlevel H [m] of reservoir
-    waterlevel::Vector{Float64}
+    waterlevel::Vector{PRECISION}
     # reservoir storage [m³]
-    storage::Vector{Float64}
+    storage::Vector{PRECISION}
     # outflow from reservoir [m³ s⁻¹]
-    outflow::Vector{Float64} = fill(MISSING_VALUE, length(waterlevel))
+    outflow::Vector{PRECISION} = fill(MISSING_VALUE, length(waterlevel))
     # average outflow from reservoir [m³ s⁻¹] for model timestep Δt
-    outflow_av::Vector{Float64} = fill(MISSING_VALUE, length(waterlevel))
+    outflow_av::Vector{PRECISION} = fill(MISSING_VALUE, length(waterlevel))
     # observed outflow from reservoir [m³ s⁻¹]
-    outflow_obs::Vector{Float64} = fill(MISSING_VALUE, length(waterlevel))
+    outflow_obs::Vector{PRECISION} = fill(MISSING_VALUE, length(waterlevel))
     # average actual evaporation for reservoir area [mm Δt⁻¹]
-    actevap::Vector{Float64} = fill(MISSING_VALUE, length(waterlevel))
+    actevap::Vector{PRECISION} = fill(MISSING_VALUE, length(waterlevel))
 end
 
 "Initialize reservoir model variables"
@@ -216,7 +216,7 @@ function ReservoirVariables(
     config::Config,
     network::NetworkReservoir,
     parameters::ReservoirParameters,
-    waterlevel::Vector{Float64},
+    waterlevel::Vector{PRECISION},
 )
     (; storfunc, area, sh) = parameters
     (; indices_outlet) = network
@@ -238,13 +238,13 @@ end
 "Struct for storing reservoir model boundary conditions"
 @with_kw struct ReservoirBC
     n::Int
-    inflow_subsurface::Vector{Float64} = fill(MISSING_VALUE, n)    # inflow from subsurface flow into reservoir [m³ s⁻¹]
-    inflow_overland::Vector{Float64} = fill(MISSING_VALUE, n)      # inflow from overland flow into reservoir [m³ s⁻¹]
-    inflow::Vector{Float64} = fill(MISSING_VALUE, n)               # total inflow into reservoir [m³ s⁻¹] for model timestep Δt
-    external_inflow::Vector{Float64}                               # external inflow (abstraction/supply/demand) [m³ s⁻¹]
-    actual_external_abstraction_av::Vector{Float64} = zeros(n)  # actual abstraction from external negative inflow [m³ s⁻¹]
-    precipitation::Vector{Float64} = fill(MISSING_VALUE, n)        # average precipitation for reservoir area [mm Δt⁻¹]
-    evaporation::Vector{Float64} = fill(MISSING_VALUE, n)          # average potential evaporation for reservoir area [mm Δt⁻¹]
+    inflow_subsurface::Vector{PRECISION} = fill(MISSING_VALUE, n)    # inflow from subsurface flow into reservoir [m³ s⁻¹]
+    inflow_overland::Vector{PRECISION} = fill(MISSING_VALUE, n)      # inflow from overland flow into reservoir [m³ s⁻¹]
+    inflow::Vector{PRECISION} = fill(MISSING_VALUE, n)               # total inflow into reservoir [m³ s⁻¹] for model timestep Δt
+    external_inflow::Vector{PRECISION}                               # external inflow (abstraction/supply/demand) [m³ s⁻¹]
+    actual_external_abstraction_av::Vector{PRECISION} = zeros(n)  # actual abstraction from external negative inflow [m³ s⁻¹]
+    precipitation::Vector{PRECISION} = fill(MISSING_VALUE, n)        # average precipitation for reservoir area [mm Δt⁻¹]
+    evaporation::Vector{PRECISION} = fill(MISSING_VALUE, n)          # average potential evaporation for reservoir area [mm Δt⁻¹]
 end
 
 "Initialize reservoir model boundary conditions"
@@ -282,8 +282,8 @@ end
 "Determine the water level depending on the storage function"
 function waterlevel(
     storfunc::ReservoirProfileType.T,
-    area::Float64,
-    storage::Float64,
+    area::PRECISION,
+    storage::PRECISION,
     sh::Union{SH, Missing},
 )
     if storfunc == ReservoirProfileType.linear
@@ -311,8 +311,8 @@ end
 "Determine the initial storage depending on the storage function"
 function initialize_storage(
     storfunc::Vector{ReservoirProfileType.T},
-    area::Vector{Float64},
-    waterlevel::Vector{Float64},
+    area::Vector{PRECISION},
+    waterlevel::Vector{PRECISION},
     sh::Vector{Union{SH, Missing}},
 )
     storage = similar(area)
@@ -335,7 +335,7 @@ function interpolate_linear(x, xp, fp)
         idx = findall(i -> i <= x, xp)
         i1 = last(idx)
         i2 = i1 + 1
-        return fp[i1] * (1.0 - (x - xp[i1]) / (xp[i2] - xp[i1])) +
+        return fp[i1] * (ONE - (x - xp[i1]) / (xp[i2] - xp[i1])) +
                fp[i2] * (x - xp[i1]) / (xp[i2] - xp[i1])
     end
 end
@@ -355,24 +355,24 @@ function update_reservoir_simple(
     reservoir_model::ReservoirModel,
     i::Int,
     boundary_vars::NamedTuple,
-    dt::Float64,
+    dt::PRECISION,
 )
     res_p = reservoir_model.parameters
     res_v = reservoir_model.variables
     (; precipitation, actevap, inflow) = boundary_vars
 
     storage = res_v.storage[i] + (inflow * dt) + precipitation - actevap
-    storage = max(storage, 0.0)
+    storage = max(storage, ZERO)
 
     percfull = storage / res_p.maxstorage[i]
     # first determine minimum (environmental) flow using a simple sigmoid curve to scale for target level
-    fac = scurve(percfull, res_p.targetminfrac[i], 1.0, 30.0)
+    fac = scurve(percfull, res_p.targetminfrac[i], ONE, 30.0)
     demandrelease = min(fac * res_p.demand[i] * dt, storage)
     storage -= demandrelease
 
-    wantrel = max(0.0, storage - (res_p.maxstorage[i] * res_p.targetfullfrac[i]))
+    wantrel = max(ZERO, storage - (res_p.maxstorage[i] * res_p.targetfullfrac[i]))
     # Assume extra maximum Q if spilling
-    overflow_q = max((storage - res_p.maxstorage[i]), 0.0)
+    overflow_q = max((storage - res_p.maxstorage[i]), ZERO)
     torelease = min(wantrel, overflow_q + res_p.maxrelease[i] * dt - demandrelease)
     storage -= torelease
     outflow = torelease + demandrelease
@@ -389,27 +389,26 @@ function update_reservoir_modified_puls(
     reservoir_model::ReservoirModel,
     i::Int,
     boundary_vars::NamedTuple,
-    dt::Float64,
+    dt::PRECISION,
 )
     res_p = reservoir_model.parameters
     res_v = reservoir_model.variables
     (; precipitation, actevap, inflow) = boundary_vars
 
-    res_factor = res_p.area[i] / (dt * pow(res_p.b[i], 0.5))
-    si_factor = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, 0.0) # prevent negative values
+    res_factor = res_p.area[i] / (dt * sqrt(res_p.b[i]))
+    si_factor = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, ZERO) # prevent negative values
     # Adjust si_factor for reservoir threshold != 0
     si_factor_adj = si_factor - res_p.area[i] * res_p.threshold[i] / dt
     # Calculate the new reservoir outflow/waterlevel/storage
-    if si_factor_adj > 0.0
-        quadratic_sol_term =
-            -res_factor + pow((pow(res_factor, 2.0) + 4.0 * si_factor_adj), 0.5)
-        if quadratic_sol_term > 0.0
-            outflow = pow(0.5 * quadratic_sol_term, 2.0)
+    if si_factor_adj > ZERO
+        quadratic_sol_term = -res_factor + sqrt((pow(res_factor, 2) + 4 * si_factor_adj))
+        if quadratic_sol_term > ZERO
+            outflow = pow(quadratic_sol_term / 2, 2)
         else
-            outflow = 0.0
+            outflow = ZERO
         end
     else
-        outflow = 0.0
+        outflow = ZERO
     end
     outflow = min(outflow, si_factor)
     storage = (si_factor - outflow) * dt
@@ -421,13 +420,13 @@ function update_reservoir_hq(
     reservoir_model::ReservoirModel,
     i::Int,
     boundary_vars::NamedTuple,
-    dt::Float64,
+    dt::PRECISION,
 )
     res_p = reservoir_model.parameters
     res_v = reservoir_model.variables
     (; precipitation, actevap, inflow) = boundary_vars
 
-    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, 0.0) # prevent negative values
+    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, ZERO) # prevent negative values
 
     outflow = interpolate_linear(
         res_v.waterlevel[i],
@@ -438,7 +437,7 @@ function update_reservoir_hq(
 
     storage = (storage_input - outflow) * dt
 
-    overflow = max(0.0, (storage - res_p.maxstorage[i]) / dt)
+    overflow = max(ZERO, (storage - res_p.maxstorage[i]) / dt)
     storage = min(storage, res_p.maxstorage[i])
     outflow += overflow
 
@@ -450,7 +449,7 @@ function update_reservoir_free_weir(
     reservoir_model::ReservoirModel,
     i::Int,
     boundary_vars::NamedTuple,
-    dt::Float64,
+    dt::PRECISION,
 )
     res_p = reservoir_model.parameters
     res_v = reservoir_model.variables
@@ -458,33 +457,33 @@ function update_reservoir_free_weir(
 
     lo = res_p.lower_reservoir_ind[i]
     has_lower_res = lo != 0
-    diff_wl = has_lower_res ? res_v.waterlevel[i] - res_v.waterlevel[lo] : 0.0
+    diff_wl = has_lower_res ? res_v.waterlevel[i] - res_v.waterlevel[lo] : ZERO
 
-    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, 0.0) # prevent negative values
+    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, ZERO) # prevent negative values
 
-    if diff_wl >= 0.0
+    if diff_wl >= ZERO
         if res_v.waterlevel[i] > res_p.threshold[i]
             dh = res_v.waterlevel[i] - res_p.threshold[i]
             outflow = res_p.b[i] * pow(dh, res_p.e[i])
             maxflow = (dh * res_p.area[i]) / dt
             outflow = min(outflow, maxflow)
         else
-            outflow = Float64(0)
+            outflow = PRECISION(0)
         end
     else
         if res_v.waterlevel[lo] > res_p.threshold[i]
             dh = res_v.waterlevel[lo] - res_p.threshold[i]
-            outflow = -1.0 * res_p.b[i] * pow(dh, res_p.e[i])
+            outflow = -ONE * res_p.b[i] * pow(dh, res_p.e[i])
             maxflow = (dh * res_p.area[lo]) / dt
             outflow = max(outflow, -maxflow)
         else
-            outflow = Float64(0)
+            outflow = PRECISION(0)
         end
     end
     storage = (storage_input - outflow) * dt
 
     # update lower reservoir (linked reservoirs) in case flow from lower reservoir to upper reservoir occurs
-    if diff_wl < 0.0
+    if diff_wl < ZERO
         lower_res_storage = res_v.storage[lo] + outflow * dt
 
         lower_res_waterlevel = if res_p.storfunc[lo] == ReservoirProfileType.linear
@@ -507,12 +506,12 @@ function update_reservoir_outflow_obs(
     reservoir_model::ReservoirModel,
     i::Int,
     boundary_vars::NamedTuple,
-    dt::Float64,
+    dt::PRECISION,
 )
     res_v = reservoir_model.variables
     (; precipitation, actevap, inflow) = boundary_vars
 
-    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, 0.0) # prevent negative values
+    storage_input = max((res_v.storage[i] + precipitation - actevap) / dt + inflow, ZERO) # prevent negative values
     outflow = min(res_v.outflow_obs[i], storage_input)
     storage = (storage_input - outflow) * dt
     return outflow, storage
@@ -527,9 +526,9 @@ element rather than all at once.
 function update_reservoir_model!(
     reservoir_model::ReservoirModel,
     i::Int,
-    inflow::Float64,
-    dt::Float64,
-    dt_forcing::Float64,
+    inflow::PRECISION,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
 )
     res_bc = reservoir_model.boundary_conditions
     res_p = reservoir_model.parameters

--- a/Wflow/src/routing/surface/surface_kinwave.jl
+++ b/Wflow/src/routing/surface/surface_kinwave.jl
@@ -329,7 +329,8 @@ function update_overland_flow_model!(
     t = ZERO
     while t < dt
         dt_s =
-            adaptive ? stable_timestep(overland_flow_model, flow_length, 0.02) :
+            adaptive ?
+            stable_timestep(overland_flow_model, flow_length, to_precision(0.02)) :
             overland_flow_model.timestepping.dt_fixed
         dt_s = check_timestepsize(dt_s, t, dt)
         kinwave_land_update!(overland_flow_model, domain, dt_s)
@@ -493,7 +494,7 @@ function update_river_flow_model!(
     t = ZERO
     while t < dt
         dt_s =
-            adaptive ? stable_timestep(river_flow_model, flow_length, 0.05) :
+            adaptive ? stable_timestep(river_flow_model, flow_length, to_precision(0.05)) :
             river_flow_model.timestepping.dt_fixed
         dt_s = check_timestepsize(dt_s, t, dt)
         kinwave_river_update!(river_flow_model, domain.river, dt_s, dt)
@@ -532,7 +533,7 @@ function stable_timestep(
     stable_timesteps .= Inf
     k = 0
     for i in 1:n
-        if q[i] > 0.0
+        if q[i] > ZERO
             k += 1
             c = ONE / (alpha[i] * BETA_KINWAVE * pow(q[i], (BETA_KINWAVE - ONE)))
             stable_timesteps[k] = (flow_length[i] / c)
@@ -544,7 +545,7 @@ function stable_timestep(
     elseif k > 0
         quantile!(@view(stable_timesteps[1:k]), p)
     else
-        600.0
+        to_precision(600.0)
     end
 
     return dt_min

--- a/Wflow/src/routing/surface/surface_kinwave.jl
+++ b/Wflow/src/routing/surface/surface_kinwave.jl
@@ -1,33 +1,33 @@
 "Struct for storing (shared) variables for river and overland flow models"
 @with_kw struct FlowVariables
     n::Int
-    q::Vector{Float64} = zeros(n)            # Discharge [m³ s⁻¹]
-    qlat::Vector{Float64} = zeros(n)         # Lateral inflow per unit length [m² s⁻¹]
-    qin::Vector{Float64} = zeros(n)          # Inflow from upstream cells [m³ s⁻¹]
-    qin_av::Vector{Float64} = zeros(n)       # Average inflow from upstream cells  [m³ s⁻¹] for model timestep Δt
-    q_av::Vector{Float64} = zeros(n)         # Average discharge [m³ s⁻¹] for model timestep Δt
-    storage::Vector{Float64} = zeros(n)      # Kinematic wave storage [m³] (based on water depth h)
-    h::Vector{Float64} = zeros(n)            # Water depth [m]
+    q::Vector{PRECISION} = zeros(n)            # Discharge [m³ s⁻¹]
+    qlat::Vector{PRECISION} = zeros(n)         # Lateral inflow per unit length [m² s⁻¹]
+    qin::Vector{PRECISION} = zeros(n)          # Inflow from upstream cells [m³ s⁻¹]
+    qin_av::Vector{PRECISION} = zeros(n)       # Average inflow from upstream cells  [m³ s⁻¹] for model timestep Δt
+    q_av::Vector{PRECISION} = zeros(n)         # Average discharge [m³ s⁻¹] for model timestep Δt
+    storage::Vector{PRECISION} = zeros(n)      # Kinematic wave storage [m³] (based on water depth h)
+    h::Vector{PRECISION} = zeros(n)            # Water depth [m]
 end
 
 "Struct for storing Manning flow parameters"
 @with_kw struct ManningFlowParameters
     n::Int
-    slope::Vector{Float64}        # Slope [m m⁻¹]
-    mannings_n::Vector{Float64}   # Manning's roughness [s m⁻⅓]
-    alpha_pow::Float64            # Used in the power part of alpha [-]
-    alpha_term::Vector{Float64} = fill(MISSING_VALUE, n)   # Term used in computation of alpha [-]
-    alpha::Vector{Float64} = fill(MISSING_VALUE, n)        # Constant in momentum equation A = alpha*Q^beta, based on Manning's equation [s3/5 m1/5]
+    slope::Vector{PRECISION}        # Slope [m m⁻¹]
+    mannings_n::Vector{PRECISION}   # Manning's roughness [s m⁻⅓]
+    alpha_pow::PRECISION            # Used in the power part of alpha [-]
+    alpha_term::Vector{PRECISION} = fill(MISSING_VALUE, n)   # Term used in computation of alpha [-]
+    alpha::Vector{PRECISION} = fill(MISSING_VALUE, n)        # Constant in momentum equation A = alpha*Q^beta, based on Manning's equation [s3/5 m1/5]
 end
 
 "Initialize Manning flow parameters"
-function ManningFlowParameters(mannings_n::Vector{Float64}, slope::Vector{Float64})
+function ManningFlowParameters(mannings_n::Vector{PRECISION}, slope::Vector{PRECISION})
     n = length(slope)
     parameters = ManningFlowParameters(;
         n,
         slope,
         mannings_n,
-        alpha_pow = Float64((2.0 / 3.0) * 0.6),
+        alpha_pow = PRECISION((2.0 / 3.0) * 0.6),
     )
     return parameters
 end
@@ -35,7 +35,7 @@ end
 "Struct for storing river flow model parameters"
 @with_kw struct RiverFlowParameters
     flow::ManningFlowParameters
-    bankfull_depth::Vector{Float64} # Bankfull water level [m]
+    bankfull_depth::Vector{PRECISION} # Bankfull water level [m]
 end
 
 "Overload `getproperty` for river flow model parameters"
@@ -71,10 +71,10 @@ end
 "Struct for storing river flow model boundary conditions"
 @with_kw struct RiverFlowBC{R <: Union{ReservoirModel, Nothing}}
     n::Int
-    inwater::Vector{Float64} = zeros(n)                         # Lateral inflow [m³ s⁻¹]
-    external_inflow::Vector{Float64} = zeros(n)                 # External inflow (abstraction/supply/demand) [m³ s⁻¹]
-    actual_external_abstraction_av::Vector{Float64} = zeros(n)  # Actual abstraction from external negative inflow [m³ s⁻¹]
-    abstraction::Vector{Float64} = zeros(n)                     # Abstraction (computed as part of water demand and allocation) [m³ s⁻¹]
+    inwater::Vector{PRECISION} = zeros(n)                         # Lateral inflow [m³ s⁻¹]
+    external_inflow::Vector{PRECISION} = zeros(n)                 # External inflow (abstraction/supply/demand) [m³ s⁻¹]
+    actual_external_abstraction_av::Vector{PRECISION} = zeros(n)  # Actual abstraction from external negative inflow [m³ s⁻¹]
+    abstraction::Vector{PRECISION} = zeros(n)                     # Abstraction (computed as part of water demand and allocation) [m³ s⁻¹]
     reservoir::R                                                # ReservoirModel model struct of arrays
 end
 
@@ -142,7 +142,7 @@ end
 @with_kw struct OverLandFlowVariables
     n::Int
     flow::FlowVariables = FlowVariables(; n)
-    to_river::Vector{Float64} = zeros(n) # Part of overland flow [m³ s⁻¹] that flows to the river
+    to_river::Vector{PRECISION} = zeros(n) # Part of overland flow [m³ s⁻¹] that flows to the river
 end
 
 "Overload `getproperty` for overland flow model variables"
@@ -159,7 +159,7 @@ end
 "Struct for storing overland flow model boundary conditions"
 @with_kw struct LandFlowBC
     n::Int
-    inwater::Vector{Float64} = zeros(n) # Lateral inflow [m³ s⁻¹]
+    inwater::Vector{PRECISION} = zeros(n) # Lateral inflow [m³ s⁻¹]
 end
 
 "Overland flow model using the kinematic wave method and the Manning flow{ equation"
@@ -201,10 +201,10 @@ simulation timestep, during the timestep the total (weighted) sum is computed fr
 each internal timestep.
 """
 function set_reservoir_vars!(reservoir_model::ReservoirModel)
-    reservoir_model.boundary_conditions.inflow .= 0.0
-    reservoir_model.boundary_conditions.actual_external_abstraction_av .= 0.0
-    reservoir_model.variables.outflow_av .= 0.0
-    reservoir_model.variables.actevap .= 0.0
+    reservoir_model.boundary_conditions.inflow .= ZERO
+    reservoir_model.boundary_conditions.actual_external_abstraction_av .= ZERO
+    reservoir_model.variables.outflow_av .= ZERO
+    reservoir_model.variables.actevap .= ZERO
 
     return nothing
 end
@@ -214,7 +214,7 @@ set_reservoir_vars!(reservoir_model) = nothing
 Helper function to compute the average of reservoir variables. This is done at the end of
 each simulation timestep.
 """
-function average_reservoir_vars!(reservoir_model::ReservoirModel, dt::Float64)
+function average_reservoir_vars!(reservoir_model::ReservoirModel, dt::PRECISION)
     reservoir_model.variables.outflow_av ./= dt
     reservoir_model.boundary_conditions.inflow ./= dt
     reservoir_model.boundary_conditions.actual_external_abstraction_av ./= dt
@@ -234,18 +234,18 @@ each sub timestep.
 function set_flow_vars!(river_flow_model::AbstractRiverFlowModel)
     (; q_av) = river_flow_model.variables
     (; actual_external_abstraction_av) = river_flow_model.boundary_conditions
-    q_av .= 0.0
-    actual_external_abstraction_av .= 0.0
+    q_av .= ZERO
+    actual_external_abstraction_av .= ZERO
     return nothing
 end
 
 """
-    average_flow_vars!(river_flow::AbstractRiverFlowModel, dt::Float64)
+    average_flow_vars!(river_flow::AbstractRiverFlowModel, dt::PRECISION)
 
 Helper functions to compute average river flow routing variables. This is done at the end of
 each simulation timestep.
 """
-function average_flow_vars!(river_flow_model::AbstractRiverFlowModel, dt::Float64)
+function average_flow_vars!(river_flow_model::AbstractRiverFlowModel, dt::PRECISION)
     (; q_av) = river_flow_model.variables
     (; actual_external_abstraction_av) = river_flow_model.boundary_conditions
     q_av ./= dt
@@ -257,7 +257,7 @@ end
 function kinwave_land_update!(
     overland_flow_model::KinWaveOverlandFlowModel,
     domain::DomainLand,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; order_of_subdomains, order_subdomain, subdomain_indices, upstream_nodes) =
         domain.network
@@ -267,20 +267,20 @@ function kinwave_land_update!(
     (; surface_flow_width, flow_length, flow_fraction_to_river) = domain.parameters
 
     ns = length(order_of_subdomains)
-    qin .= 0.0
+    qin .= ZERO
     for k in 1:ns
         threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
             m = order_of_subdomains[k][i]
             for (n, v) in zip(subdomain_indices[m], order_subdomain[m])
                 # for a river cell without a reservoir part of the upstream surface flow
                 # goes to the river (flow_fraction_to_river) and part goes to the surface
-                # flow reservoir (1.0 - flow_fraction_to_river), upstream nodes with a
+                # flow reservoir (ONE - flow_fraction_to_river), upstream nodes with a
                 # reservoir are excluded
                 to_river[v] +=
                     sum_at(i -> q[i] * flow_fraction_to_river[i], upstream_nodes[n]) * dt
-                if surface_flow_width[v] > 0.0
+                if surface_flow_width[v] > ZERO
                     qin[v] = sum_at(
-                        i -> q[i] * (1.0 - flow_fraction_to_river[i]),
+                        i -> q[i] * (ONE - flow_fraction_to_river[i]),
                         upstream_nodes[n],
                     )
                 end
@@ -288,8 +288,8 @@ function kinwave_land_update!(
                 q[v], crossarea =
                     kinematic_wave(qin[v], q[v], qlat[v], alpha[v], dt, flow_length[v])
 
-                # update h, only if flow width > 0.0
-                if surface_flow_width[v] > 0.0
+                # update h, only if flow width > ZERO
+                if surface_flow_width[v] > ZERO
                     h[v] = crossarea / surface_flow_width[v]
                 end
                 storage[v] = flow_length[v] * surface_flow_width[v] * h[v]
@@ -309,7 +309,7 @@ Update overland flow model `KinWaveOverlandFlowModel` for a single timestep `dt`
 function update_overland_flow_model!(
     overland_flow_model::KinWaveOverlandFlowModel,
     domain::DomainLand,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; inwater) = overland_flow_model.boundary_conditions
     (; alpha_term, mannings_n, alpha_pow, alpha) = overland_flow_model.parameters
@@ -322,11 +322,11 @@ function update_overland_flow_model!(
     @. alpha = alpha_term * pow(surface_flow_width, alpha_pow)
     @. qlat = inwater / flow_length
 
-    q_av .= 0.0
-    to_river .= 0.0
-    qin_av .= 0.0
+    q_av .= ZERO
+    to_river .= ZERO
+    qin_av .= ZERO
 
-    t = 0.0
+    t = ZERO
     while t < dt
         dt_s =
             adaptive ? stable_timestep(overland_flow_model, flow_length, 0.02) :
@@ -347,8 +347,8 @@ function update_reservoir_model!(
     river_flow_vars::FlowVariables,
     network::NetworkRiver,
     v::Int,
-    dt::Float64,
-    dt_forcing::Float64,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
 )
     (; boundary_conditions, variables) = reservoir_model
     (; storage, outflow) = variables
@@ -366,7 +366,7 @@ function update_reservoir_model!(
 
     # If the external inflow is negative, the abstraction is limited
     inflow_ext = external_inflow[i]
-    if inflow_ext < 0.0
+    if inflow_ext < ZERO
         abstraction = min(-inflow_ext, (storage[i] / dt) * 0.98)
         actual_external_abstraction_av[i] += abstraction * dt
         inflow = -abstraction
@@ -398,8 +398,8 @@ end
 function kinwave_river_update!(
     river_flow_model::KinWaveRiverFlowModel,
     domain::DomainRiver,
-    dt::Float64,
-    dt_forcing::Float64,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
 )
     (; order_of_subdomains, order_subdomain, subdomain_indices, upstream_nodes) =
         domain.network
@@ -412,7 +412,7 @@ function kinwave_river_update!(
     (; h, q, q_av, storage, qin, qin_av, qlat) = river_flow_model.variables
 
     ns = length(order_of_subdomains)
-    qin .= 0.0
+    qin .= ZERO
     for k in 1:ns
         threaded_foreach(eachindex(order_of_subdomains[k]); basesize = 1) do i
             m = order_of_subdomains[k][i]
@@ -421,7 +421,7 @@ function kinwave_river_update!(
                 qin[v] += sum_at(q, upstream_nodes[n])
                 # Inflow supply/abstraction is added to qlat (divide by flow length)
                 # If external_inflow < 0, abstraction is limited
-                if external_inflow[v] < 0.0
+                if external_inflow[v] < ZERO
                     _abstraction = min(-external_inflow[v], (storage[v] / dt) * 0.80)
                     actual_external_abstraction_av[v] += _abstraction * dt
                     _inflow = -_abstraction / flow_length[v]
@@ -485,12 +485,12 @@ function update_river_flow_model!(
     @. qlat = inwater / flow_length
 
     set_flow_vars!(river_flow_model)
-    qin_av .= 0.0
+    qin_av .= ZERO
     set_reservoir_vars!(reservoir)
     update_index_hq!(reservoir, clock)
 
     dt = tosecond(clock.dt)
-    t = 0.0
+    t = ZERO
     while t < dt
         dt_s =
             adaptive ? stable_timestep(river_flow_model, flow_length, 0.05) :
@@ -507,7 +507,7 @@ function update_river_flow_model!(
 end
 
 # constant in Manning's equation [-]
-const BETA_KINWAVE = 0.6
+const BETA_KINWAVE = to_precision(0.6)
 
 """
 Compute a stable timestep size for the kinematice wave method for a river or overland flow
@@ -521,8 +521,8 @@ accuracy.
 """
 function stable_timestep(
     flow_model::S,
-    flow_length::Vector{Float64},
-    p::Float64,
+    flow_length::Vector{PRECISION},
+    p::PRECISION,
 ) where {S <: Union{KinWaveOverlandFlowModel, KinWaveRiverFlowModel}}
     (; q) = flow_model.variables
     (; alpha) = flow_model.parameters
@@ -534,7 +534,7 @@ function stable_timestep(
     for i in 1:n
         if q[i] > 0.0
             k += 1
-            c = 1.0 / (alpha[i] * BETA_KINWAVE * pow(q[i], (BETA_KINWAVE - 1.0)))
+            c = ONE / (alpha[i] * BETA_KINWAVE * pow(q[i], (BETA_KINWAVE - ONE)))
             stable_timesteps[k] = (flow_length[i] / c)
         end
     end
@@ -558,7 +558,7 @@ function update_lateral_inflow!(
     river_flow_model::AbstractRiverFlowModel,
     external_models::NamedTuple,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; allocation, runoff, overland_flow, subsurface_flow) = external_models
     (; inwater) = river_flow_model.boundary_conditions
@@ -586,7 +586,7 @@ function update_lateral_inflow!(
     external_models::NamedTuple,
     domain::Domain,
     config::Config,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; soil, subsurface_flow, allocation) = external_models
     (; net_runoff) = soil.variables
@@ -600,7 +600,7 @@ function update_lateral_inflow!(
         drainflux = zeros(length(net_runoff))
         drainflux[land_indices] = -drain.variables.flux ./ tosecond(BASETIMESTEP)
     else
-        drainflux = 0.0
+        drainflux = ZERO
     end
     inwater .=
         (net_runoff .+ get_nonirrigation_returnflow(allocation)) .* area * 0.001 ./ dt .+

--- a/Wflow/src/routing/surface/surface_local_inertial.jl
+++ b/Wflow/src/routing/surface/surface_local_inertial.jl
@@ -6,16 +6,16 @@ abstract type AbstractFloodPlainModel end
     ne::Int                                 # number of edges [-]
     active_n::Vector{Int}                   # active nodes [-]
     active_e::Vector{Int}                   # active edges [-]
-    froude_limit::Bool                      # if true a check is performed if froude number > 1.0 (algorithm is modified) [-]
-    h_thresh::Float64                       # depth threshold for calculating flow [m]
-    zb::Vector{Float64}                     # river bed elevation [m]
-    zb_max::Vector{Float64}                 # maximum channel bed elevation [m]
-    bankfull_storage::Vector{Float64}       # bankfull storage [m³]
-    bankfull_depth::Vector{Float64}         # bankfull depth [m]
-    mannings_n_sq::Vector{Float64}          # Manning's roughness squared at edge [(s m-1/3)2]
-    mannings_n::Vector{Float64}             # Manning's roughness [s m-1/3] at node
-    flow_length_at_edge::Vector{Float64}    # flow (river) length at edge [m]
-    flow_width_at_edge::Vector{Float64}     # flow (river) width at edge [m]
+    froude_limit::Bool                      # if true a check is performed if froude number > ONE (algorithm is modified) [-]
+    h_thresh::PRECISION                       # depth threshold for calculating flow [m]
+    zb::Vector{PRECISION}                     # river bed elevation [m]
+    zb_max::Vector{PRECISION}                 # maximum channel bed elevation [m]
+    bankfull_storage::Vector{PRECISION}       # bankfull storage [m³]
+    bankfull_depth::Vector{PRECISION}         # bankfull depth [m]
+    mannings_n_sq::Vector{PRECISION}          # Manning's roughness squared at edge [(s m-1/3)2]
+    mannings_n::Vector{PRECISION}             # Manning's roughness [s m-1/3] at node
+    flow_length_at_edge::Vector{PRECISION}    # flow (river) length at edge [m]
+    flow_width_at_edge::Vector{PRECISION}     # flow (river) width at edge [m]
 end
 
 "Initialize local inertial river flow model parameters"
@@ -39,7 +39,7 @@ function LocalInertialRiverFlowParameters(
         config,
         "model_boundary_condition_river__length",
         Routing;
-        sel = pit_indices,
+        sel=pit_indices,
     )
     bankfull_elevation_2d = ncread(dataset, config, "river_bank_water__elevation", Routing)
     bankfull_depth_2d = ncread(dataset, config, "river_bank_water__depth", Routing)
@@ -52,7 +52,7 @@ function LocalInertialRiverFlowParameters(
         config,
         "river_water_flow__manning_n_parameter",
         Routing;
-        sel = indices,
+        sel=indices,
     )
 
     n = length(indices)
@@ -67,10 +67,10 @@ function LocalInertialRiverFlowParameters(
 
     # determine z, width, length and manning's n at edges
     n_edges = ne(graph)
-    zb_max = fill(Float64(0), n_edges)
-    width_at_edge = fill(Float64(0), n_edges)
-    length_at_edge = fill(Float64(0), n_edges)
-    mannings_n_sq = fill(Float64(0), n_edges)
+    zb_max = fill(PRECISION(0), n_edges)
+    width_at_edge = fill(PRECISION(0), n_edges)
+    length_at_edge = fill(PRECISION(0), n_edges)
+    mannings_n_sq = fill(PRECISION(0), n_edges)
     for i in 1:n_edges
         src_node = nodes_at_edge.src[i]
         dst_node = nodes_at_edge.dst[i]
@@ -88,19 +88,19 @@ function LocalInertialRiverFlowParameters(
 
     parameters = LocalInertialRiverFlowParameters(;
         n,
-        ne = n_edges,
-        active_n = active_index,
-        active_e = active_index,
+        ne=n_edges,
+        active_n=active_index,
+        active_e=active_index,
         froude_limit,
-        h_thresh = waterdepth_threshold,
+        h_thresh=waterdepth_threshold,
         zb,
         zb_max,
         bankfull_storage,
         bankfull_depth,
         mannings_n,
         mannings_n_sq,
-        flow_length_at_edge = length_at_edge,
-        flow_width_at_edge = width_at_edge,
+        flow_length_at_edge=length_at_edge,
+        flow_width_at_edge=width_at_edge,
     )
     return parameters
 end
@@ -109,19 +109,19 @@ end
 @with_kw struct LocalInertialRiverFlowVariables
     n::Int
     n_edges::Int
-    q::Vector{Float64} = zeros(n_edges)                        # river discharge at edge (subgrid channel) [m³ s⁻¹]
-    q0::Vector{Float64} = zeros(n_edges)                       # river discharge at edge (subgrid channel) at previous time step [m³ s⁻¹]
-    q_av::Vector{Float64}                     # average river channel (+ floodplain) discharge at edge [m³ s⁻¹] (model timestep Δt)
-    q_channel_av::Vector{Float64}             # average river channel discharge at edge [m³ s⁻¹] (for model timestep Δt)
-    h::Vector{Float64}                        # water depth [m]
-    zs_max::Vector{Float64} = zeros(n_edges)  # maximum water elevation at edge [m]
-    zs_src::Vector{Float64} = zeros(n_edges)  # water elevation of source node of edge [m]
-    zs_dst::Vector{Float64} = zeros(n_edges)  # water elevation of downstream node of edge [m]
-    hf::Vector{Float64} = zeros(n_edges)       # water depth at edge [m]
-    a::Vector{Float64} = zeros(n_edges)        # flow area at edge [m²]
-    r::Vector{Float64} = zeros(n_edges)        # wetted perimeter at edge [m]
-    storage::Vector{Float64} = zeros(n)        # river storage [m³]
-    error::Vector{Float64} = zeros(n)          # error storage [m³]
+    q::Vector{PRECISION} = zeros(n_edges)                        # river discharge at edge (subgrid channel) [m³ s⁻¹]
+    q0::Vector{PRECISION} = zeros(n_edges)                       # river discharge at edge (subgrid channel) at previous time step [m³ s⁻¹]
+    q_av::Vector{PRECISION}                     # average river channel (+ floodplain) discharge at edge [m³ s⁻¹] (model timestep Δt)
+    q_channel_av::Vector{PRECISION}             # average river channel discharge at edge [m³ s⁻¹] (for model timestep Δt)
+    h::Vector{PRECISION}                        # water depth [m]
+    zs_max::Vector{PRECISION} = zeros(n_edges)  # maximum water elevation at edge [m]
+    zs_src::Vector{PRECISION} = zeros(n_edges)  # water elevation of source node of edge [m]
+    zs_dst::Vector{PRECISION} = zeros(n_edges)  # water elevation of downstream node of edge [m]
+    hf::Vector{PRECISION} = zeros(n_edges)       # water depth at edge [m]
+    a::Vector{PRECISION} = zeros(n_edges)        # flow area at edge [m²]
+    r::Vector{PRECISION} = zeros(n_edges)        # wetted perimeter at edge [m]
+    storage::Vector{PRECISION} = zeros(n)        # river storage [m³]
+    error::Vector{PRECISION} = zeros(n)          # error storage [m³]
 end
 
 "Initialize shallow water river flow model variables"
@@ -137,7 +137,7 @@ function LocalInertialRiverFlowVariables(
         config,
         "model_boundary_condition_river_bank_water__depth",
         Routing;
-        sel = pit_indices,
+        sel=pit_indices,
     )
 
     n = length(indices)
@@ -151,7 +151,7 @@ function LocalInertialRiverFlowVariables(
         n,
         n_edges,
         q_av,
-        q_channel_av = config.model.floodplain_1d__flag ? zeros(n_edges) : q_av,
+        q_channel_av=config.model.floodplain_1d__flag ? zeros(n_edges) : q_av,
         h,
     )
     return variables
@@ -159,9 +159,9 @@ end
 
 "Shallow water river flow model using the local inertial method"
 @with_kw struct LocalInertialRiverFlowModel{
-    R <: RiverFlowBC,
-    F <: Union{AbstractFloodPlainModel, Nothing},
-    A <: AbstractAllocationModel,
+    R<:RiverFlowBC,
+    F<:Union{AbstractFloodPlainModel,Nothing},
+    A<:AbstractAllocationModel,
 } <: AbstractRiverFlowModel
     timestepping::TimeStepping
     boundary_conditions::R
@@ -176,7 +176,7 @@ function LocalInertialRiverFlowModel(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    reservoir_model::Union{ReservoirModel, Nothing},
+    reservoir_model::Union{ReservoirModel,Nothing},
 )
     # The local inertial approach makes use of a staggered grid (Bates et al. (2010)),
     # with nodes and edges. This information is extracted from the directed graph of the
@@ -211,8 +211,8 @@ function LocalInertialRiverFlowModel(
         parameters,
         variables,
         floodplain,
-        allocation = do_water_demand(config) ? AllocationRiverModel(n) :
-                     NoAllocationRiverModel(n),
+        allocation=do_water_demand(config) ? AllocationRiverModel(n) :
+                   NoAllocationRiverModel(n),
     )
     return river_flow
 end
@@ -253,7 +253,7 @@ Update river channel flow for the local inertial river flow model.
 function update_river_channel_flow!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::DomainRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; nodes_at_edge) = domain.network
     river_v = river_flow_model.variables
@@ -291,12 +291,14 @@ function update_river_channel_flow!(
                 river_p.froude_limit,
                 dt,
             ),
-            0.0,
+            ZERO,
         )
 
         # limit q in case water is not available
-        river_v.q[i] = ifelse(river_v.h[i_src] <= 0.0, min(river_v.q[i], 0.0), river_v.q[i])
-        river_v.q[i] = ifelse(river_v.h[i_dst] <= 0.0, max(river_v.q[i], 0.0), river_v.q[i])
+        river_v.q[i] =
+            ifelse(river_v.h[i_src] <= ZERO, min(river_v.q[i], ZERO), river_v.q[i])
+        river_v.q[i] =
+            ifelse(river_v.h[i_dst] <= ZERO, max(river_v.q[i], ZERO), river_v.q[i])
         # average river discharge (here accumulated for model timestep Δt)
         river_v.q_av[i] += river_v.q[i] * dt
     end
@@ -307,10 +309,10 @@ end
 Update floodplain flow for the local inertial river flow model.
 """
 function update_floodplain_flow!(
-    river_flow_model::LocalInertialRiverFlowModel{R, F},
+    river_flow_model::LocalInertialRiverFlowModel{R,F},
     domain::DomainRiver,
-    dt::Float64,
-) where {R, F <: AbstractFloodPlainModel}
+    dt::PRECISION,
+) where {R,F<:AbstractFloodPlainModel}
     (; nodes_at_edge) = domain.network
     (; flow_width) = domain.parameters
 
@@ -320,7 +322,7 @@ function update_floodplain_flow!(
     floodplain_v = river_flow_model.floodplain.variables
 
     @batch per = thread minbatch = 1000 for i in 1:length(floodplain_v.hf)
-        floodplain_v.hf[i] = max(river_v.zs_max[i] - floodplain_p.zb_max[i], 0.0)
+        floodplain_v.hf[i] = max(river_v.zs_max[i] - floodplain_p.zb_max[i], ZERO)
     end
 
     n = 0
@@ -329,7 +331,7 @@ function update_floodplain_flow!(
             n += 1
             floodplain_v.hf_index[n] = i
         else
-            floodplain_v.q[i] = 0.0
+            floodplain_v.q[i] = ZERO
         end
     end
 
@@ -359,10 +361,10 @@ function update_floodplain_flow!(
         i2 = ifelse(i1 == length(floodplain_p.profile.depth), i1, i1 + 1)
 
         a_src = get_area(i, i1, i2, i_src)
-        a_src = max(a_src - (floodplain_v.hf[i] * flow_width[i_src]), 0.0)
+        a_src = max(a_src - (floodplain_v.hf[i] * flow_width[i_src]), ZERO)
 
         a_dst = get_area(i, i1, i2, i_dst)
-        a_dst = max(a_dst - (floodplain_v.hf[i] * flow_width[i_dst]), 0.0)
+        a_dst = max(a_dst - (floodplain_v.hf[i] * flow_width[i_dst]), ZERO)
 
         floodplain_v.a[i] = min(a_src, a_dst)
 
@@ -372,7 +374,7 @@ function update_floodplain_flow!(
             a_dst / get_wetted_perimeter(i, i1, i_dst)
         end
 
-        floodplain_v.q[i] = if floodplain_v.a[i] > 1.0e-05
+        floodplain_v.q[i] = if floodplain_v.a[i] > 1e-05
             local_inertial_flow(
                 floodplain_v.q0[i],
                 river_v.zs_src[i],
@@ -386,20 +388,20 @@ function update_floodplain_flow!(
                 dt,
             )
         else
-            0.0
+            ZERO
         end
 
         # limit floodplain q in case water is not available
-        if floodplain_v.h[i_src] <= 0.0
-            floodplain_v.q[i] = min(floodplain_v.q[i], 0.0)
+        if floodplain_v.h[i_src] <= ZERO
+            floodplain_v.q[i] = min(floodplain_v.q[i], ZERO)
         end
 
-        if floodplain_v.h[i_dst] <= 0.0
-            floodplain_v.q[i] = max(floodplain_v.q[i], 0.0)
+        if floodplain_v.h[i_dst] <= ZERO
+            floodplain_v.q[i] = max(floodplain_v.q[i], ZERO)
         end
 
-        if floodplain_v.q[i] * river_v.q[i] < 0.0
-            floodplain_v.q[i] = 0.0
+        if floodplain_v.q[i] * river_v.q[i] < ZERO
+            floodplain_v.q[i] = ZERO
         end
 
         # average floodplain discharge (here accumulated for model timestep Δt)
@@ -409,10 +411,10 @@ function update_floodplain_flow!(
 end
 
 update_floodplain_flow!(
-    model::LocalInertialRiverFlowModel{R, F},
+    model::LocalInertialRiverFlowModel{R,F},
     domain::DomainRiver,
-    dt::Float64,
-) where {R, F <: Nothing} = nothing
+    dt::PRECISION,
+) where {R,F<:Nothing} = nothing
 
 """
 Update reservoir boundary conditions for the local inertial river flow model.
@@ -421,8 +423,8 @@ function update_bc_reservoir_model!(
     reservoir_model::ReservoirModel,
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
-    dt::Float64,
-    dt_forcing::Float64,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
 )
     (; edges_at_node) = domain.river.network
     inds_reservoir = domain.reservoir.network.river_indices
@@ -435,7 +437,7 @@ function update_bc_reservoir_model!(
 
         q_in = get_inflow_reservoir(river_flow_model, edges_at_node.src[i])
         # If external_inflow < 0, abstraction is limited
-        if res_bc.external_inflow[v] < 0.0
+        if res_bc.external_inflow[v] < ZERO
             abstraction = min(
                 -res_bc.external_inflow[v],
                 (reservoir_model.variables.storage[v] / dt) * 0.98,
@@ -457,8 +459,8 @@ update_bc_reservoir_model!(
     reservoir_model::Nothing,
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
-    dt::Float64,
-    dt_forcing::Float64,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
 ) = nothing
 
 """
@@ -468,7 +470,7 @@ function update_water_depth_and_storage!(
     floodplain_model::AbstractFloodPlainModel,
     river_flow_model::LocalInertialRiverFlowModel,
     domain::DomainRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; edges_at_node) = domain.network
     (; flow_length, flow_width) = domain.parameters
@@ -482,9 +484,9 @@ function update_water_depth_and_storage!(
         q_src = sum_at(floodplain_v.q, edges_at_node.src[i])
         q_dst = sum_at(floodplain_v.q, edges_at_node.dst[i])
         floodplain_v.storage[i] = floodplain_v.storage[i] + (q_src - q_dst) * dt
-        if floodplain_v.storage[i] < 0.0
+        if floodplain_v.storage[i] < ZERO
             floodplain_v.error[i] += abs(floodplain_v.storage[i])
-            floodplain_v.storage[i] = 0.0
+            floodplain_v.storage[i] = ZERO
         end
         storage_total = river_v.storage[i] + floodplain_v.storage[i]
         if storage_total > river_p.bankfull_storage[i]
@@ -492,13 +494,13 @@ function update_water_depth_and_storage!(
             h = flood_depth(floodplain_p.profile, flood_storage, flow_length[i], i)
             river_v.h[i] = river_p.bankfull_depth[i] + h
             river_v.storage[i] = river_v.h[i] * flow_width[i] * flow_length[i]
-            floodplain_v.storage[i] = max(storage_total - river_v.storage[i], 0.0)
-            floodplain_v.h[i] = floodplain_v.storage[i] > 0.0 ? h : 0.0
+            floodplain_v.storage[i] = max(storage_total - river_v.storage[i], ZERO)
+            floodplain_v.h[i] = floodplain_v.storage[i] > ZERO ? h : ZERO
         else
             river_v.h[i] = storage_total / (flow_length[i] * flow_width[i])
             river_v.storage[i] = storage_total
-            floodplain_v.h[i] = 0.0
-            floodplain_v.storage[i] = 0.0
+            floodplain_v.h[i] = ZERO
+            floodplain_v.storage[i] = ZERO
         end
     end
     return nothing
@@ -511,7 +513,7 @@ update_water_depth_and_storage!(
     ::Nothing,
     ::LocalInertialRiverFlowModel,
     ::DomainRiver,
-    ::Float64,
+    ::PRECISION,
 ) = nothing
 
 """
@@ -520,7 +522,7 @@ Update water depth and storage for river.
 function update_water_depth_and_storage!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::DomainRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; edges_at_node) = domain.network
     (; flow_length, flow_width) = domain.parameters
@@ -538,12 +540,12 @@ function update_water_depth_and_storage!(
         river_v.storage[i] =
             river_v.storage[i] + (q_src - q_dst + inwater[i] - abstraction[i]) * dt
 
-        if river_v.storage[i] < 0.0
+        if river_v.storage[i] < ZERO
             river_v.error[i] = river_v.error[i] + abs(river_v.storage[i])
-            river_v.storage[i] = 0.0 # set storage to zero
+            river_v.storage[i] = ZERO # set storage to zero
         end
         # limit negative external inflow
-        if external_inflow[i] < 0.0
+        if external_inflow[i] < ZERO
             _abstraction = min(-external_inflow[i], river_v.storage[i] / dt * 0.80)
             actual_external_abstraction_av[i] += _abstraction * dt
             _inflow = -_abstraction
@@ -560,8 +562,8 @@ end
 function local_inertial_river_update!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
-    dt::Float64,
-    dt_forcing::Float64,
+    dt::PRECISION,
+    dt_forcing::PRECISION,
     update_h::Bool,
 )
     # Update river channel flow
@@ -601,7 +603,7 @@ function update_river_flow_model!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     clock::Clock;
-    update_h = true,
+    update_h=true,
 )
     (; reservoir) = river_flow_model.boundary_conditions
     (; flow_length) = domain.river.parameters
@@ -610,12 +612,12 @@ function update_river_flow_model!(
     update_index_hq!(reservoir, clock)
 
     if !isnothing(river_flow_model.floodplain)
-        river_flow_model.floodplain.variables.q_av .= 0.0
+        river_flow_model.floodplain.variables.q_av .= ZERO
     end
     set_flow_vars!(river_flow_model)
 
     dt = tosecond(clock.dt)
-    t = 0.0
+    t = ZERO
     while t < dt
         dt_s = stable_timestep(river_flow_model, flow_length)
         dt_s = check_timestepsize(dt_s, t, dt)
@@ -640,37 +642,37 @@ end
 @with_kw struct LocalInertialOverlandFlowVariables
     n::Int
     # flow in y direction at edge at previous time step [m³ s⁻¹]
-    qy0::Vector{Float64} = zeros(n + 1)
+    qy0::Vector{PRECISION} = zeros(n + 1)
     # flow in x direction at edge at previous time step [m³ s⁻¹]
-    qx0::Vector{Float64} = zeros(n + 1)
+    qx0::Vector{PRECISION} = zeros(n + 1)
     # flow in x direction at edge [m³ s⁻¹]
-    qx::Vector{Float64} = zeros(n + 1)
+    qx::Vector{PRECISION} = zeros(n + 1)
     # average flow in x direction at edge [m³ s⁻¹] for model timestep Δt
-    qx_av::Vector{Float64} = zeros(n + 1)
+    qx_av::Vector{PRECISION} = zeros(n + 1)
     # flow in y direction at edge [m³ s⁻¹]
-    qy::Vector{Float64} = zeros(n + 1)
+    qy::Vector{PRECISION} = zeros(n + 1)
     # average flow in y direction at edge [m³ s⁻¹] for model timestep Δt
-    qy_av::Vector{Float64} = zeros(n + 1)
+    qy_av::Vector{PRECISION} = zeros(n + 1)
     # total storage of cell [m³] (including river storage for river cells)
-    storage::Vector{Float64} = zeros(n)
+    storage::Vector{PRECISION} = zeros(n)
     # error storage [m³]
-    error::Vector{Float64} = zeros(n)
+    error::Vector{PRECISION} = zeros(n)
     # water depth of cell [m] (for river cells the reference is the river bed elevation `zb`)
-    h::Vector{Float64} = zeros(n)
+    h::Vector{PRECISION} = zeros(n)
 end
 
 "Struct to store local inertial overland flow model parameters"
 @with_kw struct LocalInertialOverlandFlowParameters
     n::Int                              # number of cells [-]
-    xwidth::Vector{Float64}             # effective flow width x direction at edge (floodplain) [m]
-    ywidth::Vector{Float64}             # effective flow width y direction at edge (floodplain) [m]
-    theta::Float64                      # weighting factor (de Almeida et al., 2012) [-]
-    h_thresh::Float64                   # depth threshold for calculating flow [m]
-    zx_max::Vector{Float64}             # maximum cell elevation at edge [m] (x direction)
-    zy_max::Vector{Float64}             # maximum cell elevation at edge [m] (y direction)
-    mannings_n_sq::Vector{Float64}      # Manning's roughness squared at edge [(s m-1/3)2]
-    z::Vector{Float64}                  # elevation [m] of cell
-    froude_limit::Bool                  # if true a check is performed if froude number > 1.0 (algorithm is modified) [-]
+    xwidth::Vector{PRECISION}             # effective flow width x direction at edge (floodplain) [m]
+    ywidth::Vector{PRECISION}             # effective flow width y direction at edge (floodplain) [m]
+    theta::PRECISION                      # weighting factor (de Almeida et al., 2012) [-]
+    h_thresh::PRECISION                   # depth threshold for calculating flow [m]
+    zx_max::Vector{PRECISION}             # maximum cell elevation at edge [m] (x direction)
+    zy_max::Vector{PRECISION}             # maximum cell elevation at edge [m] (y direction)
+    mannings_n_sq::Vector{PRECISION}      # Manning's roughness squared at edge [(s m-1/3)2]
+    z::Vector{PRECISION}                  # elevation [m] of cell
+    froude_limit::Bool                  # if true a check is performed if froude number > ONE (algorithm is modified) [-]
 end
 
 "Initialize shallow water overland flow model parameters"
@@ -694,15 +696,15 @@ function LocalInertialOverlandFlowParameters(
         config,
         "land_surface_water_flow__manning_n_parameter",
         Routing;
-        sel = indices,
+        sel=indices,
     )
     elevation_2d =
         ncread(dataset, config, "land_surface_water_flow__ground_elevation", Routing)
     elevation = elevation_2d[indices]
     n = length(domain.land.network.indices)
 
-    zx_max = fill(Float64(0), n)
-    zy_max = fill(Float64(0), n)
+    zx_max = fill(PRECISION(0), n)
+    zy_max = fill(PRECISION(0), n)
     for i in 1:n
         xu = edge_indices.xu[i]
         if xu <= n
@@ -722,14 +724,14 @@ function LocalInertialOverlandFlowParameters(
     set_effective_flowwidth!(we_x, we_y, domain)
     parameters = LocalInertialOverlandFlowParameters(;
         n,
-        xwidth = we_x,
-        ywidth = we_y,
+        xwidth=we_x,
+        ywidth=we_y,
         theta,
-        h_thresh = waterdepth_threshold,
+        h_thresh=waterdepth_threshold,
         zx_max,
         zy_max,
-        mannings_n_sq = mannings_n .* mannings_n,
-        z = elevation,
+        mannings_n_sq=mannings_n .* mannings_n,
+        z=elevation,
         froude_limit,
     )
     return parameters
@@ -738,7 +740,7 @@ end
 "Struct to store local inertial overland flow model boundary conditions"
 @with_kw struct LocalInertialOverlandFlowBC
     n::Int
-    runoff::Vector{Float64} = zeros(n) # runoff from hydrological model [m³ s⁻¹]
+    runoff::Vector{PRECISION} = zeros(n) # runoff from hydrological model [m³ s⁻¹]
 end
 
 "Local inertial overland flow model using the local inertial method"
@@ -770,7 +772,7 @@ function LocalInertialOverlandFlowModel(dataset::NCDataset, config::Config, doma
 end
 
 """
-    stable_timestep(river_flow_model::LocalInertialRiverFlowModel, flow_length::Vector{Float64})
+    stable_timestep(river_flow_model::LocalInertialRiverFlowModel, flow_length::Vector{PRECISION})
     stable_timestep(overland_flow_model::LocalInertialOverlandFlowModel, parameters::LandParameters)
 
 Compute a stable timestep size for the local inertial approach, based on Bates et al. (2010).
@@ -779,7 +781,7 @@ dt = α * (Δx / sqrt(g max(h))
 """
 function stable_timestep(
     river_flow_model::LocalInertialRiverFlowModel,
-    flow_length::Vector{Float64},
+    flow_length::Vector{PRECISION},
 )
     dt_min = Inf
     (; alpha_coefficient) = river_flow_model.timestepping
@@ -824,7 +826,7 @@ function update_bc_overland_flow_model!(
     overland_flow_model::LocalInertialOverlandFlowModel,
     external_models::NamedTuple,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; soil, runoff, subsurface_flow) = external_models
     (; net_runoff) = soil.variables
@@ -869,8 +871,8 @@ sum is computed from values at each sub timestep.
 """
 function set_flow_vars!(overland_flow_model::LocalInertialOverlandFlowModel)
     (; qx_av, qy_av) = overland_flow_model.variables
-    qx_av .= 0.0
-    qy_av .= 0.0
+    qx_av .= ZERO
+    qy_av .= ZERO
     return nothing
 end
 
@@ -880,7 +882,7 @@ This is done at the end of each simulation timestep.
 """
 function average_flow_vars!(
     overland_flow_model::LocalInertialOverlandFlowModel,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; qx_av, qy_av) = overland_flow_model.variables
     qx_av ./= dt
@@ -898,7 +900,7 @@ function update_overland_flow_model!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     clock::Clock;
-    update_h = false,
+    update_h=false,
 )
     (; reservoir) = river_flow_model.boundary_conditions
     (; flow_length) = domain.river.parameters
@@ -910,7 +912,7 @@ function update_overland_flow_model!(
     set_flow_vars!(overland_flow_model)
 
     dt = tosecond(clock.dt)
-    t = 0.0
+    t = ZERO
     while t < dt
         dt_river = stable_timestep(river_flow_model, flow_length)
         dt_land = stable_timestep(overland_flow_model, parameters)
@@ -944,7 +946,7 @@ Update flow for a single direction in the local inertial overland flow model.
     overland_flow_model::LocalInertialOverlandFlowModel,
     domain::Domain,
     i::Int,
-    dt::Float64,
+    dt::PRECISION,
     is_x_direction::Bool,
 )
     indices = domain.land.network.edge_indices
@@ -975,7 +977,7 @@ Update flow for a single direction in the local inertial overland flow model.
 
     # the effective flow width is zero when the river width exceeds the cell width and
     # floodplain flow is not calculated.
-    if upstream_idx <= land_p.n && width != 0.0
+    if upstream_idx <= land_p.n && width != ZERO
         zs_current = land_p.z[i] + land_v.h[i]
         zs_upstream = land_p.z[upstream_idx] + land_v.h[upstream_idx]
         zs_max = max(zs_current, zs_upstream)
@@ -998,14 +1000,14 @@ Update flow for a single direction in the local inertial overland flow model.
                 dt,
             )
             # limit q in case water is not available
-            if land_v.h[i] <= 0.0
-                q_current[i] = min(q_current[i], 0.0)
+            if land_v.h[i] <= ZERO
+                q_current[i] = min(q_current[i], ZERO)
             end
-            if land_v.h[upstream_idx] <= 0.0
-                q_current[i] = max(q_current[i], 0.0)
+            if land_v.h[upstream_idx] <= ZERO
+                q_current[i] = max(q_current[i], ZERO)
             end
         else
-            q_current[i] = 0.0
+            q_current[i] = ZERO
         end
         q_av[i] += q_current[i] * dt
     end
@@ -1019,7 +1021,7 @@ Update fluxes for overland flow `LocalInertialOverlandFlowModel` model for a sin
 function local_inertial_update_fluxes!(
     overland_flow_model::LocalInertialOverlandFlowModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     p = overland_flow_model.parameters
     v = overland_flow_model.variables
@@ -1044,7 +1046,7 @@ single timestep.
 """
 function update_inflow_reservoir!(
     overland_flow_model::LocalInertialOverlandFlowModel,
-    reservoir_model::Union{ReservoirModel, Nothing},
+    reservoir_model::Union{ReservoirModel,Nothing},
     domain::Domain,
 )
     indices = domain.land.network.edge_indices
@@ -1070,7 +1072,7 @@ Compute storage change for a river cell from fluxes.
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     i::Int,
-    dt::Float64,
+    dt::PRECISION,
 )
     indices = domain.land.network.edge_indices
     inds_river = domain.land.network.river_indices
@@ -1103,9 +1105,9 @@ Returns tuple: (inflow, abstraction_to_add)
     overland_flow_model::LocalInertialOverlandFlowModel,
     i::Int,
     river_idx::Int,
-    dt::Float64,
+    dt::PRECISION,
 )
-    if river_flow_model.boundary_conditions.external_inflow[river_idx] < 0.0
+    if river_flow_model.boundary_conditions.external_inflow[river_idx] < ZERO
         available_volume =
             if overland_flow_model.variables.storage[i] >=
                river_flow_model.parameters.bankfull_storage[river_idx]
@@ -1119,7 +1121,7 @@ Returns tuple: (inflow, abstraction_to_add)
         )
         return (-_abstraction, _abstraction * dt)
     else
-        return (river_flow_model.boundary_conditions.external_inflow[river_idx], 0.0)
+        return (river_flow_model.boundary_conditions.external_inflow[river_idx], ZERO)
     end
 end
 
@@ -1128,7 +1130,7 @@ Compute river and land water depths based on total storage and bankfull capacity
 Returns tuple: (river_h, land_h, river_storage)
 """
 @inline function compute_water_depths(
-    total_storage::Float64,
+    total_storage::PRECISION,
     river_idx::Int,
     i::Int,
     river::LocalInertialRiverFlowModel,
@@ -1153,7 +1155,7 @@ Returns tuple: (river_h, land_h, river_storage)
                 domain.river.parameters.flow_length[river_idx] *
                 domain.river.parameters.flow_width[river_idx]
             )
-        return (river_h, 0.0, total_storage)
+        return (river_h, ZERO, total_storage)
     end
 end
 
@@ -1164,7 +1166,7 @@ Compute storage change for a land cell from horizontal fluxes and runoff.
     overland_flow_model::LocalInertialOverlandFlowModel,
     network::NetworkLand,
     i::Int,
-    dt::Float64,
+    dt::PRECISION,
 )
     indices = network.edge_indices
     yd = indices.yd[i]
@@ -1185,7 +1187,7 @@ Update storage and water depth for a single river cell.
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     i::Int,
-    dt::Float64,
+    dt::PRECISION,
 )
     inds_river = domain.land.network.river_indices
     river_idx = inds_river[i]
@@ -1196,10 +1198,10 @@ Update storage and water depth for a single river cell.
     overland_flow_model.variables.storage[i] += storage_change
 
     # Handle negative storage
-    if overland_flow_model.variables.storage[i] < 0.0
+    if overland_flow_model.variables.storage[i] < ZERO
         overland_flow_model.variables.error[i] +=
             abs(overland_flow_model.variables.storage[i])
-        overland_flow_model.variables.storage[i] = 0.0 # set storage to zero
+        overland_flow_model.variables.storage[i] = ZERO # set storage to zero
     end
 
     # Compute and apply external inflow
@@ -1231,17 +1233,17 @@ Update storage and water depth for a single land cell (non-river).
     overland_flow_model::LocalInertialOverlandFlowModel,
     domain::DomainLand,
     i::Int,
-    dt::Float64,
+    dt::PRECISION,
 )
     # Compute and apply storage change
     storage_change = compute_land_storage_change(overland_flow_model, domain.network, i, dt)
     overland_flow_model.variables.storage[i] += storage_change
 
     # Handle negative storage
-    if overland_flow_model.variables.storage[i] < 0.0
+    if overland_flow_model.variables.storage[i] < ZERO
         overland_flow_model.variables.error[i] +=
             abs(overland_flow_model.variables.storage[i])
-        overland_flow_model.variables.storage[i] = 0.0 # set storage to zero
+        overland_flow_model.variables.storage[i] = ZERO # set storage to zero
     end
 
     # Update water depth
@@ -1260,7 +1262,7 @@ function local_inertial_update_water_depth!(
     overland_flow_model::LocalInertialOverlandFlowModel,
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; river_location, reservoir_outlet) = domain.land.parameters
 
@@ -1292,11 +1294,11 @@ cumulative floodplain `storage` a floodplain profile as a function of `flood_dep
 derived with floodplain area `a` (cumulative) and wetted perimeter radius `p` (cumulative).
 """
 @with_kw struct FloodPlainProfile
-    depth::Vector{Float64}        # Flood depth [m]
-    storage::Matrix{Float64}      # Flood storage (cumulative) [m³]
-    width::Matrix{Float64}        # Flood width [m]
-    a::Matrix{Float64}            # Flow area (cumulative) [m²]
-    p::Matrix{Float64}            # Wetted perimeter (cumulative) [m]
+    depth::Vector{PRECISION}        # Flood depth [m]
+    storage::Matrix{PRECISION}      # Flood storage (cumulative) [m³]
+    width::Matrix{PRECISION}        # Flood width [m]
+    a::Matrix{PRECISION}            # Flow area (cumulative) [m²]
+    p::Matrix{PRECISION}            # Wetted perimeter (cumulative) [m]
 end
 
 "Initialize floodplain profile `FloodPlainProfile`"
@@ -1313,16 +1315,16 @@ function FloodPlainProfile(
         config,
         "floodplain_water__sum_of_volume_per_depth",
         Routing;
-        sel = indices,
+        sel=indices,
     )
     n = length(indices)
 
     # for convenience (interpolation) flood depth 0.0 m is added, with associated area (a),
     # storage, width (river width) and wetted perimeter (p).
-    storage = vcat(fill(Float64(0), n)', storage)
+    storage = vcat(fill(ZERO, n)', storage)
     start_storage = storage
-    flood_depths = Float64.(dataset["flood_depth"][:])
-    pushfirst!(flood_depths, 0.0)
+    flood_depths = PRECISION.(dataset["flood_depth"][:])
+    pushfirst!(flood_depths, ZERO)
     n_depths = length(flood_depths)
 
     p = zeros(n_depths, n)
@@ -1340,28 +1342,28 @@ function FloodPlainProfile(
         riv_cell = 0
         diff_storage = diff(storage[:, i])
 
-        for j in 1:(n_depths - 1)
+        for j in 1:(n_depths-1)
             # assume rectangular shape of flood depth segment
-            width[j + 1, i] = diff_storage[j] / (h[j] * flow_length[i])
+            width[j+1, i] = diff_storage[j] / (h[j] * flow_length[i])
             # check provided flood storage (floodplain width should be constant or increasing
             # as a function of flood depth)
-            if width[j + 1, i] < width[j, i]
+            if width[j+1, i] < width[j, i]
                 # raise warning only if difference is larger than rounding error of 0.01 m³
-                if ((width[j, i] - width[j + 1, i]) * h[j] * flow_length[i]) > 0.01
+                if ((width[j, i] - width[j+1, i]) * h[j] * flow_length[i]) > 0.01
                     incorrect_vol += 1
                     riv_cell = 1
                     error_vol =
                         error_vol +
-                        ((width[j, i] - width[j + 1, i]) * h[j] * flow_length[i])
+                        ((width[j, i] - width[j+1, i]) * h[j] * flow_length[i])
                 end
-                width[j + 1, i] = width[j, i]
+                width[j+1, i] = width[j, i]
             end
-            a[j + 1, i] = width[j + 1, i] * h[j]
-            p[j + 1, i] = (width[j + 1, i] - width[j, i]) + 2.0 * h[j]
-            segment_storage[j + 1, i] = a[j + 1, i] * flow_length[i]
+            a[j+1, i] = width[j+1, i] * h[j]
+            p[j+1, i] = (width[j+1, i] - width[j, i]) + 2.0 * h[j]
+            segment_storage[j+1, i] = a[j+1, i] * flow_length[i]
             if j == 1
                 # for interpolation wetted perimeter at flood depth 0.0 is required
-                p[j, i] = p[j + 1, i] - 2.0 * h[j]
+                p[j, i] = p[j+1, i] - 2.0 * h[j]
             end
         end
 
@@ -1373,8 +1375,8 @@ function FloodPlainProfile(
     end
 
     if incorrect_vol > 0
-        perc_riv_cells = round(100.0 * (riv_cells / n); digits = 2)
-        perc_error_vol = round(100.0 * (error_vol / sum(start_storage[end, :])); digits = 2)
+        perc_riv_cells = round(100.0 * (riv_cells / n); digits=2)
+        perc_error_vol = round(100.0 * (error_vol / sum(start_storage[end, :])); digits=2)
         @warn string(
             "The provided storage of $incorrect_vol rectangular floodplain schematization",
             " segments for $riv_cells river cells ($perc_riv_cells % of total river cells)",
@@ -1389,16 +1391,16 @@ function FloodPlainProfile(
     p = hcat(p, p[:, index_pit])
 
     # initialize floodplain profile parameters
-    profile = FloodPlainProfile(; storage, width, depth = flood_depths, a, p)
+    profile = FloodPlainProfile(; storage, width, depth=flood_depths, a, p)
     return profile
 end
 
 "Struct to store floodplain flow model parameters"
 @with_kw struct FloodPlainParameters
     profile::FloodPlainProfile          # floodplain profile
-    mannings_n::Vector{Float64}         # manning's roughness [s m-1/3]
-    mannings_n_sq::Vector{Float64}      # manning's roughness squared at edge [(s m-1/3)2]
-    zb_max::Vector{Float64}             # maximum bankfull elevation at edge [m]
+    mannings_n::Vector{PRECISION}         # manning's roughness [s m-1/3]
+    mannings_n_sq::Vector{PRECISION}      # manning's roughness squared at edge [(s m-1/3)2]
+    zb_max::Vector{PRECISION}             # maximum bankfull elevation at edge [m]
 end
 
 "Initialize floodplain flow model parameters"
@@ -1406,7 +1408,7 @@ function FloodPlainParameters(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    zb_floodplain::Vector{Float64},
+    zb_floodplain::Vector{PRECISION},
     index_pit::Vector{Int},
 )
     (; indices, nodes_at_edge, graph) = domain.network
@@ -1419,12 +1421,12 @@ function FloodPlainParameters(
         config,
         "floodplain_water_flow__manning_n_parameter",
         Routing;
-        sel = indices,
+        sel=indices,
     )
     # manning roughness at edges
     append!(mannings_n, mannings_n[index_pit]) # copy to ghost nodes
-    mannings_n_sq = fill(Float64(0), n_edges)
-    zb_max = fill(Float64(0), n_edges)
+    mannings_n_sq = fill(PRECISION(0), n_edges)
+    zb_max = fill(PRECISION(0), n_edges)
     for i in 1:n_edges
         src_node = nodes_at_edge.src[i]
         dst_node = nodes_at_edge.dst[i]
@@ -1444,21 +1446,21 @@ end
 @with_kw struct FloodPlainVariables
     n::Int
     n_edges::Int
-    storage::Vector{Float64} = zeros(n)    # storage [m³]
-    h::Vector{Float64}                     # water depth [m]
-    error::Vector{Float64} = zeros(n)      # error storage [m³]
-    a::Vector{Float64} = zeros(n_edges)    # flow area at edge [m²]
-    r::Vector{Float64} = zeros(n_edges)    # hydraulic radius at edge [m]
-    hf::Vector{Float64} = zeros(n_edges)   # water depth at edge [m]
-    q0::Vector{Float64} = zeros(n_edges)   # discharge at edge at previous time step
-    q::Vector{Float64} = zeros(n_edges)    # discharge at edge  [m³ s⁻¹]
-    q_av::Vector{Float64} = zeros(n_edges) # average river discharge at edge  [m³ s⁻¹] for model timestep Δt
+    storage::Vector{PRECISION} = zeros(n)    # storage [m³]
+    h::Vector{PRECISION}                     # water depth [m]
+    error::Vector{PRECISION} = zeros(n)      # error storage [m³]
+    a::Vector{PRECISION} = zeros(n_edges)    # flow area at edge [m²]
+    r::Vector{PRECISION} = zeros(n_edges)    # hydraulic radius at edge [m]
+    hf::Vector{PRECISION} = zeros(n_edges)   # water depth at edge [m]
+    q0::Vector{PRECISION} = zeros(n_edges)   # discharge at edge at previous time step
+    q::Vector{PRECISION} = zeros(n_edges)    # discharge at edge  [m³ s⁻¹]
+    q_av::Vector{PRECISION} = zeros(n_edges) # average river discharge at edge  [m³ s⁻¹] for model timestep Δt
     hf_index::Vector{Int} = zeros(Int, n_edges) # edge index with `hf` [-] above depth threshold
 end
 
 "Initialize floodplain flow model variables"
 function FloodPlainVariables(n::Int, n_edges::Int, index_pit::Vector{Int})
-    variables = FloodPlainVariables(; n, n_edges, h = zeros(n + length(index_pit)))
+    variables = FloodPlainVariables(; n, n_edges, h=zeros(n + length(index_pit)))
     return variables
 end
 
@@ -1481,7 +1483,7 @@ function initialize_storage!(river, domain::Domain, nriv::Int)
             profile.depth[i1],
             floodplain.variables.h[i],
         )
-        a = max(a - (flow_width[i] * floodplain.variables.h[i]), 0.0)
+        a = max(a - (flow_width[i] * floodplain.variables.h[i]), ZERO)
         floodplain.variables.storage[i] = flow_length[i] * a
     end
     return nothing
@@ -1530,8 +1532,8 @@ end
 "Compute flood depth by interpolating flood storage `flood_storage` using flood depth intervals."
 function flood_depth(
     profile::FloodPlainProfile,
-    flood_storage::Float64,
-    flow_length::Float64,
+    flood_storage::PRECISION,
+    flow_length::PRECISION,
     i::Int,
 )
     i1, i2 = interpolation_indices(flood_storage, @view profile.storage[:, i])
@@ -1546,7 +1548,7 @@ function FloodPlainModel(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    zb_floodplain::Vector{Float64},
+    zb_floodplain::Vector{PRECISION},
 )
     (; indices, local_drain_direction, graph) = domain.network
     n = length(indices)

--- a/Wflow/src/routing/surface/surface_local_inertial.jl
+++ b/Wflow/src/routing/surface/surface_local_inertial.jl
@@ -39,7 +39,7 @@ function LocalInertialRiverFlowParameters(
         config,
         "model_boundary_condition_river__length",
         Routing;
-        sel=pit_indices,
+        sel = pit_indices,
     )
     bankfull_elevation_2d = ncread(dataset, config, "river_bank_water__elevation", Routing)
     bankfull_depth_2d = ncread(dataset, config, "river_bank_water__depth", Routing)
@@ -52,7 +52,7 @@ function LocalInertialRiverFlowParameters(
         config,
         "river_water_flow__manning_n_parameter",
         Routing;
-        sel=indices,
+        sel = indices,
     )
 
     n = length(indices)
@@ -88,19 +88,19 @@ function LocalInertialRiverFlowParameters(
 
     parameters = LocalInertialRiverFlowParameters(;
         n,
-        ne=n_edges,
-        active_n=active_index,
-        active_e=active_index,
+        ne = n_edges,
+        active_n = active_index,
+        active_e = active_index,
         froude_limit,
-        h_thresh=waterdepth_threshold,
+        h_thresh = waterdepth_threshold,
         zb,
         zb_max,
         bankfull_storage,
         bankfull_depth,
         mannings_n,
         mannings_n_sq,
-        flow_length_at_edge=length_at_edge,
-        flow_width_at_edge=width_at_edge,
+        flow_length_at_edge = length_at_edge,
+        flow_width_at_edge = width_at_edge,
     )
     return parameters
 end
@@ -137,7 +137,7 @@ function LocalInertialRiverFlowVariables(
         config,
         "model_boundary_condition_river_bank_water__depth",
         Routing;
-        sel=pit_indices,
+        sel = pit_indices,
     )
 
     n = length(indices)
@@ -151,7 +151,7 @@ function LocalInertialRiverFlowVariables(
         n,
         n_edges,
         q_av,
-        q_channel_av=config.model.floodplain_1d__flag ? zeros(n_edges) : q_av,
+        q_channel_av = config.model.floodplain_1d__flag ? zeros(n_edges) : q_av,
         h,
     )
     return variables
@@ -159,9 +159,9 @@ end
 
 "Shallow water river flow model using the local inertial method"
 @with_kw struct LocalInertialRiverFlowModel{
-    R<:RiverFlowBC,
-    F<:Union{AbstractFloodPlainModel,Nothing},
-    A<:AbstractAllocationModel,
+    R <: RiverFlowBC,
+    F <: Union{AbstractFloodPlainModel, Nothing},
+    A <: AbstractAllocationModel,
 } <: AbstractRiverFlowModel
     timestepping::TimeStepping
     boundary_conditions::R
@@ -176,7 +176,7 @@ function LocalInertialRiverFlowModel(
     dataset::NCDataset,
     config::Config,
     domain::DomainRiver,
-    reservoir_model::Union{ReservoirModel,Nothing},
+    reservoir_model::Union{ReservoirModel, Nothing},
 )
     # The local inertial approach makes use of a staggered grid (Bates et al. (2010)),
     # with nodes and edges. This information is extracted from the directed graph of the
@@ -211,8 +211,8 @@ function LocalInertialRiverFlowModel(
         parameters,
         variables,
         floodplain,
-        allocation=do_water_demand(config) ? AllocationRiverModel(n) :
-                   NoAllocationRiverModel(n),
+        allocation = do_water_demand(config) ? AllocationRiverModel(n) :
+                     NoAllocationRiverModel(n),
     )
     return river_flow
 end
@@ -309,10 +309,10 @@ end
 Update floodplain flow for the local inertial river flow model.
 """
 function update_floodplain_flow!(
-    river_flow_model::LocalInertialRiverFlowModel{R,F},
+    river_flow_model::LocalInertialRiverFlowModel{R, F},
     domain::DomainRiver,
     dt::PRECISION,
-) where {R,F<:AbstractFloodPlainModel}
+) where {R, F <: AbstractFloodPlainModel}
     (; nodes_at_edge) = domain.network
     (; flow_width) = domain.parameters
 
@@ -411,10 +411,10 @@ function update_floodplain_flow!(
 end
 
 update_floodplain_flow!(
-    model::LocalInertialRiverFlowModel{R,F},
+    model::LocalInertialRiverFlowModel{R, F},
     domain::DomainRiver,
     dt::PRECISION,
-) where {R,F<:Nothing} = nothing
+) where {R, F <: Nothing} = nothing
 
 """
 Update reservoir boundary conditions for the local inertial river flow model.
@@ -603,7 +603,7 @@ function update_river_flow_model!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     clock::Clock;
-    update_h=true,
+    update_h = true,
 )
     (; reservoir) = river_flow_model.boundary_conditions
     (; flow_length) = domain.river.parameters
@@ -696,7 +696,7 @@ function LocalInertialOverlandFlowParameters(
         config,
         "land_surface_water_flow__manning_n_parameter",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     elevation_2d =
         ncread(dataset, config, "land_surface_water_flow__ground_elevation", Routing)
@@ -724,14 +724,14 @@ function LocalInertialOverlandFlowParameters(
     set_effective_flowwidth!(we_x, we_y, domain)
     parameters = LocalInertialOverlandFlowParameters(;
         n,
-        xwidth=we_x,
-        ywidth=we_y,
+        xwidth = we_x,
+        ywidth = we_y,
         theta,
-        h_thresh=waterdepth_threshold,
+        h_thresh = waterdepth_threshold,
         zx_max,
         zy_max,
-        mannings_n_sq=mannings_n .* mannings_n,
-        z=elevation,
+        mannings_n_sq = mannings_n .* mannings_n,
+        z = elevation,
         froude_limit,
     )
     return parameters
@@ -835,7 +835,7 @@ function update_bc_overland_flow_model!(
     river_indices = domain.river.network.land_indices
 
     @. overland_flow_model.boundary_conditions.runoff =
-        net_runoff / 1000.0 * area / dt + net_runoff_river * area * 0.001 / dt
+        net_runoff / 1000 * area / dt + net_runoff_river * area / dt / 1000
     overland_flow_model.boundary_conditions.runoff[river_indices] .+=
         get_flux_to_river(subsurface_flow, river_indices)
     return nothing
@@ -900,7 +900,7 @@ function update_overland_flow_model!(
     river_flow_model::LocalInertialRiverFlowModel,
     domain::Domain,
     clock::Clock;
-    update_h=false,
+    update_h = false,
 )
     (; reservoir) = river_flow_model.boundary_conditions
     (; flow_length) = domain.river.parameters
@@ -1046,7 +1046,7 @@ single timestep.
 """
 function update_inflow_reservoir!(
     overland_flow_model::LocalInertialOverlandFlowModel,
-    reservoir_model::Union{ReservoirModel,Nothing},
+    reservoir_model::Union{ReservoirModel, Nothing},
     domain::Domain,
 )
     indices = domain.land.network.edge_indices
@@ -1315,7 +1315,7 @@ function FloodPlainProfile(
         config,
         "floodplain_water__sum_of_volume_per_depth",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     n = length(indices)
 
@@ -1342,28 +1342,28 @@ function FloodPlainProfile(
         riv_cell = 0
         diff_storage = diff(storage[:, i])
 
-        for j in 1:(n_depths-1)
+        for j in 1:(n_depths - 1)
             # assume rectangular shape of flood depth segment
-            width[j+1, i] = diff_storage[j] / (h[j] * flow_length[i])
+            width[j + 1, i] = diff_storage[j] / (h[j] * flow_length[i])
             # check provided flood storage (floodplain width should be constant or increasing
             # as a function of flood depth)
-            if width[j+1, i] < width[j, i]
+            if width[j + 1, i] < width[j, i]
                 # raise warning only if difference is larger than rounding error of 0.01 m³
-                if ((width[j, i] - width[j+1, i]) * h[j] * flow_length[i]) > 0.01
+                if ((width[j, i] - width[j + 1, i]) * h[j] * flow_length[i]) > 0.01
                     incorrect_vol += 1
                     riv_cell = 1
                     error_vol =
                         error_vol +
-                        ((width[j, i] - width[j+1, i]) * h[j] * flow_length[i])
+                        ((width[j, i] - width[j + 1, i]) * h[j] * flow_length[i])
                 end
-                width[j+1, i] = width[j, i]
+                width[j + 1, i] = width[j, i]
             end
-            a[j+1, i] = width[j+1, i] * h[j]
-            p[j+1, i] = (width[j+1, i] - width[j, i]) + 2.0 * h[j]
-            segment_storage[j+1, i] = a[j+1, i] * flow_length[i]
+            a[j + 1, i] = width[j + 1, i] * h[j]
+            p[j + 1, i] = (width[j + 1, i] - width[j, i]) + 2.0 * h[j]
+            segment_storage[j + 1, i] = a[j + 1, i] * flow_length[i]
             if j == 1
                 # for interpolation wetted perimeter at flood depth 0.0 is required
-                p[j, i] = p[j+1, i] - 2.0 * h[j]
+                p[j, i] = p[j + 1, i] - 2.0 * h[j]
             end
         end
 
@@ -1375,8 +1375,8 @@ function FloodPlainProfile(
     end
 
     if incorrect_vol > 0
-        perc_riv_cells = round(100.0 * (riv_cells / n); digits=2)
-        perc_error_vol = round(100.0 * (error_vol / sum(start_storage[end, :])); digits=2)
+        perc_riv_cells = round(100.0 * (riv_cells / n); digits = 2)
+        perc_error_vol = round(100.0 * (error_vol / sum(start_storage[end, :])); digits = 2)
         @warn string(
             "The provided storage of $incorrect_vol rectangular floodplain schematization",
             " segments for $riv_cells river cells ($perc_riv_cells % of total river cells)",
@@ -1391,7 +1391,7 @@ function FloodPlainProfile(
     p = hcat(p, p[:, index_pit])
 
     # initialize floodplain profile parameters
-    profile = FloodPlainProfile(; storage, width, depth=flood_depths, a, p)
+    profile = FloodPlainProfile(; storage, width, depth = flood_depths, a, p)
     return profile
 end
 
@@ -1421,7 +1421,7 @@ function FloodPlainParameters(
         config,
         "floodplain_water_flow__manning_n_parameter",
         Routing;
-        sel=indices,
+        sel = indices,
     )
     # manning roughness at edges
     append!(mannings_n, mannings_n[index_pit]) # copy to ghost nodes
@@ -1460,7 +1460,7 @@ end
 
 "Initialize floodplain flow model variables"
 function FloodPlainVariables(n::Int, n_edges::Int, index_pit::Vector{Int})
-    variables = FloodPlainVariables(; n, n_edges, h=zeros(n + length(index_pit)))
+    variables = FloodPlainVariables(; n, n_edges, h = zeros(n + length(index_pit)))
     return variables
 end
 

--- a/Wflow/src/routing/surface/surface_process.jl
+++ b/Wflow/src/routing/surface/surface_process.jl
@@ -7,7 +7,7 @@ a `snow` model.
 function lateral_snow_transport!(snow::AbstractSnowModel, domain::DomainLand)
     (; snow_storage, snow_water, snow_in, snow_out) = snow.variables
     (; slope) = domain.parameters
-    snowflux_frac = min.(0.5, slope ./ 5.67) .* min.(1.0, snow_storage ./ 10000.0)
+    snowflux_frac = min.(0.5, slope ./ 5.67) .* min.(ONE, snow_storage ./ 10000.0)
     maxflux = snowflux_frac .* snow_storage
     snow_out .= accucapacityflux(snow_storage, domain.network, maxflux)
     snow_out .+= accucapacityflux(snow_water, domain.network, snow_water .* snowflux_frac)
@@ -18,19 +18,19 @@ lateral_snow_transport!(snow::NoSnowModel, domain::DomainLand) = nothing
 
 "Kinematic wave surface flow rate for a single cell and timestep"
 function kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx)
-    if q_in + q_prev + q_lat ≈ 0.0
-        return 0.0, 0.0
+    if q_in + q_prev + q_lat ≈ ZERO
+        return ZERO, ZERO
     else
         dt_dx = dt / dx
         # constant_term = (dt/dx)*q_in + alpha*q_prev^(3/5) + dt*q_lat
         # Use q_prev^(3/5) = (q_prev^(1/5))^3
-        u_prev = q_prev >= 0.0 ? Wflow.pow(q_prev, 0.2) : 0.0
+        u_prev = q_prev >= ZERO ? Wflow.pow(q_prev, 1 // 5) : ZERO
         constant_term = dt_dx * q_in + alpha * u_prev * u_prev * u_prev + dt * q_lat
 
         # Initial estimate: use u_prev as starting point (cheap, no pow calls)
         # Since q changes smoothly between timesteps, u_prev is already close to the root.
         # For the case q_prev == 0, use C/alpha as a rough estimate for u^3, so u ≈ cbrt(C/alpha)
-        u = if u_prev > 0.0
+        u = if u_prev > ZERO
             u_prev
         else
             cbrt(constant_term / alpha)
@@ -40,12 +40,12 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx)
         # f'(u)  = 5*dt_dx * u^4 + 3*alpha * u^2
         # f''(u) = 20*dt_dx * u^3 + 6*alpha * u
         max_iters = 3000
-        epsilon = 1.0e-12
+        epsilon = to_precision(1e-12)
 
-        const_1 = 5.0 * dt_dx
-        const_2 = 3.0 * alpha
-        const_3 = 20.0 * dt_dx
-        const_4 = 6.0 * alpha
+        const_1 = 5 * dt_dx
+        const_2 = 3 * alpha
+        const_3 = 20 * dt_dx
+        const_4 = 6 * alpha
 
         for _ in 1:max_iters
             u2 = u * u
@@ -55,7 +55,7 @@ function kinematic_wave(q_in, q_prev, q_lat, alpha, dt, dx)
             d2f_u = u * (const_3 * u2 + const_4)
             # Halley's correction: u -= f*f' / (f'^2 - f*f''/2)
             u -= (f_u * df_u) / (df_u * df_u - f_u * d2f_u / 2)
-            if isnan(u) || u <= 0.0
+            if isnan(u) || u <= ZERO
                 u = KIN_WAVE_MIN_FLOW_QROOT
             end
             if (abs(f_u) <= epsilon)
@@ -107,10 +107,10 @@ function local_inertial_flow(
         )
     )
 
-    # if froude number > 1.0, limit flow
+    # if froude number > ONE, limit flow
     fr = ((q / A) / sqrt(GRAVITATIONAL_ACCELERATION * hf)) * froude_limit
-    q = ifelse((abs(fr) > 1.0) * (q > 0.0), sqrt(GRAVITATIONAL_ACCELERATION * hf) * A, q)
-    q = ifelse((abs(fr) > 1.0) * (q < 0.0), -sqrt(GRAVITATIONAL_ACCELERATION * hf) * A, q)
+    q = ifelse((abs(fr) > ONE) * (q > ZERO), sqrt(GRAVITATIONAL_ACCELERATION * hf) * A, q)
+    q = ifelse((abs(fr) > ONE) * (q < ZERO), -sqrt(GRAVITATIONAL_ACCELERATION * hf) * A, q)
 
     return q
 end
@@ -150,12 +150,12 @@ function local_inertial_flow(
             GRAVITATIONAL_ACCELERATION * dt * mannings_n_sq * abs(q0) / (pow_hf * width)
         )
     )
-    # if froude number > 1.0, limit flow
+    # if froude number > ONE, limit flow
     if froude_limit
         fr = (q / width / hf) / sqrt(GRAVITATIONAL_ACCELERATION * hf)
-        if abs(fr) > 1.0 && q > 0.0
+        if abs(fr) > ONE && q > ZERO
             q = hf * sqrt(GRAVITATIONAL_ACCELERATION * hf) * width
-        elseif abs(fr) > 1.0 && q < 0.0
+        elseif abs(fr) > ONE && q < ZERO
             q = -hf * sqrt(GRAVITATIONAL_ACCELERATION * hf) * width
         end
     end

--- a/Wflow/src/routing/timestepping.jl
+++ b/Wflow/src/routing/timestepping.jl
@@ -1,10 +1,10 @@
 
 "Timestepping for river, overland and subsurface flow routing."
 @with_kw struct TimeStepping
-    stable_timesteps::Vector{Float64} = Float64[]
-    dt_fixed::Float64 = 0.0
+    stable_timesteps::Vector{PRECISION} = PRECISION[]
+    dt_fixed::PRECISION = ZERO
     adaptive::Bool = true
-    alpha_coefficient::Float64 = 1.0
+    alpha_coefficient::PRECISION = ONE
 end
 
 "Check timestep size"

--- a/Wflow/src/routing/utils.jl
+++ b/Wflow/src/routing/utils.jl
@@ -1,5 +1,5 @@
-const KIN_WAVE_MIN_FLOW = 1e-30 # [m³ s⁻¹]
-const KIN_WAVE_MIN_FLOW_QROOT = KIN_WAVE_MIN_FLOW^0.2
+const KIN_WAVE_MIN_FLOW = to_precision(1e-30) # [m³ s⁻¹]
+const KIN_WAVE_MIN_FLOW_QROOT = KIN_WAVE_MIN_FLOW^to_precision(0.2)
 
 "Convert a gridded drainage direction to a directed graph"
 function flowgraph(ldd::AbstractVector, indices::AbstractVector, PCR_DIR::AbstractVector)

--- a/Wflow/src/sbm.jl
+++ b/Wflow/src/sbm.jl
@@ -2,7 +2,7 @@ abstract type AbstractDemandModel end
 abstract type AbstractAllocationModel end
 
 "Land hydrology model with SBM soil model"
-@with_kw struct LandHydrologySBM{D<:AbstractDemandModel,A<:AbstractAllocationModel} <:
+@with_kw struct LandHydrologySBM{D <: AbstractDemandModel, A <: AbstractAllocationModel} <:
                 AbstractLandModel
     atmospheric_forcing::AtmosphericForcing
     vegetation_parameters::VegetationParameters
@@ -40,7 +40,7 @@ function LandHydrologySBM(dataset::NCDataset, config::Config, domain::DomainLand
         snow = NoSnowModel(n)
     end
     if do_snow && do_glacier
-        glacier_bc = SnowStateBC(; snow_storage=snow.variables.snow_storage)
+        glacier_bc = SnowStateBC(; snow_storage = snow.variables.snow_storage)
         glacier = GlacierHbvModel(dataset, config, indices, dt, glacier_bc)
     elseif !do_snow && do_glacier
         @warn string(
@@ -85,7 +85,7 @@ function update_land_hydrology_model!(
     routing::Routing,
     domain::Domain,
     config::Config,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; parameters) = domain.land
     (; glacier, snow, interception, runoff, soil, demand, allocation, atmospheric_forcing) =
@@ -170,7 +170,7 @@ function update_total_water_storage!(
 
     # Chunk the data for parallel computing
     n = length(ustoredepth)
-    threaded_foreach(1:n; basesize=1000) do i
+    threaded_foreach(1:n; basesize = 1000) do i
         sub_surface = ustoredepth[i] + satwaterdepth[i]
         lateral = (
             overland_flow.variables.h[i] * (1 - river_fraction[i]) * 1000 # convert to mm

--- a/Wflow/src/sbm_gwf_model.jl
+++ b/Wflow/src/sbm_gwf_model.jl
@@ -39,7 +39,7 @@ function Model(config::Config, type::SbmGwfModel)
         modelmap,
         domain,
         dataset;
-        extra_dim = (name = "layer", value = Float64.(1:(maxlayers))),
+        extra_dim = (name = "layer", value = PRECISION.(1:(maxlayers))),
     )
     close(dataset)
 
@@ -73,15 +73,15 @@ function update_model!(model::AbstractModel{<:SbmGwfModel})
     # set river stage and storage (groundwater boundary)
     update_river_storage_stage!(boundary_conditions.river, routing.river_flow)
     # determine stable time step for groundwater flow
-    dt_gwf = (dt / tosecond(BASETIMESTEP)) # dt is in seconds (Float64)
+    dt_gwf = (dt / tosecond(BASETIMESTEP)) # dt is in seconds (PRECISION)
 
     # exchange of recharge between SBM soil model and groundwater flow domain
     # recharge rate groundwater is required in units [m d⁻¹]
     @. boundary_conditions.recharge.variables.rate =
-        soil.variables.recharge / 1000.0 * (1.0 / dt_gwf)
+        soil.variables.recharge / 1000.0 * (ONE / dt_gwf)
     if do_water_demand(config)
         @. boundary_conditions.recharge.variables.rate -=
-            land.allocation.variables.act_groundwater_abst / 1000.0 * (1.0 / dt_gwf)
+            land.allocation.variables.act_groundwater_abst / 1000.0 * (ONE / dt_gwf)
     end
     # update groundwater domain
     update_subsurface_flow_model!(

--- a/Wflow/src/sbm_gwf_model.jl
+++ b/Wflow/src/sbm_gwf_model.jl
@@ -78,10 +78,10 @@ function update_model!(model::AbstractModel{<:SbmGwfModel})
     # exchange of recharge between SBM soil model and groundwater flow domain
     # recharge rate groundwater is required in units [m d⁻¹]
     @. boundary_conditions.recharge.variables.rate =
-        soil.variables.recharge / 1000.0 * (ONE / dt_gwf)
+        soil.variables.recharge / 1000 * (ONE / dt_gwf)
     if do_water_demand(config)
         @. boundary_conditions.recharge.variables.rate -=
-            land.allocation.variables.act_groundwater_abst / 1000.0 * (ONE / dt_gwf)
+            land.allocation.variables.act_groundwater_abst / 1000 * (ONE / dt_gwf)
     end
     # update groundwater domain
     update_subsurface_flow_model!(

--- a/Wflow/src/sbm_model.jl
+++ b/Wflow/src/sbm_model.jl
@@ -34,7 +34,7 @@ function Model(config::Config, type::SbmModel)
         modelmap,
         domain,
         dataset;
-        extra_dim = (name = "layer", value = Float64.(1:(maxlayers))),
+        extra_dim = (name = "layer", value = PRECISION.(1:(maxlayers))),
     )
     close(dataset)
 
@@ -116,7 +116,7 @@ function set_states!(model::AbstractModel{<:Union{SbmModel, SbmGwfModel}})
         nriv = length(domain.river.network.indices)
         instate_path = input_path(config, config.state.path_input)
         @info "Set initial conditions from state file `$instate_path`."
-        set_states!(instate_path, model; type = Float64, dimname = :layer)
+        set_states!(instate_path, model; type = PRECISION, dimname = :layer)
 
         update_diagnostic_vars!(land.soil)
 
@@ -124,9 +124,9 @@ function set_states!(model::AbstractModel{<:Union{SbmModel, SbmGwfModel}})
             (; surface_flow_width, flow_length) = domain.land.parameters
             # make sure land cells with zero flow width are set to zero q and h
             for i in eachindex(surface_flow_width)
-                if surface_flow_width[i] <= 0.0
-                    land_v.q[i] = 0.0
-                    land_v.h[i] = 0.0
+                if surface_flow_width[i] <= ZERO
+                    land_v.q[i] = ZERO
+                    land_v.h[i] = ZERO
                 end
             end
             land_v.storage .= land_v.h .* surface_flow_width .* flow_length
@@ -137,7 +137,7 @@ function set_states!(model::AbstractModel{<:Union{SbmModel, SbmGwfModel}})
             for i in eachindex(land_v.storage)
                 if river_location[i]
                     j = domain.land.network.river_indices[i]
-                    if land_v.h[i] > 0.0
+                    if land_v.h[i] > ZERO
                         land_v.storage[i] =
                             land_v.h[i] * x_length[i] * y_length[i] + bankfull_storage[j]
                     else

--- a/Wflow/src/sbm_model.jl
+++ b/Wflow/src/sbm_model.jl
@@ -75,15 +75,15 @@ function update_model!(model::AbstractModel{<:SbmModel})
             land.allocation.variables.act_groundwater_abst
     end
     # unit conversions
-    boundary_conditions.recharge.variables.rate .*= 0.001 * (tosecond(BASETIMESTEP) / dt)
-    routing.subsurface_flow.variables.zi .= land.soil.variables.zi ./ 1000.0
+    boundary_conditions.recharge.variables.rate .*= (tosecond(BASETIMESTEP) / dt) / 1000
+    routing.subsurface_flow.variables.zi .= land.soil.variables.zi ./ 1000
     # update lateral subsurface flow domain (kinematic wave)
     kh_layered_profile!(land.soil, routing.subsurface_flow, kv_profile, dt)
     update_subsurface_flow_model!(
         routing.subsurface_flow,
         land.soil,
         domain,
-        clock.dt / BASETIMESTEP,
+        to_precision(clock.dt / BASETIMESTEP),
     )
     # update SBM soil model (runoff, ustorelayerdepth and satwaterdepth)
     update_soil_water_storage!(soil, (; runoff, demand, routing.subsurface_flow))

--- a/Wflow/src/sediment/erosion/erosion_process.jl
+++ b/Wflow/src/sediment/erosion/erosion_process.jl
@@ -30,30 +30,30 @@ Rainfall erosion model based on EUROSEM.
 - `rainfall_erosion` (soil loss [t Δt⁻¹])
 """
 function rainfall_erosion_eurosem(
-    precip::Float64,
-    interception::Float64,
-    waterlevel::Float64,
-    soil_detachability::Float64,
-    eurosem_exponent::Float64,
-    canopyheight::Float64,
-    canopygapfraction::Float64,
-    soilcover_fraction::Float64,
-    area::Float64,
-    dt::Float64,
+    precip::PRECISION,
+    interception::PRECISION,
+    waterlevel::PRECISION,
+    soil_detachability::PRECISION,
+    eurosem_exponent::PRECISION,
+    canopyheight::PRECISION,
+    canopygapfraction::PRECISION,
+    soilcover_fraction::PRECISION,
+    area::PRECISION,
+    dt::PRECISION,
 )
     # calculate rainfall intensity [mm/h]
     rintnsty = precip / (dt / 3600)
     # Kinetic energy of direct throughfall [J/m2/mm]
     # kedir = max(11.87 + 8.73 * log10(max(0.0001, rintnsty)),0.0) #basis used in USLE
-    kedir = max(8.95 + 8.44 * log10(max(0.0001, rintnsty)), 0.0) #variant used in most distributed models
+    kedir = max(8.95 + 8.44 * log10(max(0.0001, rintnsty)), ZERO) #variant used in most distributed models
     # Kinetic energy of leaf drainage [J/m2/mm]
     pheff = 0.5 * canopyheight
-    keleaf = max((15.8 * sqrt(pheff)) - 5.87, 0.0)
+    keleaf = max((15.8 * sqrt(pheff)) - 5.87, ZERO)
 
     #Depths of rainfall (total, leaf drianage, direct) [mm]
     rdtot = precip
     rdleaf = rdtot * 0.1 * canopygapfraction #stemflow
-    rddir = max(rdtot - rdleaf - interception, 0.0) #throughfall
+    rddir = max(rdtot - rdleaf - interception, ZERO) #throughfall
 
     #Total kinetic energy by rainfall [J/m2]
     ketot = (rddir * kedir + rdleaf * keleaf) * 0.001
@@ -62,7 +62,7 @@ function rainfall_erosion_eurosem(
     rainfall_erosion *= area * 1e-6 # ton/cell
 
     # Remove the impervious area
-    rainfall_erosion *= 1.0 - soilcover_fraction
+    rainfall_erosion *= ONE - soilcover_fraction
     return rainfall_erosion
 end
 
@@ -90,12 +90,12 @@ Rainfall erosion model based on ANSWERS.
 - `rainfall_erosion` (soil loss [t Δt⁻¹])
 """
 function rainfall_erosion_answers(
-    precip::Float64,
-    usle_k::Float64,
-    usle_c::Float64,
-    answers_rainfall_factor::Float64,
-    area::Float64,
-    dt::Float64,
+    precip::PRECISION,
+    usle_k::PRECISION,
+    usle_c::PRECISION,
+    answers_rainfall_factor::PRECISION,
+    area::PRECISION,
+    dt::PRECISION,
 )
     # calculate rainfall intensity [mm/min]
     rintnsty = precip / (dt / 60)
@@ -132,13 +132,13 @@ Overland flow erosion model based on ANSWERS.
 - `overland_flow_erosion` (soil loss [t Δt⁻¹])
 """
 function overland_flow_erosion_answers(
-    overland_flow::Float64,
-    usle_k::Float64,
-    usle_c::Float64,
-    answers_overland_flow_factor::Float64,
-    slope::Float64,
-    area::Float64,
-    dt::Float64,
+    overland_flow::PRECISION,
+    usle_k::PRECISION,
+    usle_c::PRECISION,
+    answers_overland_flow_factor::PRECISION,
+    slope::PRECISION,
+    area::PRECISION,
+    dt::PRECISION,
 )
     # Overland flow rate [m2/min]
     qr_land = overland_flow * 60 / sqrt(area)
@@ -234,14 +234,14 @@ Repartition of the effective shear stress between the bank and the bed from Knig
 - `bank` (potential bank erosion [t Δt⁻¹])
 """
 function river_erosion_julian_torres(
-    waterlevel::Float64,
-    d50::Float64,
-    width::Float64,
-    length::Float64,
-    slope::Float64,
-    dt::Float64,
+    waterlevel::PRECISION,
+    d50::PRECISION,
+    width::PRECISION,
+    length::PRECISION,
+    slope::PRECISION,
+    dt::PRECISION,
 )
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         # Bed and Bank from Shields diagram, Da Silva & Yalin (2017)
         E_ = (2.65 - 1) * GRAVITATIONAL_ACCELERATION
         E = 10 * d50 * cbrt(E_)
@@ -273,19 +273,19 @@ function river_erosion_julian_torres(
 
         # Potential erosion rates of the bed and bank [t/cell/timestep]
         #(assuming only one bank is eroding)
-        Tex = max(TEffbank - TCrbank, 0.0)
+        Tex = max(TEffbank - TCrbank, ZERO)
         # 1.4 is bank default bulk density
         ERbank = kdbank * Tex * length * waterlevel * 1.4 * dt
         # 1.5 is bed default bulk density
         ERbed = kdbed * (TEffbed - TCrbed) * length * width * 1.5 * dt
 
         # Potential maximum bed/bank erosion
-        bed = max(ERbed, 0.0)
-        bank = max(ERbank, 0.0)
+        bed = max(ERbed, ZERO)
+        bank = max(ERbank, ZERO)
 
     else
-        bed = 0.0
-        bank = 0.0
+        bed = ZERO
+        bank = ZERO
     end
 
     return bed, bank
@@ -293,8 +293,8 @@ end
 
 """
     function river_erosion_store!(
-        store_vec::Vector{Float64}
-        excess_sediment::Float64,
+        store_vec::Vector{PRECISION}
+        excess_sediment::PRECISION,
         v::Int,
     )
 
@@ -309,7 +309,11 @@ River erosion of the previously deposited sediment.
 - `erosion` (river erosion [t Δt⁻¹])
 - `excess_sediment` (updated excess sediment [t Δt⁻¹])
 """
-function river_erosion_store!(store_vec::Vector{Float64}, excess_sediment::Float64, v::Int)
+function river_erosion_store!(
+    store_vec::Vector{PRECISION},
+    excess_sediment::PRECISION,
+    v::Int,
+)
     store = store_vec[v]
     if store > 0
         # River erosion of the previously deposited sediment
@@ -318,7 +322,7 @@ function river_erosion_store!(store_vec::Vector{Float64}, excess_sediment::Float
         excess_sediment -= erosion
         store_vec[v] = store - erosion
     else
-        erosion = 0.0
+        erosion = ZERO
     end
     return erosion, excess_sediment
 end

--- a/Wflow/src/sediment/erosion/overland_flow_erosion.jl
+++ b/Wflow/src/sediment/erosion/overland_flow_erosion.jl
@@ -4,24 +4,24 @@ abstract type AbstractOverlandFlowErosionModel end
 @with_kw struct OverlandFlowErosionVariables
     n::Int
     # Total soil erosion rate [t dt-1] from overland flow
-    soil_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    soil_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing overland flow erosion model boundary conditions"
 @with_kw struct OverlandFlowErosionBC
     n::Int
     # Overland flow [m3 s-1]
-    q::Vector{Float64} = fill(MISSING_VALUE, n)
+    q::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing ANSWERS overland flow erosion model parameters"
 @with_kw struct OverlandFlowErosionAnswersParameters
     # Soil erodibility factor [-]
-    usle_k::Vector{Float64}
+    usle_k::Vector{PRECISION}
     # Crop management factor [-]
-    usle_c::Vector{Float64}
+    usle_c::Vector{PRECISION}
     # ANSWERS overland flow erosion factor [-]
-    answers_overland_flow_factor::Vector{Float64}
+    answers_overland_flow_factor::Vector{PRECISION}
 end
 
 "Initialize ANSWERS overland flow erosion model parameters"
@@ -81,7 +81,7 @@ end
 function update_overland_flow_erosion_model!(
     overland_flow_erosion_model::OverlandFlowErosionAnswersModel,
     geometry::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q) = overland_flow_erosion_model.boundary_conditions
     (; usle_k, usle_c, answers_overland_flow_factor) =

--- a/Wflow/src/sediment/erosion/rainfall_erosion.jl
+++ b/Wflow/src/sediment/erosion/rainfall_erosion.jl
@@ -4,32 +4,32 @@ abstract type AbstractRainfallErosionModel end
 @with_kw struct RainfallErosionModelVariables
     n::Int
     # Total soil erosion rate [t dt-1] from rainfall (splash)
-    soil_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    soil_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing EUROSEM rainfall erosion model boundary conditions"
 @with_kw struct RainfallErosionEurosemBC
     n::Int
     # precipitation [mm dt-1]
-    precipitation::Vector{Float64} = fill(MISSING_VALUE, n)
+    precipitation::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Interception [mm dt-1]
-    interception::Vector{Float64} = fill(MISSING_VALUE, n)
+    interception::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Waterlevel on land [m]
-    waterlevel::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing EUROSEM rainfall erosion model parameters"
 @with_kw struct RainfallErosionEurosemParameters
     # Soil detachability factor [g J-1]
-    soil_detachability::Vector{Float64}
+    soil_detachability::Vector{PRECISION}
     # Exponent EUROSEM [-]
-    eurosem_exponent::Vector{Float64}
+    eurosem_exponent::Vector{PRECISION}
     # Canopy height [m]
-    canopyheight::Vector{Float64}
+    canopyheight::Vector{PRECISION}
     # Canopy gap fraction [-]
-    canopygapfraction::Vector{Float64}
+    canopygapfraction::Vector{PRECISION}
     # Fraction of the soil that is covered (eg paved, snow, etc) [-]
-    soilcover_fraction::Vector{Float64}
+    soilcover_fraction::Vector{PRECISION}
 end
 
 "Initialize EUROSEM rainfall erosion model parameters"
@@ -115,7 +115,7 @@ end
 function update_rainfall_erosion_model!(
     rainfall_erosion_model::RainfallErosionEurosemModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; precipitation, interception, waterlevel) = rainfall_erosion_model.boundary_conditions
     (;
@@ -148,17 +148,17 @@ end
 @with_kw struct RainfallErosionAnswersBC
     n::Int
     # precipitation [mm dt-1]
-    precipitation::Vector{Float64} = fill(MISSING_VALUE, n)
+    precipitation::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing ANSWERS rainfall erosion model parameters"
 @with_kw struct RainfallErosionAnswersParameters
     # Soil erodibility factor [-]
-    usle_k::Vector{Float64}
+    usle_k::Vector{PRECISION}
     # Crop management factor [-]
-    usle_c::Vector{Float64}
+    usle_c::Vector{PRECISION}
     # ANSWERS rainfall erosion factor [-]
-    answers_rainfall_factor::Vector{Float64}
+    answers_rainfall_factor::Vector{PRECISION}
 end
 
 "Initialize ANSWERS rainfall erosion model parameters"
@@ -218,7 +218,7 @@ end
 function update_rainfall_erosion_model!(
     rainfall_erosion_model::RainfallErosionAnswersModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; precipitation) = rainfall_erosion_model.boundary_conditions
     (; usle_k, usle_c, answers_rainfall_factor) = rainfall_erosion_model.parameters

--- a/Wflow/src/sediment/erosion/river_erosion.jl
+++ b/Wflow/src/sediment/erosion/river_erosion.jl
@@ -4,22 +4,22 @@ abstract type AbstractRiverErosionModel end
 @with_kw struct RiverErosionModelVariables
     n::Int
     # Potential river bed erosion rate [t dt-1]
-    bed::Vector{Float64} = fill(MISSING_VALUE, n)
+    bed::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Potential river bank erosion rate [t dt-1]
-    bank::Vector{Float64} = fill(MISSING_VALUE, n)
+    bank::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing river erosion model boundary conditions"
 @with_kw struct RiverErosionBC
     n::Int
     # Waterlevel [m]
-    waterlevel::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing river erosion model parameters"
 @with_kw struct RiverErosionParameters
     # Mean diameter [mm] in the river bed/bank
-    d50::Vector{Float64}
+    d50::Vector{PRECISION}
 end
 
 "Julian and Torres river erosion model"
@@ -74,7 +74,7 @@ end
 function update_river_erosion_model!(
     river_erosion_model::RiverErosionJulianTorresModel,
     parameters_river::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; boundary_conditions, parameters, variables) = river_erosion_model
     (; waterlevel) = boundary_conditions

--- a/Wflow/src/sediment/erosion/soil_erosion.jl
+++ b/Wflow/src/sediment/erosion/soil_erosion.jl
@@ -4,40 +4,40 @@ abstract type AbstractSoilErosionModel end
 @with_kw struct SoilErosionModelVariables
     n::Int
     # Total soil erosion rate [t dt-1]
-    soil_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    soil_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total clay erosion rate [t dt-1]
-    clay_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    clay_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total silt erosion rate [t dt-1]
-    silt_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    silt_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total sand erosion rate [t dt-1]
-    sand_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sand_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total small aggregates erosion rate [t dt-1]
-    sagg_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sagg_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total large aggregates erosion rate [t dt-1]
-    lagg_erosion_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    lagg_erosion_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing soil erosion model boundary conditions"
 @with_kw struct SoilErosionBC
     n::Int
     # Rainfall erosion rate [t dt-1]
-    rainfall_erosion::Vector{Float64} = fill(MISSING_VALUE, n)
+    rainfall_erosion::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Overland flow erosion rate [t dt-1]
-    overland_flow_erosion::Vector{Float64} = fill(MISSING_VALUE, n)
+    overland_flow_erosion::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing soil erosion model parameters"
 @with_kw struct SoilErosionParameters
     # Soil content clay [-]
-    clay_fraction::Vector{Float64}
+    clay_fraction::Vector{PRECISION}
     # Soil content silt [-]
-    silt_fraction::Vector{Float64}
+    silt_fraction::Vector{PRECISION}
     # Soil content sand [-]
-    sand_fraction::Vector{Float64}
+    sand_fraction::Vector{PRECISION}
     # Soil content small aggregates [-]
-    sagg_fraction::Vector{Float64}
+    sagg_fraction::Vector{PRECISION}
     # Soil content large aggregates [-]
-    lagg_fraction::Vector{Float64}
+    lagg_fraction::Vector{PRECISION}
 end
 
 "Initialize soil erosion model parameters"
@@ -69,7 +69,7 @@ function SoilErosionParameters(
     # Check that soil fractions sum to 1
     soil_fractions =
         clay_fraction + silt_fraction + sand_fraction + sagg_fraction + lagg_fraction
-    if !all(f -> isapprox(f, 1.0; rtol = 1e-3), soil_fractions)
+    if !all(f -> isapprox(f, ONE; rtol = 1e-3), soil_fractions)
         error("Particle fractions in the soil must sum to 1")
     end
     soil_parameters = SoilErosionParameters(;

--- a/Wflow/src/sediment/sediment_transport/deposition.jl
+++ b/Wflow/src/sediment/sediment_transport/deposition.jl
@@ -28,19 +28,19 @@ Deposition of sediment in reservoirs from Camp 1945.
 - `deposition` (deposition [t Δt⁻¹])
 """
 function reservoir_deposition_camp(
-    input::Float64,
-    q::Float64,
-    waterlevel::Float64,
-    res_area::Float64,
-    res_trapping_efficiency::Float64,
-    dm::Float64,
-    slope::Float64,
+    input::PRECISION,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    res_area::PRECISION,
+    res_trapping_efficiency::PRECISION,
+    dm::PRECISION,
+    slope::PRECISION,
 )
     # Compute critical velocity
     vcres = q / res_area
     DCres = STOKES_FACTOR / vcres
     # Natural deposition
-    deposition = input * min(1.0, (DCres * (dm / 1000)^2))
+    deposition = input * min(ONE, (DCres * (dm / 1000)^2))
 
     # Check if particles are travelling in suspension or bed load using Rouse number
     dsuspf =

--- a/Wflow/src/sediment/sediment_transport/land_to_river.jl
+++ b/Wflow/src/sediment/sediment_transport/land_to_river.jl
@@ -4,14 +4,14 @@ abstract type AbstractSedimentToRiverModel end
 @with_kw struct SedimentToRiverVariables
     n::Int
     # Total sediment rate to the river [t dt-1]
-    sediment_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store total sediment reaching the river model boundary conditions"
 @with_kw struct SedimentToRiverBC
     n::Int
     # Deposition material rate [t dt-1]
-    deposition::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store total sediment reaching the river model"
@@ -45,7 +45,7 @@ function update_sediment_to_river_model!(
     (; deposition) = sediment_to_river_model.boundary_conditions
     (; sediment_rate) = sediment_to_river_model.variables
 
-    zeros = fill(0.0, length(sediment_rate))
+    zeros = fill(ZERO, length(sediment_rate))
     sediment_rate .= ifelse.(rivers, deposition, zeros)
 end
 
@@ -53,32 +53,32 @@ end
 @with_kw struct SedimentToRiverDifferentiationVariables
     n::Int
     # Total sediment rate [t dt-1]
-    sediment_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Clay rate [t dt-1]
-    clay_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    clay_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Silt rate [t dt-1]
-    silt_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    silt_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sand rate [t dt-1]
-    sand_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sand_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Small aggregates rate [t dt-1]
-    sagg_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sagg_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Large aggregates rate [t dt-1]
-    lagg_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    lagg_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store differentiated sediment reaching the river model boundary conditions"
 @with_kw struct SedimentToRiverDifferentiationBC
     n::Int
     # Clay deposition rate [t dt-1]
-    deposition_clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Silt deposition rate [t dt-1]
-    deposition_silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sand deposition rate [t dt-1]
-    deposition_sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Small aggregates deposition rate [t dt-1]
-    deposition_sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Large aggregates deposition rate [t dt-1]
-    deposition_lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store differentiated sediment reaching the river model"
@@ -139,11 +139,11 @@ function update_sediment_to_river_model!(
             sagg_rate[i] = deposition_sagg[i]
             lagg_rate[i] = deposition_lagg[i]
         else
-            clay_rate[i] = 0.0
-            silt_rate[i] = 0.0
-            sand_rate[i] = 0.0
-            sagg_rate[i] = 0.0
-            lagg_rate[i] = 0.0
+            clay_rate[i] = ZERO
+            silt_rate[i] = ZERO
+            sand_rate[i] = ZERO
+            sagg_rate[i] = ZERO
+            lagg_rate[i] = ZERO
         end
     end
     @. sediment_rate = clay_rate + silt_rate + sand_rate + sagg_rate + lagg_rate

--- a/Wflow/src/sediment/sediment_transport/overland_flow_transport.jl
+++ b/Wflow/src/sediment/sediment_transport/overland_flow_transport.jl
@@ -4,18 +4,18 @@ abstract type AbstractSedimentLandTransportModel end
 @with_kw struct SedimentLandTransportVariables
     n::Int
     # Total sediment rate [t dt-1]
-    sediment_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total sediment deposition rate [t dt-1]
-    deposition::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store total sediment flux in overland flow model boundary conditions"
 @with_kw struct SedimentLandTransportBC
     n::Int
     # Erosion rate material [t dt-1]
-    erosion::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity [t dt-1]
-    transport_capacity::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store total sediment flux in overland flow model"
@@ -62,54 +62,54 @@ end
 @with_kw struct SedimentLandTransportDifferentiationVariables
     n::Int
     # Total sediment rate [t dt-1]
-    sediment_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition rate [t dt-1]
-    deposition::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Clay rate [t dt-1]
-    clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition clay rate [t dt-1]
-    deposition_clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Silt rate [t dt-1]
-    silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition silt rate [t dt-1]
-    deposition_silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sand rate [t dt-1]
-    sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition sand rate [t dt-1]
-    deposition_sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Small aggregates rate [t dt-1]
-    sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition rate small aggregates [t dt-1]
-    deposition_sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Large aggregates rate [t dt-1]
-    lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Deposition rate large aggregates [t dt-1]
-    deposition_lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition_lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store differentiated sediment flux in overland flow model boundary conditions"
 @with_kw struct SedimentLandTransportDifferentiationBC
     n::Int
     # Erosion rate clay [t dt-1]
-    erosion_clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Erosion rate silt [t dt-1]
-    erosion_silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Erosion rate sand [t dt-1]
-    erosion_sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Erosion rate small aggregates [t dt-1]
-    erosion_sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Erosion large aggregates [t dt-1]
-    erosion_lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity clay [t dt-1]
-    transport_capacity_clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity_clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity silt [t dt-1]
-    transport_capacity_silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity_silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity sand [t dt-1]
-    transport_capacity_sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity_sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity small aggregates [t dt-1]
-    transport_capacity_sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity_sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity large aggregates [t dt-1]
-    transport_capacity_lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity_lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store differentiated sediment flux in overland flow model"

--- a/Wflow/src/sediment/sediment_transport/river_transport.jl
+++ b/Wflow/src/sediment/sediment_transport/river_transport.jl
@@ -4,81 +4,81 @@ abstract type AbstractSedimentRiverTransportModel end
 @with_kw struct SedimentRiverTransportVariables
     n::Int
     # Sediment flux [t dt-1]
-    sediment_rate::Vector{Float64} = fill(MISSING_VALUE, n)
-    clay_rate::Vector{Float64} = zeros(n)
-    silt_rate::Vector{Float64} = zeros(n)
-    sand_rate::Vector{Float64} = zeros(n)
-    sagg_rate::Vector{Float64} = zeros(n)
-    lagg_rate::Vector{Float64} = zeros(n)
-    gravel_rate::Vector{Float64} = zeros(n)
+    sediment_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    clay_rate::Vector{PRECISION} = zeros(n)
+    silt_rate::Vector{PRECISION} = zeros(n)
+    sand_rate::Vector{PRECISION} = zeros(n)
+    sagg_rate::Vector{PRECISION} = zeros(n)
+    lagg_rate::Vector{PRECISION} = zeros(n)
+    gravel_rate::Vector{PRECISION} = zeros(n)
     # Total Sediment deposition rate [t dt-1]
-    deposition::Vector{Float64} = fill(MISSING_VALUE, n)
+    deposition::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total sediment erosion rate (from store + direct river bed/bank) [t dt-1]
-    erosion::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sediment / particle left in the cell [t] - states
-    leftover_clay::Vector{Float64} = zeros(n)
-    leftover_silt::Vector{Float64} = zeros(n)
-    leftover_sand::Vector{Float64} = zeros(n)
-    leftover_sagg::Vector{Float64} = zeros(n)
-    leftover_lagg::Vector{Float64} = zeros(n)
-    leftover_gravel::Vector{Float64} = zeros(n)
+    leftover_clay::Vector{PRECISION} = zeros(n)
+    leftover_silt::Vector{PRECISION} = zeros(n)
+    leftover_sand::Vector{PRECISION} = zeros(n)
+    leftover_sagg::Vector{PRECISION} = zeros(n)
+    leftover_lagg::Vector{PRECISION} = zeros(n)
+    leftover_gravel::Vector{PRECISION} = zeros(n)
     # Sediment / particle stored on the river bed after deposition [t] -states
-    store_clay::Vector{Float64} = zeros(n)
-    store_silt::Vector{Float64} = zeros(n)
-    store_sand::Vector{Float64} = zeros(n)
-    store_sagg::Vector{Float64} = zeros(n)
-    store_lagg::Vector{Float64} = zeros(n)
-    store_gravel::Vector{Float64} = zeros(n)
+    store_clay::Vector{PRECISION} = zeros(n)
+    store_silt::Vector{PRECISION} = zeros(n)
+    store_sand::Vector{PRECISION} = zeros(n)
+    store_sagg::Vector{PRECISION} = zeros(n)
+    store_lagg::Vector{PRECISION} = zeros(n)
+    store_gravel::Vector{PRECISION} = zeros(n)
 end
 
 "Struct to store river sediment transport model boundary conditions"
 @with_kw struct SedimentRiverTransportBC
     n::Int
     # Waterlevel [m]
-    waterlevel::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Discharge [m³ s⁻¹]
-    q::Vector{Float64} = fill(MISSING_VALUE, n)
+    q::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity of the flow [t dt-1]
-    transport_capacity::Vector{Float64} = fill(MISSING_VALUE, n)
+    transport_capacity::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sediment input rate from land erosion [t dt-1]
-    erosion_land_clay::Vector{Float64} = fill(MISSING_VALUE, n)
-    erosion_land_silt::Vector{Float64} = fill(MISSING_VALUE, n)
-    erosion_land_sand::Vector{Float64} = fill(MISSING_VALUE, n)
-    erosion_land_sagg::Vector{Float64} = fill(MISSING_VALUE, n)
-    erosion_land_lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    erosion_land_clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    erosion_land_silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    erosion_land_sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    erosion_land_sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    erosion_land_lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sediment erosion rate from direct river erosion [t dt-1]
-    potential_erosion_river_bed::Vector{Float64} = fill(MISSING_VALUE, n)
-    potential_erosion_river_bank::Vector{Float64} = fill(MISSING_VALUE, n)
+    potential_erosion_river_bed::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    potential_erosion_river_bank::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store river sediment transport model parameters"
 @with_kw struct SedimentRiverTransportParameters
     # River bed/bank content clay [-]
-    clay_fraction::Vector{Float64}
+    clay_fraction::Vector{PRECISION}
     # River bed/bank content silt [-]
-    silt_fraction::Vector{Float64}
+    silt_fraction::Vector{PRECISION}
     # River bed/bank content sand [-]
-    sand_fraction::Vector{Float64}
+    sand_fraction::Vector{PRECISION}
     # River bed/bank content gravel [-]
-    gravel_fraction::Vector{Float64}
+    gravel_fraction::Vector{PRECISION}
     # Clay mean diameter [µm]
-    dm_clay::Vector{Float64}
+    dm_clay::Vector{PRECISION}
     # Silt mean diameter [µm]
-    dm_silt::Vector{Float64}
+    dm_silt::Vector{PRECISION}
     # Sand mean diameter [µm]
-    dm_sand::Vector{Float64}
+    dm_sand::Vector{PRECISION}
     # Small aggregates mean diameter [µm]
-    dm_sagg::Vector{Float64}
+    dm_sagg::Vector{PRECISION}
     # Large aggregates mean diameter [µm]
-    dm_lagg::Vector{Float64}
+    dm_lagg::Vector{PRECISION}
     # Gravel mean diameter [µm]
-    dm_gravel::Vector{Float64}
+    dm_gravel::Vector{PRECISION}
     # Reservoir outlets [-]
     reservoir_outlet::Vector{Bool}
     # Reservoir area [m²]
-    reservoir_area::Vector{Float64}
+    reservoir_area::Vector{PRECISION}
     # Reservoir trapping efficiency [-]
-    reservoir_trapping_efficiency::Vector{Float64}
+    reservoir_trapping_efficiency::Vector{PRECISION}
 end
 
 "Initialize river sediment transport model parameters"
@@ -118,7 +118,7 @@ function SedimentRiverTransportParameters(
     )
     # Check that river fractions sum to 1
     river_fractions = clay_fraction + silt_fraction + sand_fraction + gravel_fraction
-    if any(abs.(river_fractions .- 1.0) .> 1e-3)
+    if any(abs.(river_fractions .- ONE) .> 1e-3)
         error("Particle fractions in the river bed must sum to 1")
     end
     dm_clay = ncread(dataset, config, "clay__mean_diameter", SoilLossModel; sel = indices)
@@ -289,7 +289,7 @@ function compute_sediment_input(
     upstream_nodes = inneighbors(graph, v)
     if !isempty(upstream_nodes)
         for i in upstream_nodes
-            if clay_rate[i] >= 0.0 # avoid NaN from upstream non-river cells
+            if clay_rate[i] >= ZERO # avoid NaN from upstream non-river cells
                 input_clay += clay_rate[i]
                 input_silt += silt_rate[i]
                 input_sand += sand_rate[i]
@@ -308,8 +308,8 @@ Calculate direct river bed/bank erosion based on sediment need
 """
 function compute_direct_river_erosion(
     sediment_transport_model::SedimentRiverTransportModel,
-    sediment_need::Float64,
-    store_sediment::Float64,
+    sediment_need::PRECISION,
+    store_sediment::PRECISION,
     v::Int,
 )
     (; potential_erosion_river_bed, potential_erosion_river_bank) =
@@ -318,21 +318,21 @@ function compute_direct_river_erosion(
         sediment_transport_model.parameters
 
     if sediment_need <= store_sediment
-        return (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+        return (ZERO, ZERO, ZERO, ZERO, ZERO, ZERO)
     end
 
     # Effective sediment needed from river bed and bank erosion [ton]
     effsediment_need = sediment_need - store_sediment
 
     # Relative potential erosion rates of the bed and the bank [-]
-    if (potential_erosion_river_bank[v] + potential_erosion_river_bed[v] > 0.0)
+    if (potential_erosion_river_bank[v] + potential_erosion_river_bed[v] > ZERO)
         RTEbank =
             potential_erosion_river_bank[v] /
             (potential_erosion_river_bank[v] + potential_erosion_river_bed[v])
     else
-        RTEbank = 0.0
+        RTEbank = ZERO
     end
-    RTEbed = 1.0 - RTEbank
+    RTEbed = ONE - RTEbank
 
     # Actual bed and bank erosion
     erosion_bank = min(RTEbank * effsediment_need, potential_erosion_river_bank[v])
@@ -345,8 +345,8 @@ function compute_direct_river_erosion(
     erosion_sand = erosion_river * sand_fraction[v]
     erosion_gravel = erosion_river * gravel_fraction[v]
     # No small and large aggregates in the river bed/bank
-    erosion_sagg = 0.0
-    erosion_lagg = 0.0
+    erosion_sagg = ZERO
+    erosion_lagg = ZERO
 
     return (
         erosion_clay,
@@ -363,7 +363,7 @@ Calculate erosion from previously deposited sediment store
 """
 function compute_store_erosion!(
     variables::SedimentRiverTransportVariables,
-    sediment_need::Float64,
+    sediment_need::PRECISION,
     v::Int,
 )
     (; store_clay, store_silt, store_sand, store_sagg, store_lagg, store_gravel) = variables
@@ -391,8 +391,8 @@ Calculate sediment deposition in reservoir outlets using Camp's formula
 function compute_reservoir_deposition(
     sediment_transport_model::SedimentRiverTransportModel,
     domain_parameters::RiverParameters,
-    input_particles::NTuple{6, Float64},
-    erosion_particles::NTuple{6, Float64},
+    input_particles::NTuple{6, PRECISION},
+    erosion_particles::NTuple{6, PRECISION},
     v::Int,
 )
     (; boundary_conditions, parameters) = sediment_transport_model
@@ -448,7 +448,7 @@ function transport_capacity_deposition(excess_sediment, input, erosion)
         excess_sediment -= total
     else
         deposition = excess_sediment
-        excess_sediment = 0.0
+        excess_sediment = ZERO
     end
     return deposition, excess_sediment
 end
@@ -457,9 +457,9 @@ end
 Calculate river deposition from transport capacity exceedance (gravel to clay priority)
 """
 function compute_transport_capacity_deposition(
-    excess_sediment::Float64,
-    input_particles::NTuple{6, Float64},
-    erosion_particles::NTuple{6, Float64},
+    excess_sediment::PRECISION,
+    input_particles::NTuple{6, PRECISION},
+    erosion_particles::NTuple{6, PRECISION},
 )
     input_clay, input_silt, input_sand, input_sagg, input_lagg, input_gravel =
         input_particles
@@ -490,8 +490,13 @@ function compute_transport_capacity_deposition(
     )
 end
 
-function natural_deposition(xs::Float64, dm::Float64, input::Float64, erosion::Float64)
-    x_material = min(1.0, 1.0 - exp(-xs * (STOKES_FACTOR * (dm / 1000)^2)))
+function natural_deposition(
+    xs::PRECISION,
+    dm::PRECISION,
+    input::PRECISION,
+    erosion::PRECISION,
+)
+    x_material = min(ONE, ONE - exp(-xs * (STOKES_FACTOR * (dm / 1000)^2)))
     deposition = x_material * (input + erosion)
     return deposition
 end
@@ -502,8 +507,8 @@ Calculate natural river deposition using Einstein's formula (Stokes settling)
 function compute_natural_deposition(
     sediment_transport_model::SedimentRiverTransportModel,
     domain_parameters::RiverParameters,
-    input_particles::NTuple{6, Float64},
-    erosion_particles::NTuple{6, Float64},
+    input_particles::NTuple{6, PRECISION},
+    erosion_particles::NTuple{6, PRECISION},
     v::Int,
 )
     (; boundary_conditions, parameters) = sediment_transport_model
@@ -517,7 +522,7 @@ function compute_natural_deposition(
         erosion_particles
 
     # Particle fall velocity [m/s] from Stokes
-    xs = ifelse(q[v] > 0.0, 1.055 * flow_length[v] / (q[v] / flow_width[v]), 0.0)
+    xs = ifelse(q[v] > ZERO, 1.055 * flow_length[v] / (q[v] / flow_width[v]), ZERO)
 
     deposition_clay = natural_deposition(xs, dm_clay[v], input_clay, erosion_clay)
     deposition_silt = natural_deposition(xs, dm_silt[v], input_silt, erosion_silt)
@@ -537,19 +542,19 @@ function compute_natural_deposition(
 end
 
 function water_outflow_fraction(waterlevel, q, flow_width, flow_length, dt)
-    return if waterlevel > 0.0
-        min(q * dt / (waterlevel * flow_width * flow_length), 1.0)
+    return if waterlevel > ZERO
+        min(q * dt / (waterlevel * flow_width * flow_length), ONE)
     else
-        1.0
+        ONE
     end
 end
 
 function update_variables!(
     variables::SedimentRiverTransportVariables,
-    input_particles::NTuple{6, Float64},
-    erosion_particles::NTuple{6, Float64},
-    deposition_particles::NTuple{6, Float64},
-    fwaterout::Float64,
+    input_particles::NTuple{6, PRECISION},
+    erosion_particles::NTuple{6, PRECISION},
+    deposition_particles::NTuple{6, PRECISION},
+    fwaterout::PRECISION,
     v::Int,
 )
     (;
@@ -634,7 +639,7 @@ end
 function update_sediment_river_transport_model!(
     sediment_transport_model::SedimentRiverTransportModel,
     domain::DomainRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; waterlevel, q, transport_capacity) = sediment_transport_model.boundary_conditions
     (; reservoir_outlet) = sediment_transport_model.parameters
@@ -652,10 +657,10 @@ function update_sediment_river_transport_model!(
 
         ### River erosion ###
         # Erosion only if the load is below the transport capacity of the flow.
-        sediment_need = max(transport_capacity[v] - input_sediment, 0.0)
+        sediment_need = max(transport_capacity[v] - input_sediment, ZERO)
         # No erosion in reservoirs
         if reservoir_coverage[v]
-            sediment_need = 0.0
+            sediment_need = ZERO
         end
 
         # Available sediment stored from previous deposition
@@ -696,13 +701,13 @@ function update_sediment_river_transport_model!(
             )
         elseif reservoir_coverage[v]
             # No deposition in reservoir coverage, only at the outlets
-            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+            (ZERO, ZERO, ZERO, ZERO, ZERO, ZERO)
         else
             # Deposition in the river
 
             # From transport capacity exceedance
-            excess_sediment = max(input_sediment - transport_capacity[v], 0.0)
-            if excess_sediment > 0.0
+            excess_sediment = max(input_sediment - transport_capacity[v], ZERO)
+            if excess_sediment > ZERO
                 compute_transport_capacity_deposition(
                     excess_sediment,
                     input_particles,
@@ -741,47 +746,47 @@ abstract type AbstractSedimentConcentrationsRiverModel end
 @with_kw struct SedimentConcentrationsRiverVariables
     n::Int
     # Total sediment concentration in the river [g m-3]
-    total::Vector{Float64} = fill(MISSING_VALUE, n)
+    total::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # suspended sediemnt concentration in the river [g m-3]
-    suspended::Vector{Float64} = fill(MISSING_VALUE, n)
+    suspended::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # bed load sediment concentration in the river [g m-3]
-    bed::Vector{Float64} = fill(MISSING_VALUE, n)
+    bed::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store river sediment concentrations model boundary conditions"
 @with_kw struct SedimentConcentrationsRiverBC
     n::Int
     # Discharge [m³ s⁻¹]
-    q::Vector{Float64} = fill(MISSING_VALUE, n)
-    waterlevel::Vector{Float64} = fill(MISSING_VALUE, n) # [m]
+    q::Vector{PRECISION} = fill(MISSING_VALUE, n)
+    waterlevel::Vector{PRECISION} = fill(MISSING_VALUE, n) # [m]
     # Clay load [g m-3]
-    clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Silt load [g m-3]
-    silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Sand load [g m-3]
-    sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Small aggregates load [g m-3]
-    sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Large aggregates load [g m-3]
-    lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Gravel load [g m-3]
-    gravel::Vector{Float64} = fill(MISSING_VALUE, n)
+    gravel::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store river sediment concentrations model parameters"
 @with_kw struct SedimentConcentrationsRiverParameters
     # Clay mean diameter [µm]
-    dm_clay::Vector{Float64}
+    dm_clay::Vector{PRECISION}
     # Silt mean diameter [µm]
-    dm_silt::Vector{Float64}
+    dm_silt::Vector{PRECISION}
     # Sand mean diameter [µm]
-    dm_sand::Vector{Float64}
+    dm_sand::Vector{PRECISION}
     # Small aggregates mean diameter [µm]
-    dm_sagg::Vector{Float64}
+    dm_sagg::Vector{PRECISION}
     # Large aggregates mean diameter [µm]
-    dm_lagg::Vector{Float64}
+    dm_lagg::Vector{PRECISION}
     # Gravel mean diameter [µm]
-    dm_gravel::Vector{Float64}
+    dm_gravel::Vector{PRECISION}
 end
 
 "Initialize river sediment concentrations model parameters"
@@ -869,7 +874,7 @@ function suspended_solid(dm, dsuspf, dbedf, substance)
     elseif dm <= dbedf
         substance / 2
     else
-        0.0
+        ZERO
     end
 end
 
@@ -877,7 +882,7 @@ end
 function update_river_sediment_concentration_model!(
     sediment_transport_model::SedimentConcentrationsRiverModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel, clay, silt, sand, sagg, lagg, gravel) =
         sediment_transport_model.boundary_conditions
@@ -913,9 +918,9 @@ function update_river_sediment_concentration_model!(
             suspended[i] = SS * to_conc
             bed[i] = (total_ - SS) * to_conc
         else
-            suspended[i] = 0.0
-            bed[i] = 0.0
-            total[i] = 0.0
+            suspended[i] = ZERO
+            bed[i] = ZERO
+            total[i] = ZERO
         end
     end
 end

--- a/Wflow/src/sediment/sediment_transport/transport_capacity.jl
+++ b/Wflow/src/sediment/sediment_transport/transport_capacity.jl
@@ -4,16 +4,16 @@ abstract type AbstractTransportCapacityModel end
 @with_kw struct TransportCapacityModelVariables
     n::Int
     # Total sediment transport capacity [t dt-1]
-    sediment_transport_capacity::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_transport_capacity::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store total transport capacity model boundary conditions"
 @with_kw struct TransportCapacityBC
     n::Int
     # Discharge [m³ s⁻¹]
-    q::Vector{Float64} = fill(MISSING_VALUE, n)
+    q::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Flow depth [m]
-    waterlevel::Vector{Float64} = fill(MISSING_VALUE, n)
+    waterlevel::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Update total transport capacity model boundary conditions"
@@ -39,11 +39,11 @@ end
 "Struct to store Govers overland flow transport capacity model parameters"
 @with_kw struct TransportCapacityGoversParameters
     # Particle density [kg m-3]
-    density::Vector{Float64}
+    density::Vector{PRECISION}
     # Govers transport capacity coefficient [-]
-    c_govers::Vector{Float64}
+    c_govers::Vector{PRECISION}
     # Govers transport capacity exponent [-]
-    n_govers::Vector{Float64}
+    n_govers::Vector{PRECISION}
 end
 
 "Initialize Govers overland flow transport capacity model parameters"
@@ -97,7 +97,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityGoversModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, c_govers, n_govers) = transport_capacity_model.parameters
@@ -125,9 +125,9 @@ end
 "Struct to store Yalin overland flow transport capacity model parameters"
 @with_kw struct TransportCapacityYalinParameters
     # Particle density [kg m-3]
-    density::Vector{Float64}
+    density::Vector{PRECISION}
     # Particle mean diameter [mm]
-    d50::Vector{Float64}
+    d50::Vector{PRECISION}
 end
 
 "Initialize Yalin overland flow transport capacity model parameters"
@@ -175,7 +175,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityYalinModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, d50) = transport_capacity_model.parameters
@@ -203,33 +203,33 @@ end
 @with_kw struct TransportCapacityYalinDifferentiationModelVariables
     n::Int
     # Total sediment transport capacity [t dt-1]
-    sediment_transport_capacity::Vector{Float64} = fill(MISSING_VALUE, n)
+    sediment_transport_capacity::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity clay [t dt-1]
-    clay::Vector{Float64} = fill(MISSING_VALUE, n)
+    clay::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity silt [t dt-1]
-    silt::Vector{Float64} = fill(MISSING_VALUE, n)
+    silt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity sand [t dt-1]
-    sand::Vector{Float64} = fill(MISSING_VALUE, n)
+    sand::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity small aggregates [t dt-1]
-    sagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    sagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Transport capacity large aggregates [t dt-1]
-    lagg::Vector{Float64} = fill(MISSING_VALUE, n)
+    lagg::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct to store Yalin differentiated overland flow transport capacity model parameters"
 @with_kw struct TransportCapacityYalinDifferentiationParameters
     # Particle density [kg m-3]
-    density::Vector{Float64}
+    density::Vector{PRECISION}
     # Clay mean diameter [μm]
-    dm_clay::Vector{Float64}
+    dm_clay::Vector{PRECISION}
     # Silt mean diameter [μm]
-    dm_silt::Vector{Float64}
+    dm_silt::Vector{PRECISION}
     # Sand mean diameter [μm]
-    dm_sand::Vector{Float64}
+    dm_sand::Vector{PRECISION}
     # Small aggregates mean diameter [μm]
-    dm_sagg::Vector{Float64}
+    dm_sagg::Vector{PRECISION}
     # Large aggregates mean diameter [μm]
-    dm_lagg::Vector{Float64}
+    dm_lagg::Vector{PRECISION}
 end
 
 "Initialize Yalin differentiated overland flow transport capacity model parameters"
@@ -295,7 +295,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityYalinDifferentiationModel,
     parameters::LandParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, dm_clay, dm_silt, dm_sand, dm_sagg, dm_lagg) =
@@ -384,9 +384,9 @@ end
 "Struct to store common river transport capacity model parameters"
 @with_kw struct TransportCapacityRiverParameters
     # Particle density [kg m-3]
-    density::Vector{Float64}
+    density::Vector{PRECISION}
     # Particle mean diameter [mm]
-    d50::Vector{Float64}
+    d50::Vector{PRECISION}
 end
 
 "Initialize common river transport capacity model parameters"
@@ -413,9 +413,9 @@ end
 "Struct to store Bagnold transport capacity model parameters"
 @with_kw struct TransportCapacityBagnoldParameters
     # Bagnold transport capacity coefficient [-]
-    c_bagnold::Vector{Float64}
+    c_bagnold::Vector{PRECISION}
     # Bagnold transport capacity exponent [-]
-    e_bagnold::Vector{Float64}
+    e_bagnold::Vector{PRECISION}
 end
 
 "Initialize Bagnold transport capacity model parameters"
@@ -468,7 +468,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityBagnoldModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; c_bagnold, e_bagnold) = transport_capacity_model.parameters
@@ -514,7 +514,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityEngelundModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, d50) = transport_capacity_model.parameters
@@ -538,13 +538,13 @@ end
 "Struct to store Kodatie river transport capacity model parameters"
 @with_kw struct TransportCapacityKodatieParameters
     # Kodatie transport capacity coefficient a [-]
-    a_kodatie::Vector{Float64}
+    a_kodatie::Vector{PRECISION}
     # Kodatie transport capacity coefficient b [-]
-    b_kodatie::Vector{Float64}
+    b_kodatie::Vector{PRECISION}
     # Kodatie transport capacity coefficient c [-]
-    c_kodatie::Vector{Float64}
+    c_kodatie::Vector{PRECISION}
     # Kodatie transport capacity coefficient d [-]
-    d_kodatie::Vector{Float64}
+    d_kodatie::Vector{PRECISION}
 end
 
 "Initialize Kodatie river transport capacity model parameters"
@@ -612,7 +612,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityKodatieModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; a_kodatie, b_kodatie, c_kodatie, d_kodatie) = transport_capacity_model.parameters
@@ -659,7 +659,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityYangModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, d50) = transport_capacity_model.parameters
@@ -704,7 +704,7 @@ end
 function update_transport_capacity_model!(
     transport_capacity_model::TransportCapacityMolinasModel,
     parameters::RiverParameters,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; q, waterlevel) = transport_capacity_model.boundary_conditions
     (; density, d50) = transport_capacity_model.parameters

--- a/Wflow/src/sediment/sediment_transport/transport_capacity_process.jl
+++ b/Wflow/src/sediment/sediment_transport/transport_capacity_process.jl
@@ -19,7 +19,7 @@ Mask transport capacity values for         reservoirs,
 function mask_transport_capacity(transport_capacity, reservoirs, rivers)
     # Full deposition in rivers to switch to river concept
     if rivers
-        tc = 0.0
+        tc = ZERO
         # Sediment flux in reservoirs will all reach the river
     elseif reservoirs
         tc = 1e9
@@ -115,16 +115,16 @@ function transport_capacity_govers(
     # Transport capacity from govers 1990
     sinslope = sin_slope(slope) #slope in radians
     # Unit stream power
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         velocity = q / (width * waterlevel) #m/s
     else
-        velocity = 0.0
+        velocity = ZERO
     end
     omega = 10 * sinslope * 100 * velocity #cm/s
     if omega > 0.4
         TCf = c_govers * (omega - 0.4)^(n_govers) * density #kg/m3
     else
-        TCf = 0.0
+        TCf = ZERO
     end
     transport_capacity = TCf * q * dt * 1e-3 #[ton/cell]
 
@@ -164,24 +164,24 @@ Total sediment transport capacity based on Yalin.
 - `transport_capacity` (total sediment transport capacity [t dt-1])
 """
 function transport_capacity_yalin(
-    q::Float64,
-    waterlevel::Float64,
-    density::Float64,
-    d50::Float64,
-    slope::Float64,
-    width::Float64,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    density::PRECISION,
+    d50::PRECISION,
+    slope::PRECISION,
+    width::PRECISION,
     reservoirs::Bool,
     rivers::Bool,
-    dt::Float64,
+    dt::PRECISION,
 )
     sinslope = sin_slope(slope) #slope in radians
     # Transport capacity from Yalin without particle differentiation
     delta = max(
         (waterlevel * sinslope / (d50 * 0.001 * (density / WATER_DENSITY - 1)) / 0.06 - 1),
-        0.0,
+        ZERO,
     )
     alphay = delta * 2.45 / (0.001 * density)^0.4 * 0.06^(0.5)
-    if q > 0.0 && alphay != 0.0
+    if q > ZERO && !iszero(alphay)
         TC = (
             width / q *
             (density - 1000) *
@@ -194,7 +194,7 @@ function transport_capacity_yalin(
         ) # [kg/m3]
         transport_capacity = TC * q * dt * 1e-3 #[ton]
     else
-        transport_capacity = 0.0
+        transport_capacity = ZERO
     end
 
     # Mask transport capacity values for reservoirs and rivers
@@ -234,23 +234,23 @@ Total flow transportability based on Yalin with particle differentiation.
 - `dtot` (total transportability of the flow [-])
 """
 function transportability_yalin_differentiation(
-    waterlevel::Float64,
-    density::Float64,
-    dm_clay::Float64,
-    dm_silt::Float64,
-    dm_sand::Float64,
-    dm_sagg::Float64,
-    dm_lagg::Float64,
-    slope::Float64,
+    waterlevel::PRECISION,
+    density::PRECISION,
+    dm_clay::PRECISION,
+    dm_silt::PRECISION,
+    dm_sand::PRECISION,
+    dm_sagg::PRECISION,
+    dm_lagg::PRECISION,
+    slope::PRECISION,
 )
     sinslope = sin_slope(slope) #slope in radians
     # Delta parameter of Yalin for each particle class
     delta = waterlevel * sinslope / (1e-6 * (density / WATER_DENSITY - 1)) / 0.06
-    dclay = max(delta / dm_clay - 1, 0.0)
-    dsilt = max(delta / dm_silt - 1, 0.0)
-    dsand = max(delta / dm_sand - 1, 0.0)
-    dsagg = max(delta / dm_sagg - 1, 0.0)
-    dlagg = max(delta / dm_lagg - 1, 0.0)
+    dclay = max(delta / dm_clay - 1, ZERO)
+    dsilt = max(delta / dm_silt - 1, ZERO)
+    dsand = max(delta / dm_sand - 1, ZERO)
+    dsagg = max(delta / dm_sagg - 1, ZERO)
+    dlagg = max(delta / dm_lagg - 1, ZERO)
     # Total transportability
     dtot = dclay + dsilt + dsand + dsagg + dlagg
 
@@ -289,36 +289,36 @@ Transport capacity for a specific grain size based on Yalin with particle differ
 - `transport_capacity` (total sediment transport capacity [t dt-1])
 """
 function transport_capacity_yalin_differentiation(
-    q::Float64,
-    waterlevel::Float64,
-    density::Float64,
-    dm::Float64,
-    slope::Float64,
-    width::Float64,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    density::PRECISION,
+    dm::PRECISION,
+    slope::PRECISION,
+    width::PRECISION,
     reservoirs::Bool,
     rivers::Bool,
-    dtot::Float64,
-    dt::Float64,
+    dtot::PRECISION,
+    dt::PRECISION,
 )
     sinslope = sin_slope(slope) #slope in radians
     # Transport capacity from Yalin with particle differentiation
     # Delta parameter of Yalin for the specific particle class
     delta = waterlevel * sinslope / (1e-6 * (density / WATER_DENSITY - 1)) / 0.06
-    d_part = max(1 / dm * delta - 1, 0.0)
+    d_part = max(1 / dm * delta - 1, ZERO)
 
-    if q > 0.0
+    if q > ZERO
         TCa =
             width / q *
             (density - 1000) *
             1e-6 *
             (GRAVITATIONAL_ACCELERATION * waterlevel * sinslope)
     else
-        TCa = 0.0
+        TCa = ZERO
     end
 
-    TCb = 2.45 / (0.001 * density)^0.4 * 0.06^0.5
+    TCb = 2.45 / (0.001 * density)^0.4 * sqrt(0.06)
 
-    if dtot != 0.0 && d_part != 0.0
+    if dtot != ZERO && d_part != ZERO
         TC =
             TCa * dm * d_part / dtot *
             0.635 *
@@ -326,7 +326,7 @@ function transport_capacity_yalin_differentiation(
             (1 - log(1 + d_part * TCb) / d_part * TCb) # [kg/m3]
         transport_capacity = TC * q * dt * 1e-3 #[ton]
     else
-        transport_capacity = 0.0
+        transport_capacity = ZERO
     end
 
     # Mask transport capacity values for reservoirs and rivers
@@ -361,16 +361,16 @@ Total sediment transport capacity based on Bagnold.
 - `transport_capacity` (total sediment transport capacity [t dt-1])
 """
 function transport_capacity_bagnold(
-    q::Float64,
-    waterlevel::Float64,
-    c_bagnold::Float64,
-    e_bagnold::Float64,
-    width::Float64,
-    length::Float64,
-    dt::Float64,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    c_bagnold::PRECISION,
+    e_bagnold::PRECISION,
+    width::PRECISION,
+    length::PRECISION,
+    dt::PRECISION,
 )
     # Transport capacity from Bagnold
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         # Transport capacity [tons/m3]
         transport_capacity = c_bagnold * (q / (waterlevel * width))^e_bagnold
         transport_capacity = limit_and_convert_transport_capacity(
@@ -382,7 +382,7 @@ function transport_capacity_bagnold(
             dt,
         )
     else
-        transport_capacity = 0.0
+        transport_capacity = ZERO
     end
 
     return transport_capacity
@@ -416,17 +416,17 @@ Total sediment transport capacity based on Engelund and Hansen.
 - `transport_capacity` (total sediment transport capacity [t dt-1])
 """
 function transport_capacity_engelund(
-    q::Float64,
-    waterlevel::Float64,
-    density::Float64,
-    d50::Float64,
-    width::Float64,
-    length::Float64,
-    slope::Float64,
-    dt::Float64,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    density::PRECISION,
+    d50::PRECISION,
+    width::PRECISION,
+    length::PRECISION,
+    slope::PRECISION,
+    dt::PRECISION,
 )
     # Transport capacity from Engelund and Hansen
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         # Hydraulic radius of the river [m] (rectangular channel)
         hydrad = waterlevel * width / (width + 2 * waterlevel)
         vshear = sqrt(GRAVITATIONAL_ACCELERATION * hydrad * slope)
@@ -438,12 +438,12 @@ function transport_capacity_engelund(
         cw =
             density / WATER_DENSITY * 0.05 * velocity * vshear^3 /
             ((density / WATER_DENSITY - 1)^2 * GRAVITATIONAL_ACCELERATION^2 * d50 * hydrad)
-        cw = min(1.0, cw)
+        cw = min(ONE, cw)
 
         # Transport capacity [tons/m3]
         transport_capacity =
             cw / (cw + (1 - cw) * density / WATER_DENSITY) * density / WATER_DENSITY
-        transport_capacity = max(transport_capacity, 0.0)
+        transport_capacity = max(transport_capacity, ZERO)
         # Transport capacity [tons]
         transport_capacity = limit_and_convert_transport_capacity(
             transport_capacity,
@@ -455,7 +455,7 @@ function transport_capacity_engelund(
         )
 
     else
-        transport_capacity = 0.0
+        transport_capacity = ZERO
     end
 
     return transport_capacity
@@ -505,7 +505,7 @@ function transport_capacity_kodatie(
     dt,
 )
     # Transport capacity from Kodatie
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         # Flow velocity [m/s]
         velocity = (q / (waterlevel * width))
 
@@ -525,7 +525,7 @@ function transport_capacity_kodatie(
         )
 
     else
-        transport_capacity = 0.0
+        transport_capacity = ZERO
     end
 
     return transport_capacity
@@ -559,14 +559,14 @@ Total sediment transport capacity based on Yang sand and gravel equations.
 - `transport_capacity` (total sediment transport capacity [t dt-1])
 """
 function transport_capacity_yang(
-    q::Float64,
-    waterlevel::Float64,
-    density::Float64,
-    d50::Float64,
-    width::Float64,
-    length::Float64,
-    slope::Float64,
-    dt::Float64,
+    q::PRECISION,
+    waterlevel::PRECISION,
+    density::PRECISION,
+    d50::PRECISION,
+    width::PRECISION,
+    length::PRECISION,
+    slope::PRECISION,
+    dt::PRECISION,
 )
     # Transport capacity from Yang
     omegas = STOKES_FACTOR * d50^2
@@ -577,7 +577,7 @@ function transport_capacity_yang(
     var1 = vshear * d50 / 1000 / WATER_KINEMATIC_VISCOSITY
     var2 = omegas * d50 / 1000 / WATER_KINEMATIC_VISCOSITY
     vcr = ifelse(var1 >= 70.0, 2.05 * omegas, omegas * (2.5 / (log10(var1) - 0.06) + 0.66))
-    vcr = min(vcr, 0.0)
+    vcr = min(vcr, ZERO)
 
     # Sand equation
     if width * waterlevel > vcr
@@ -601,7 +601,7 @@ function transport_capacity_yang(
             )
         end
     else
-        logcppm = 0.0
+        logcppm = ZERO
     end
 
     # Sediment concentration by weight
@@ -609,7 +609,7 @@ function transport_capacity_yang(
     # Transport capacity [tons/m3]
     transport_capacity =
         cw / (cw + (1 - cw) * density / WATER_DENSITY) * density / WATER_DENSITY
-    transport_capacity = max(transport_capacity, 0.0)
+    transport_capacity = max(transport_capacity, ZERO)
     # Transport capacity [tons]
     transport_capacity = limit_and_convert_transport_capacity(
         transport_capacity,
@@ -652,7 +652,7 @@ Total sediment transport capacity based on Molinas and Wu.
 """
 function transport_capacity_molinas(q, waterlevel, density, d50, width, length, slope, dt)
     # Transport capacity from Molinas and Wu
-    if waterlevel > 0.0
+    if waterlevel > ZERO
         # Flow velocity [m/s]
         velocity = (q / (waterlevel * width))
         omegas = STOKES_FACTOR * d50^2

--- a/Wflow/src/sediment_flux.jl
+++ b/Wflow/src/sediment_flux.jl
@@ -79,7 +79,7 @@ function update_overland_flow_model!(
     overland_flow_model::OverlandFlowSedimentModel,
     erosion_model::SoilErosionModel,
     domain::DomainLand,
-    dt::Float64,
+    dt::PRECISION,
 )
     # Transport capacity
     update_bc_transport_capacity_model!(
@@ -179,7 +179,7 @@ function update_river_sediment_model!(
     river_flow_model::RiverSedimentModel,
     sediment_to_river_model::SedimentToRiverDifferentiationModel,
     domain::DomainRiver,
-    dt::Float64,
+    dt::PRECISION,
 )
     # Transport capacity
     update_bc_transport_capacity_model!(

--- a/Wflow/src/sediment_model.jl
+++ b/Wflow/src/sediment_model.jl
@@ -75,7 +75,7 @@ function set_states!(model::AbstractModel{<:SedimentModel})
     if !config.model.cold_start__flag
         instate_path = input_path(config, config.state.path_input)
         @info "Set initial conditions from state file `$instate_path`."
-        set_states!(instate_path, model; type = Float64)
+        set_states!(instate_path, model; type = PRECISION)
     else
         @info "Set initial conditions from default values."
     end

--- a/Wflow/src/snow/snow.jl
+++ b/Wflow/src/snow/snow.jl
@@ -4,44 +4,44 @@ abstract type AbstractSnowModel end
 @with_kw struct SnowVariables
     n::Int
     # Snow storage [mm]
-    snow_storage::Vector{Float64} = zeros(n)
+    snow_storage::Vector{PRECISION} = zeros(n)
     # Liquid water content in the snow pack [mm]
-    snow_water::Vector{Float64} = zeros(n)
+    snow_water::Vector{PRECISION} = zeros(n)
     # Snow water equivalent (SWE) [mm]
-    swe::Vector{Float64} = fill(MISSING_VALUE, n)
+    swe::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Snow melt [mm Δt⁻¹]
-    snow_melt::Vector{Float64} = fill(MISSING_VALUE, n)
+    snow_melt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Runoff from snowpack [mm Δt⁻¹]
-    runoff::Vector{Float64} = fill(MISSING_VALUE, n)
+    runoff::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Lateral snow (SWE) transport from upstreams cells [mm Δt⁻¹]
-    snow_in::Vector{Float64} = zeros(n)
+    snow_in::Vector{PRECISION} = zeros(n)
     # Lateral snow (SWE) transport out of a cell [mm Δt⁻¹]
-    snow_out::Vector{Float64} = zeros(n)
+    snow_out::Vector{PRECISION} = zeros(n)
 end
 
 "Struct for storing snow model boundary conditions"
 @with_kw struct SnowBC
     n::Int
     # Effective precipitation [mm Δt⁻¹]
-    effective_precip::Vector{Float64} = fill(MISSING_VALUE, n)
+    effective_precip::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Snow precipitation [mm Δt⁻¹]
-    snow_precip::Vector{Float64} = fill(MISSING_VALUE, n)
+    snow_precip::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Liquid precipitation [mm Δt⁻¹]
-    liquid_precip::Vector{Float64} = fill(MISSING_VALUE, n)
+    liquid_precip::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing snow HBV model parameters"
 @with_kw struct SnowHbvParameters
     # Degree-day factor [mm ᵒC⁻¹ Δt⁻¹]
-    cfmax::Vector{Float64}
+    cfmax::Vector{PRECISION}
     # Threshold temperature for snowfall [ᵒC]
-    tt::Vector{Float64}
+    tt::Vector{PRECISION}
     # Threshold temperature interval length [ᵒC]
-    tti::Vector{Float64}
+    tti::Vector{PRECISION}
     # Threshold temperature for snowmelt [ᵒC]
-    ttm::Vector{Float64}
+    ttm::Vector{PRECISION}
     # Water holding capacity as fraction of current snow pack [-]
-    whc::Vector{Float64}
+    whc::Vector{PRECISION}
 end
 
 "Snow HBV model"

--- a/Wflow/src/snow/snow_process.jl
+++ b/Wflow/src/snow/snow_process.jl
@@ -39,7 +39,7 @@ function snowpack_hbv(
         snow_storage -= snow_melt
         snow_water += snow_melt
     else
-        snow_melt = 0.0
+        snow_melt = ZERO
         potential_refreezing = cfmax * cfr * (ttm - temperature)
         refreezing = min(potential_refreezing, snow_water)
         snow_storage += refreezing
@@ -50,7 +50,7 @@ function snowpack_hbv(
     snow_water += liquid_precip
 
     max_snow_water = snow_storage * whc
-    runoff = max(snow_water - max_snow_water, 0)
+    runoff = max(snow_water - max_snow_water, ZERO)
     snow_water -= runoff
     snow_water_equivalent = snow_water + snow_storage
 
@@ -58,7 +58,7 @@ function snowpack_hbv(
 end
 
 """
-    precipitation_hbv(precipitation, temperature, tti, tt; rfcf = 1.0, sfcf = 1.0)
+    precipitation_hbv(precipitation, temperature, tti, tt; rfcf = ONE, sfcf = ONE)
 
 HBV type precipitation routine to separate precipitation in snow precipitation and liquid precipitation.
 All correction factors (RFCF and SFCF) are set to 1.
@@ -75,18 +75,18 @@ All correction factors (RFCF and SFCF) are set to 1.
 - `snow_precip`
 - `liquid_precip`
 """
-function precipitation_hbv(precipitation, temperature, tti, tt; rfcf = 1.0, sfcf = 1.0)
+function precipitation_hbv(precipitation, temperature, tti, tt; rfcf = ONE, sfcf = ONE)
     # fraction of precipitation which falls as rain
     rainfrac = if iszero(tti)
-        Float64(temperature > tt)
+        PRECISION(temperature > tt)
     else
-        frac = (temperature - (tt - tti / 2.0)) / tti
-        min(frac, 1.0)
+        frac = (temperature - (tt - tti / 2)) / tti
+        min(frac, ONE)
     end
-    rainfrac = max(rainfrac, 0.0)
+    rainfrac = max(rainfrac, ZERO)
 
     # fraction of precipitation which falls as snow
-    snowfrac = 1.0 - rainfrac
+    snowfrac = ONE - rainfrac
     # different correction for liquid_precip and snow_precip
     snow_precip = snowfrac * sfcf * precipitation  # snow_precip depth
     liquid_precip = rainfrac * rfcf * precipitation  # liquid_precip depth

--- a/Wflow/src/soil/soil.jl
+++ b/Wflow/src/soil/soil.jl
@@ -238,8 +238,8 @@ function sbm_kv_profiles(
     dataset::NCDataset,
     config::Config,
     indices::Vector{CartesianIndex{2}},
-    kv_0::Vector{PRECISION},
-    f::Vector{PRECISION},
+    kv_0::Vector{<:AbstractFloat},
+    f::Vector{<:AbstractFloat},
     maxlayers::Int,
     nlayers::Vector{Int},
     sumlayers::Vector,
@@ -525,7 +525,7 @@ function SbmSoilParameters(
         n = length(indices)
         (; rootingdepth) = vegetation_parameter_set
         # default root fraction
-        rootfraction = zeros(maxlayers, n)
+        rootfraction = zeros(PRECISION, maxlayers, n)
         for i in 1:n
             if rootingdepth[i] > ZERO
                 for k in 1:maxlayers

--- a/Wflow/src/soil/soil.jl
+++ b/Wflow/src/soil/soil.jl
@@ -4,83 +4,83 @@ abstract type AbstractSoilModel end
 @with_kw struct SbmSoilVariables{N}
     n::Int
     # Calculated soil water pressure head h3 of the root water uptake reduction function (Feddes) [cm]
-    h3::Vector{Float64} = fill(MISSING_VALUE, n)
+    h3::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Unsaturated store capacity [mm]
-    ustorecapacity::Vector{Float64}
+    ustorecapacity::Vector{PRECISION}
     # Amount of water in the unsaturated store, per layer [mm]
-    ustorelayerdepth::Vector{SVector{N, Float64}}
+    ustorelayerdepth::Vector{SVector{N, PRECISION}}
     # Thickness of unsaturated zone, per layer [mm]
-    ustorelayerthickness::Vector{SVector{N, Float64}}
+    ustorelayerthickness::Vector{SVector{N, PRECISION}}
     # Saturated store [mm]
-    satwaterdepth::Vector{Float64}
+    satwaterdepth::Vector{PRECISION}
     # Drainable water store [mm]
-    drainable_waterdepth::Vector{Float64}
+    drainable_waterdepth::Vector{PRECISION}
     # Pseudo-water table depth [mm] (top of the saturated zone)
-    zi::Vector{Float64}
+    zi::Vector{PRECISION}
     # Number of unsaturated soil layers
     n_unsatlayers::Vector{Int}
     # Transpiration [mm Δt⁻¹]
-    transpiration::Vector{Float64} = fill(MISSING_VALUE, n)
+    transpiration::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual evaporation from unsaturated store [mm Δt⁻¹]
-    ae_ustore::Vector{Float64} = fill(MISSING_VALUE, n)
+    ae_ustore::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Soil evaporation from unsaturated and saturated store [mm Δt⁻¹]
-    soilevap::Vector{Float64} = fill(MISSING_VALUE, n)
+    soilevap::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Soil evaporation from saturated store [mm Δt⁻¹]
-    soilevapsat::Vector{Float64} = fill(MISSING_VALUE, n)
+    soilevapsat::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual capillary rise [mm Δt⁻¹]
-    actcapflux::Vector{Float64} = fill(MISSING_VALUE, n)
+    actcapflux::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual transpiration from saturated store [mm Δt⁻¹]
-    actevapsat::Vector{Float64} = fill(MISSING_VALUE, n)
+    actevapsat::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total actual evapotranspiration [mm Δt⁻¹]
-    actevap::Vector{Float64} = fill(MISSING_VALUE, n)
+    actevap::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual infiltration into the unsaturated zone [mm Δt⁻¹]
-    actinfilt::Vector{Float64} = fill(MISSING_VALUE, n)
+    actinfilt::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual infiltration non-compacted fraction [mm Δt⁻¹]
-    actinfiltsoil::Vector{Float64} = fill(MISSING_VALUE, n)
+    actinfiltsoil::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual infiltration compacted fraction [mm Δt⁻¹]
-    actinfiltpath::Vector{Float64} = fill(MISSING_VALUE, n)
+    actinfiltpath::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual infiltration (compacted and the non-compacted areas) [mm Δt⁻¹]
-    infiltsoilpath::Vector{Float64} = fill(MISSING_VALUE, n)
+    infiltsoilpath::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Infiltration excess water [mm Δt⁻¹]
-    infiltexcess::Vector{Float64} = fill(MISSING_VALUE, n)
+    infiltexcess::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Water that cannot infiltrate due to saturated soil (saturation excess) [mm Δt⁻¹]
-    excesswater::Vector{Float64} = fill(MISSING_VALUE, n)
+    excesswater::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Water exfiltrating during saturation excess conditions [mm Δt⁻¹]
-    exfiltsatwater::Vector{Float64} = fill(MISSING_VALUE, n)
+    exfiltsatwater::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Excess water for non-compacted fraction [mm Δt⁻¹]
-    excesswatersoil::Vector{Float64} = fill(MISSING_VALUE, n)
+    excesswatersoil::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Excess water for compacted fraction [mm Δt⁻¹]
-    excesswaterpath::Vector{Float64} = fill(MISSING_VALUE, n)
+    excesswaterpath::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total surface runoff from infiltration and saturation excess (excluding actual open water evaporation) [mm Δt⁻¹]
-    runoff::Vector{Float64} = fill(MISSING_VALUE, n)
+    runoff::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Net surface runoff (surface runoff - actual open water evaporation) [mm Δt⁻¹]
-    net_runoff::Vector{Float64} = fill(MISSING_VALUE, n)
+    net_runoff::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Volumetric water content [-] per soil layer (including theta_r and saturated zone)
-    vwc::Vector{SVector{N, Float64}}
+    vwc::Vector{SVector{N, PRECISION}}
     # Volumetric water content [%] per soil layer (including theta_r and saturated zone)
-    vwc_perc::Vector{SVector{N, Float64}}
+    vwc_perc::Vector{SVector{N, PRECISION}}
     # Root water storage [mm] in unsaturated and saturated zone (excluding theta_r)
-    rootstore::Vector{Float64} = fill(MISSING_VALUE, n)
+    rootstore::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Volumetric water content [-] in root zone (including theta_r and saturated zone)
-    vwc_root::Vector{Float64} = fill(MISSING_VALUE, n)
+    vwc_root::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Volumetric water content [%] in root zone (including theta_r and saturated zone)
-    vwc_percroot::Vector{Float64} = fill(MISSING_VALUE, n)
+    vwc_percroot::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Amount of available water in the unsaturated zone [mm]
-    ustoredepth::Vector{Float64} = zeros(n)
+    ustoredepth::Vector{PRECISION} = zeros(n)
     # Downward flux from unsaturated to saturated zone [mm Δt⁻¹]
-    transfer::Vector{Float64} = fill(MISSING_VALUE, n)
+    transfer::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Net recharge to saturated store [mm Δt⁻¹]
-    recharge::Vector{Float64} = fill(MISSING_VALUE, n)
+    recharge::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual leakage from saturated store [mm Δt⁻¹]
-    actleakage::Vector{Float64} = fill(MISSING_VALUE, n)
+    actleakage::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Total water storage (excluding floodplain volume and reservoirs) [mm]
-    total_storage::Vector{Float64} = zeros(n)
+    total_storage::Vector{PRECISION} = zeros(n)
     # Total soil water storage [mm]
-    total_soilwater_storage::Vector{Float64}
+    total_soilwater_storage::Vector{PRECISION}
     # Top soil temperature [ᵒC]
-    tsoil::Vector{Float64} = fill(10.0, n)
+    tsoil::Vector{PRECISION} = fill(10.0, n)
     # Soil infiltration reduction factor (when soil is frozen) [-]
-    f_infiltration_reduction::Vector{Float64} = ones(n)
+    f_infiltration_reduction::Vector{PRECISION} = ones(n)
 end
 
 "Struct for storing SBM soil model parameters"
@@ -90,59 +90,59 @@ end
     # Number of soil layers [-]
     nlayers::Vector{Int}
     # Saturated water content (porosity) [-]
-    theta_s::Vector{Float64}
+    theta_s::Vector{PRECISION}
     # Residual water content [-]
-    theta_r::Vector{Float64}
+    theta_r::Vector{PRECISION}
     # Field capacity water content [-]
-    theta_fc::Vector{Float64}
+    theta_fc::Vector{PRECISION}
     # Soilwater capacity [mm]
-    soilwatercapacity::Vector{Float64}
+    soilwatercapacity::Vector{PRECISION}
     # Multiplication factor [-] applied to kv_z (vertical flow)
-    kvfrac::Vector{SVector{N, Float64}}
+    kvfrac::Vector{SVector{N, PRECISION}}
     # Air entry pressure [cm] of soil (Brooks-Corey)
-    hb::Vector{Float64}
+    hb::Vector{PRECISION}
     # Soil thickness [mm]
-    soilthickness::Vector{Float64}
+    soilthickness::Vector{PRECISION}
     # Thickness of soil layers [mm]
-    act_thickl::Vector{SVector{N, Float64}}
+    act_thickl::Vector{SVector{N, PRECISION}}
     # Cumulative sum of soil layers [mm], starting at soil surface (0)
-    sumlayers::Vector{SVector{M, Float64}}
+    sumlayers::Vector{SVector{M, PRECISION}}
     # Infiltration capacity of the compacted areas [mm Δt⁻¹]
-    infiltcappath::Vector{Float64}
+    infiltcappath::Vector{PRECISION}
     # Soil infiltration capacity [mm Δt⁻¹]
-    infiltcapsoil::Vector{Float64}
+    infiltcapsoil::Vector{PRECISION}
     # Maximum leakage [mm Δt⁻¹] from saturated zone
-    maxleakage::Vector{Float64}
+    maxleakage::Vector{PRECISION}
     # Parameter [mm] controlling capillary rise
-    cap_hmax::Vector{Float64}
+    cap_hmax::Vector{PRECISION}
     # Coefficient [-] controlling capillary rise
-    cap_n::Vector{Float64}
+    cap_n::Vector{PRECISION}
     # Brooks-Corey power coefﬁcient [-] for each soil layer
-    c::Vector{SVector{N, Float64}}
+    c::Vector{SVector{N, PRECISION}}
     # Soil temperature smooth factor [-]
-    w_soil::Vector{Float64}
+    w_soil::Vector{PRECISION}
     # Controls soil infiltration reduction factor when soil is frozen [-]
-    cf_soil::Vector{Float64}
+    cf_soil::Vector{PRECISION}
     # Fraction of compacted area  [-]
-    pathfrac::Vector{Float64}
+    pathfrac::Vector{PRECISION}
     # Controls how roots are linked to water table [-]
-    rootdistpar::Vector{Float64}
+    rootdistpar::Vector{PRECISION}
     # Fraction of the root length density in each soil layer [-]
-    rootfraction::Vector{SVector{N, Float64}}
+    rootfraction::Vector{SVector{N, PRECISION}}
     # Soil water pressure head h1 of the root water uptake reduction function (Feddes) [cm]
-    h1::Vector{Float64}
+    h1::Vector{PRECISION}
     # Soil water pressure head h2 of the root water uptake reduction function (Feddes) [cm]
-    h2::Vector{Float64}
+    h2::Vector{PRECISION}
     # Soil water pressure head h3_high of the root water uptake reduction function (Feddes) [cm]
-    h3_high::Vector{Float64}
+    h3_high::Vector{PRECISION}
     # Soil water pressure head h3_low of the root water uptake reduction function (Feddes) [cm]
-    h3_low::Vector{Float64}
+    h3_low::Vector{PRECISION}
     # Soil water pressure head h4 of the root water uptake reduction function (Feddes) [cm]
-    h4::Vector{Float64}
+    h4::Vector{PRECISION}
     # Root water uptake reduction at soil water pressure head h1 (0.0 or 1.0) [-]
-    alpha_h1::Vector{Float64}
+    alpha_h1::Vector{PRECISION}
     # Soil fraction [-]
-    soil_fraction::Vector{Float64}
+    soil_fraction::Vector{PRECISION}
     # Vertical hydraulic conductivity profile type
     kv_profile::Kv
     # Vegetation parameter set
@@ -163,7 +163,7 @@ function SbmSoilVariables(n::Int, parameters::SbmSoilParameters)
     ) = parameters
     satwaterdepth = 0.85 .* soilwatercapacity # cold state value for satwaterdepth
     ustoredepth = zeros(n)
-    zi = @. max(0.0, soilthickness - satwaterdepth / (theta_s - theta_r))
+    zi = @. max(ZERO, soilthickness - satwaterdepth / (theta_s - theta_r))
     drainable_waterdepth =
         @. (soilthickness - zi) * lower_bound_drainable_porosity(theta_s, theta_fc)
     ustorelayerthickness = set_layerthickness.(zi, sumlayers, act_thickl)
@@ -193,44 +193,44 @@ end
 @with_kw struct SbmSoilBC
     n::Int
     # Water flux at the soil surface [mm Δt⁻¹]
-    water_flux_surface::Vector{Float64} = fill(MISSING_VALUE, n)
+    water_flux_surface::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Potential transpiration rate [mm Δt⁻¹]
-    potential_transpiration::Vector{Float64} = fill(MISSING_VALUE, n)
+    potential_transpiration::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Potential soil evaporation rate [mm Δt⁻¹]
-    potential_soilevaporation::Vector{Float64} = fill(MISSING_VALUE, n)
+    potential_soilevaporation::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Exponential depth profile of vertical hydraulic conductivity at the soil surface"
 struct KvExponential
     # Vertical hydraulic conductivity [mm Δt⁻¹] at soil surface
-    kv_0::Vector{Float64}
+    kv_0::Vector{PRECISION}
     # A scaling parameter [mm⁻¹] (controls exponential decline of kv_0)
-    f::Vector{Float64}
+    f::Vector{PRECISION}
 end
 
 "Exponential constant depth profile of vertical hydraulic conductivity"
 struct KvExponentialConstant
     exponential::KvExponential
     # Depth [mm] from soil surface for which exponential decline of kv_0 is valid
-    z_exp::Vector{Float64}
+    z_exp::Vector{PRECISION}
 end
 
 "Layered depth profile of vertical hydraulic conductivity"
 struct KvLayered{N}
     # Vertical hydraulic conductivity [mm Δt⁻¹] per soil layer
-    kv::Vector{SVector{N, Float64}}
+    kv::Vector{SVector{N, PRECISION}}
 end
 
 "Layered exponential depth profile of vertical hydraulic conductivity"
 struct KvLayeredExponential{N}
     # A scaling parameter [mm⁻¹] (controls exponential decline of kv_0)
-    f::Vector{Float64}
+    f::Vector{PRECISION}
     # Vertical hydraulic conductivity [mm Δt⁻¹] per soil layer
-    kv::Vector{SVector{N, Float64}}
+    kv::Vector{SVector{N, PRECISION}}
     # Number of soil layers [-] with vertical hydraulic conductivity value `kv`
     nlayers_kv::Vector{Int}
     # Depth [mm] from soil surface for which layered profile is valid
-    z_layered::Vector{Float64}
+    z_layered::Vector{PRECISION}
 end
 
 "Initialize SBM soil model hydraulic conductivity depth profile"
@@ -238,8 +238,8 @@ function sbm_kv_profiles(
     dataset::NCDataset,
     config::Config,
     indices::Vector{CartesianIndex{2}},
-    kv_0::Vector{Float64},
-    f::Vector{Float64},
+    kv_0::Vector{PRECISION},
+    f::Vector{PRECISION},
     maxlayers::Int,
     nlayers::Vector{Int},
     sumlayers::Vector,
@@ -316,8 +316,8 @@ function SbmSoilParameters(
     config_soil_layer_thickness = config.model.soil_layer__thickness
 
     soil_layer_thickness =
-        SVector(Tuple(push!(Float64.(config_soil_layer_thickness), MISSING_VALUE)))
-    cum_depth_layers = pushfirst(cumsum(soil_layer_thickness), 0.0)
+        SVector(Tuple(push!(PRECISION.(config_soil_layer_thickness), MISSING_VALUE)))
+    cum_depth_layers = pushfirst(cumsum(soil_layer_thickness), ZERO)
     maxlayers = length(soil_layer_thickness) # max number of soil layers
 
     @info "Using `$(maxlayers - 1)` soil layers with the following thickness: `$config_soil_layer_thickness`"
@@ -500,7 +500,7 @@ function SbmSoilParameters(
 
     act_thickl =
         set_layerthickness.(soilthickness, (cum_depth_layers,), (soil_layer_thickness,))
-    sumlayers = @. pushfirst(cumsum(act_thickl), 0.0)
+    sumlayers = @. pushfirst(cumsum(act_thickl), ZERO)
     nlayers = number_of_active_layers.(act_thickl)
 
     if haskey(config.input.static, "soil_water__field_capacity_volume_fraction")
@@ -510,7 +510,7 @@ function SbmSoilParameters(
             "soil_water__field_capacity_volume_fraction";
             optional = false,
             sel = indices,
-            type = Float64,
+            type = PRECISION,
         )
     else
         theta_fc = field_capacity.(act_thickl, nlayers, theta_s, theta_r, c, hb)
@@ -527,13 +527,13 @@ function SbmSoilParameters(
         # default root fraction
         rootfraction = zeros(maxlayers, n)
         for i in 1:n
-            if rootingdepth[i] > 0.0
+            if rootingdepth[i] > ZERO
                 for k in 1:maxlayers
                     if (rootingdepth[i] - sumlayers[i][k]) >= act_thickl[i][k]
                         rootfraction[k, i] = act_thickl[i][k] / rootingdepth[i]
                     else
                         rootfraction[k, i] =
-                            max(rootingdepth[i] - sumlayers[i][k], 0.0) / rootingdepth[i]
+                            max(rootingdepth[i] - sumlayers[i][k], ZERO) / rootingdepth[i]
                     end
                 end
             end
@@ -626,7 +626,7 @@ function soil_fraction!(
     glacier_fraction = get_glacier_fraction(glacier_model)
 
     @. soil_fraction =
-        max(canopygapfraction - water_fraction - river_fraction - glacier_fraction, 0.0)
+        max(canopygapfraction - water_fraction - river_fraction - glacier_fraction, ZERO)
     return nothing
 end
 
@@ -647,12 +647,13 @@ function update_bc_soil_model!(
     evaporation!(demand.paddy, potential_soilevaporation)
     potential_soilevaporation .= potential_soilevaporation .- get_evaporation(demand.paddy)
 
-    water_flux_surface .= max.(
-        runoff.boundary_conditions.water_flux_surface .+
-        get_irrigation_allocated(allocation) .- runoff.variables.runoff_river .-
-        runoff.variables.runoff_land .+ get_water_depth(demand.paddy),
-        0.0,
-    )
+    water_flux_surface .=
+        max.(
+            runoff.boundary_conditions.water_flux_surface .+
+            get_irrigation_allocated(allocation) .- runoff.variables.runoff_river .-
+            runoff.variables.runoff_land .+ get_water_depth(demand.paddy),
+            ZERO,
+        )
     return nothing
 end
 
@@ -660,7 +661,7 @@ end
 function soil_temperature!(
     soil_model::SbmSoilModel,
     ::AbstractSnowModel,
-    temperature::Vector{Float64},
+    temperature::Vector{PRECISION},
 )
     v = soil_model.variables
     p = soil_model.parameters
@@ -668,7 +669,7 @@ function soil_temperature!(
     return nothing
 end
 
-soil_temperature!(::SbmSoilModel, ::NoSnowModel, ::Vector{Float64}) = nothing
+soil_temperature!(::SbmSoilModel, ::NoSnowModel, ::Vector{PRECISION}) = nothing
 
 "Update total available water in the unsaturated zone of the SBM soil model for a single timestep"
 function ustoredepth!(soil_model::SbmSoilModel)
@@ -742,7 +743,7 @@ function unsaturated_zone_flow!(soil_model::SbmSoilModel)
         if v.n_unsatlayers[i] > 0
             # Brooks-Corey approach
             z = cumsum(v.ustorelayerthickness[i])
-            flow_rate = 0.0
+            flow_rate = ZERO
             for m in 1:v.n_unsatlayers[i]
                 l_sat = v.ustorelayerthickness[i][m] * (p.theta_s[i] - p.theta_r[i])
                 kv_z = hydraulic_conductivity_at_depth(p.kv_profile, p.kvfrac, z[m], i, m)
@@ -757,7 +758,7 @@ function unsaturated_zone_flow!(soil_model::SbmSoilModel)
             end
             v.transfer[i] = flow_rate
         else
-            v.transfer[i] = 0.0
+            v.transfer[i] = ZERO
         end
     end
     return nothing
@@ -820,7 +821,7 @@ Update total `transpiration`, transpiration from the unsaturated store `ae_ustor
 saturated store `actevapsat` of the SBM soil model for a single timestep. Also unsaturated
 storage `ustorelayerdepth` and the saturated store `satwaterdepth` are updated.
 """
-function transpiration!(soil_model::SbmSoilModel, dt::Float64)
+function transpiration!(soil_model::SbmSoilModel, dt::PRECISION)
     (; potential_transpiration) = soil_model.boundary_conditions
     v = soil_model.variables
     p = soil_model.parameters
@@ -834,8 +835,8 @@ function transpiration!(soil_model::SbmSoilModel, dt::Float64)
         # compute sum of root fraction in unsaturated soil layers and adapt root fraction
         # lowest unsaturated soil layer if water table depth intersects the unsaturated root
         # zone
-        sum_rootfraction_unsat = 0.0
-        rootfraction_unsat_lowest = 0.0
+        sum_rootfraction_unsat = ZERO
+        rootfraction_unsat_lowest = ZERO
         for k in 1:v.n_unsatlayers[i]
             # the root fraction is valid for the root length in a soil layer, if zi decreases
             # the root length the root fraction needs to be adapted
@@ -852,7 +853,7 @@ function transpiration!(soil_model::SbmSoilModel, dt::Float64)
             rootfraction_unsat_lowest = rootfraction_unsat
         end
 
-        actevapustore = 0.0
+        actevapustore = ZERO
         for k in 1:v.n_unsatlayers[i]
             # scale rootfraction soil layer unsaturated zone based on sum of rootfraction in
             # unsaturated zone
@@ -862,12 +863,12 @@ function transpiration!(soil_model::SbmSoilModel, dt::Float64)
                 rootfraction_unsat = rootfraction_unsat_lowest
             end
             rootfraction_unsat_scaled =
-                rootingdepth[i] > 0.0 ?
-                max((1.0 / sum_rootfraction_unsat), 1.0) * rootfraction_unsat : 0.0
+                rootingdepth[i] > ZERO ?
+                max((ONE / sum_rootfraction_unsat), ONE) * rootfraction_unsat : ZERO
 
             vwc = max(
                 v.ustorelayerdepth[i][k] / v.ustorelayerthickness[i][k],
-                Float64(0.0000001),
+                PRECISION(0.0000001),
             )
             head = head_brooks_corey(vwc, p.theta_s[i], p.theta_r[i], p.c[i][k], p.hb[i])
             alpha = rwu_reduction_feddes(
@@ -880,9 +881,9 @@ function transpiration!(soil_model::SbmSoilModel, dt::Float64)
             )
 
             availcap = min(
-                1.0,
+                ONE,
                 max(
-                    0.0,
+                    ZERO,
                     (rootingdepth[i] - p.sumlayers[i][k]) / v.ustorelayerthickness[i][k],
                 ),
             )
@@ -895,15 +896,9 @@ function transpiration!(soil_model::SbmSoilModel, dt::Float64)
         end
 
         # transpiration from saturated store
-        wetroots = scurve(v.zi[i], rootingdepth[i], Float64(1.0), p.rootdistpar[i])
-        alpha = rwu_reduction_feddes(
-            Float64(0.0),
-            p.h1[i],
-            p.h2[i],
-            v.h3[i],
-            p.h4[i],
-            p.alpha_h1[i],
-        )
+        wetroots = scurve(v.zi[i], rootingdepth[i], PRECISION(ONE), p.rootdistpar[i])
+        alpha =
+            rwu_reduction_feddes(ZERO, p.h1[i], p.h2[i], v.h3[i], p.h4[i], p.alpha_h1[i])
         restpottrans = potential_transpiration[i] - actevapustore
         actevapsat = min(restpottrans * wetroots * alpha, v.drainable_waterdepth[i])
 
@@ -932,10 +927,10 @@ function actual_infiltration!(soil_model::SbmSoilModel)
     n = length(v.actinfilt)
     threaded_foreach(1:n; basesize = 1000) do i
         # check soil moisture balance per layer
-        ustoredepth_excess = 0.0
+        ustoredepth_excess = ZERO
         for k in v.n_unsatlayers[i]:-1:1
             ustoredepth_excess = max(
-                0.0,
+                ZERO,
                 v.ustorelayerdepth[i][k] -
                 v.ustorelayerthickness[i][k] * (p.theta_s[i] - p.theta_r[i]),
             )
@@ -1004,27 +999,27 @@ function capillary_flux!(soil_model::SbmSoilModel)
                 v.n_unsatlayers[i],
             )
             maxcapflux = max(
-                0.0,
+                ZERO,
                 min(ksat, v.ae_ustore[i], v.ustorecapacity[i], v.drainable_waterdepth[i]),
             )
 
             if v.zi[i] > rootingdepth[i]
                 capflux =
                     maxcapflux *
-                    pow(1.0 - min(v.zi[i], p.cap_hmax[i]) / (p.cap_hmax[i]), p.cap_n[i])
+                    pow(ONE - min(v.zi[i], p.cap_hmax[i]) / (p.cap_hmax[i]), p.cap_n[i])
             else
-                capflux = 0.0
+                capflux = ZERO
             end
 
             netcapflux = capflux
-            actcapflux = 0.0
+            actcapflux = ZERO
             for k in v.n_unsatlayers[i]:-1:1
                 toadd = min(
                     netcapflux,
                     max(
                         v.ustorelayerthickness[i][k] * (p.theta_s[i] - p.theta_r[i]) -
                         v.ustorelayerdepth[i][k],
-                        0.0,
+                        ZERO,
                     ),
                 )
                 v.ustorelayerdepth[i] =
@@ -1034,7 +1029,7 @@ function capillary_flux!(soil_model::SbmSoilModel)
             end
             v.actcapflux[i] = actcapflux
         else
-            v.actcapflux[i] = 0.0
+            v.actcapflux[i] = ZERO
         end
     end
     return nothing
@@ -1059,7 +1054,7 @@ function leakage!(soil_model::SbmSoilModel)
             p.nlayers[i],
         )
         deeptransfer = min(v.drainable_waterdepth[i], deepksat)
-        v.actleakage[i] = max(0.0, min(p.maxleakage[i], deeptransfer))
+        v.actleakage[i] = max(ZERO, min(p.maxleakage[i], deeptransfer))
     end
     return nothing
 end
@@ -1070,7 +1065,7 @@ end
         atmospheric_forcing::AtmosphericForcing,
         external_models::NamedTuple,
         config::Config,
-        dt::Float64,
+        dt::PRECISION,
     )
 
 Update the SBM soil model (infiltration, unsaturated zone flow, soil evaporation and
@@ -1081,7 +1076,7 @@ function update_soil_water_flow!(
     atmospheric_forcing::AtmosphericForcing,
     external_models::NamedTuple,
     config::Config,
-    dt::Float64,
+    dt::PRECISION,
 )
     (; snow, runoff, demand) = external_models
     (; temperature) = atmospheric_forcing
@@ -1109,8 +1104,8 @@ function update_soil_water_flow!(
     @. v.excesswater = water_flux_surface - v.actinfilt - v.infiltexcess
     actual_infiltration_soil_path!(soil_model)
     @. v.excesswatersoil =
-        max(water_flux_surface * (1.0 - p.pathfrac) - v.actinfiltsoil, 0.0)
-    @. v.excesswaterpath = max(water_flux_surface * p.pathfrac - v.actinfiltpath, 0.0)
+        max(water_flux_surface * (ONE - p.pathfrac) - v.actinfiltsoil, ZERO)
+    @. v.excesswaterpath = max(water_flux_surface * p.pathfrac - v.actinfiltpath, ZERO)
     # recompute the unsaturated store and ustorecapacity (for capillary flux)
     ustoredepth!(soil_model)
     @. v.ustorecapacity = p.soilwatercapacity - v.satwaterdepth - v.ustoredepth
@@ -1140,7 +1135,7 @@ function update_ustorelayerdepth!(soil, zi_prev, zi, i)
         for k in n_unsatlayers:n_unsatlayers_prev
             k == 0 && continue
             if isnan(ustorelayerthickness[k])
-                ustorelayerdepth = setindex(ustorelayerdepth, 0.0, k)
+                ustorelayerdepth = setindex(ustorelayerdepth, ZERO, k)
             else
                 f = ustorelayerthickness[k] / ustorelayerthickness_prev[k]
                 ustorelayerdepth = setindex(ustorelayerdepth, f * ustorelayerdepth[k], k)
@@ -1150,7 +1145,7 @@ function update_ustorelayerdepth!(soil, zi_prev, zi, i)
         for k in n_unsatlayers_prev:n_unsatlayers
             k == 0 && continue
             thickness_prev =
-                isnan(ustorelayerthickness_prev[k]) ? 0.0 : ustorelayerthickness_prev[k]
+                isnan(ustorelayerthickness_prev[k]) ? ZERO : ustorelayerthickness_prev[k]
             delta_thickness = ustorelayerthickness[k] - thickness_prev
             ustorelayerdepth = setindex(
                 ustorelayerdepth,
@@ -1242,15 +1237,15 @@ function update_soil_water_storage!(soil_model::SbmSoilModel, external_models::N
             rootstore_unsat =
                 rootstore_unsat +
                 min(
-                    1.0,
+                    ONE,
                     (
-                        max(0.0, rootingdepth[i] - p.sumlayers[i][k]) /
+                        max(ZERO, rootingdepth[i] - p.sumlayers[i][k]) /
                         ustorelayerthickness[k]
                     ),
                 ) * ustorelayerdepth[k]
         end
 
-        rootstore_sat = max(0.0, rootingdepth[i] - v.zi[i]) * (p.theta_s[i] - p.theta_r[i])
+        rootstore_sat = max(ZERO, rootingdepth[i] - v.zi[i]) * (p.theta_s[i] - p.theta_r[i])
         rootstore = rootstore_sat + rootstore_unsat
         vwc_root = rootstore / rootingdepth[i] + p.theta_r[i]
         vwc_percroot = (vwc_root / p.theta_s[i]) * 100.0

--- a/Wflow/src/soil/soil_process.jl
+++ b/Wflow/src/soil/soil_process.jl
@@ -23,12 +23,12 @@ function infiltration(
 )
     # First determine if the soil infiltration capacity can deal with the amount of water
     # split between infiltration in undisturbed soil and paved areas (path).
-    soilinf = potential_infiltration * (1.0 - pathfrac)
+    soilinf = potential_infiltration * (ONE - pathfrac)
     pathinf = potential_infiltration * pathfrac
 
     max_infiltsoil = min(infiltcapsoil * f_infiltration_reduction, soilinf)
     max_infiltpath = min(infiltcappath * f_infiltration_reduction, pathinf)
-    infiltsoilpath = min(max_infiltpath + max_infiltsoil, max(0.0, ustorecapacity))
+    infiltsoilpath = min(max_infiltpath + max_infiltsoil, max(ZERO, ustorecapacity))
 
     infiltexcess = (soilinf - max_infiltsoil) + (pathinf - max_infiltpath)
 
@@ -44,14 +44,14 @@ table), the effective saturation degree of the layer (ratio `usd` and `l_sat`), 
 Brooks-Corey power coefficient `c`.
 """
 function unsatzone_flow_layer(usd, kv_z, l_sat, c)
-    if usd <= 0.0
-        return 0.0, 0.0
+    if usd <= ZERO
+        return ZERO, ZERO
     end
     # Excess soil water:
     # first transfer soil water > maximum soil water capacity layer (iteration is not
     # required because of steady theta (usd))
-    st_sat = max(0.0, usd - l_sat)
-    st = kv_z * min(pow(usd / l_sat, c), 1.0)
+    st_sat = max(ZERO, usd - l_sat)
+    st = kv_z * min(pow(usd / l_sat, c), ONE)
     sum_ast = min(st, st_sat)
     usd -= sum_ast
 
@@ -60,7 +60,7 @@ function unsatzone_flow_layer(usd, kv_z, l_sat, c)
     remainder = min(st - sum_ast, usd)
     its = Int(cld(remainder, 0.2))
     for _ in 1:its
-        st = (kv_z / its) * min(pow(usd / l_sat, c), 1.0)
+        st = (kv_z / its) * min(pow(usd / l_sat, c), ONE)
         ast = min(st, usd)
         usd -= ast
         sum_ast += ast
@@ -107,8 +107,8 @@ end
 Return water content at field capacity based on the Brooks-Corey soil hydraulic model.
 """
 function field_capacity(layer_thickness, n_layers, theta_s, theta_r, c, hb)
-    theta_fc = 0.0
-    total_depth = 0.0
+    theta_fc = ZERO
+    total_depth = ZERO
     for i in 1:n_layers
         theta_fc +=
             vwc_brooks_corey(-100.0, hb, theta_s, theta_r, c[i]) * layer_thickness[i]
@@ -125,10 +125,10 @@ Return soil water pressure head `h3` of Feddes root water uptake reduction funct
 function feddes_h3(h3_high, h3_low, tpot, Δt)
     # value of h3 is a function of potential transpiration [mm d⁻¹]
     tpot_daily = tpot * (tosecond(BASETIMESTEP) / Δt)
-    return if tpot_daily <= 1.0
+    return if tpot_daily <= ONE
         h3_low
     elseif tpot_daily < 5.0
-        h3_low + (h3_high - h3_low) * (tpot_daily - 1.0) / (5.0 - 1.0)
+        h3_low + (h3_high - h3_low) * (tpot_daily - ONE) / (5.0 - ONE)
     else
         h3_high
     end
@@ -142,19 +142,19 @@ Root water uptake reduction factor based on Feddes.
 function rwu_reduction_feddes(h, h1, h2, h3, h4, alpha_h1)
     # root water uptake reduction coefficient alpha (see also Feddes et al., 1978)
     return if h < h4
-        0.0
+        ZERO
     elseif h < h3
         (h - h4) / (h3 - h4)
     elseif iszero(alpha_h1)
         if h < h2
-            1.0
+            ONE
         elseif h < h1
             (h1 - h) / (h1 - h2)
         else
-            0.0
+            ZERO
         end
     else
-        1.0
+        ONE
     end
 end
 
@@ -183,7 +183,7 @@ When both `modelsnow` and `soil_infiltration_reduction` are `true` an infiltrati
 factor `f_infiltration_reduction` is computed. The infiltration reduction factor is based on
 the near surface soil temperature `tsoil`, parameter `cf_soil` and a s-curve to make a
 smooth transition of `f_infiltration_reduction` as a function of `tsoil` and `cf_soil`.
-Otherwise, `f_infiltration_reduction` is set to 1.0.
+Otherwise, `f_infiltration_reduction` is set to ONE.
 """
 function infiltration_reduction_factor(
     tsoil,
@@ -192,10 +192,10 @@ function infiltration_reduction_factor(
     soil_infiltration_reduction = false,
 )
     if modelsnow && soil_infiltration_reduction
-        bb = 1.0 / (1.0 - cf_soil)
-        f_infiltration_reduction = scurve(tsoil, 0.0, bb, 8.0) + cf_soil
+        bb = ONE / (ONE - cf_soil)
+        f_infiltration_reduction = scurve(tsoil, ZERO, bb, 8.0) + cf_soil
     else
-        f_infiltration_reduction = 1.0
+        f_infiltration_reduction = ONE
     end
     return f_infiltration_reduction
 end
@@ -210,16 +210,16 @@ function soil_evaporation_unsatured_store(
     theta_effective,
 )
     if n_unsatlayers == 0
-        soilevapunsat = 0.0
+        soilevapunsat = ZERO
     elseif n_unsatlayers == 1
         # Check if groundwater level lies below the surface
         soilevapunsat =
-            potential_soilevaporation * min(1.0, ustorelayerdepth / (zi * theta_effective))
+            potential_soilevaporation * min(ONE, ustorelayerdepth / (zi * theta_effective))
     else
         # In case first layer contains no saturated storage
         soilevapunsat =
             potential_soilevaporation *
-            min(1.0, ustorelayerdepth / (ustorelayerthickness * (theta_effective)))
+            min(ONE, ustorelayerdepth / (ustorelayerthickness * (theta_effective)))
     end
     return soilevapunsat
 end
@@ -234,10 +234,10 @@ function soil_evaporation_satured_store(
 )
     if n_unsatlayers in (0, 1)
         soilevapsat =
-            potential_soilevaporation * min(1.0, (layerthickness - zi) / layerthickness)
+            potential_soilevaporation * min(ONE, (layerthickness - zi) / layerthickness)
         soilevapsat = min(soilevapsat, (layerthickness - zi) * theta_drainable)
     else
-        soilevapsat = 0.0
+        soilevapsat = ZERO
     end
     return soilevapsat
 end
@@ -251,9 +251,9 @@ function actual_infiltration_soil_path(
     infiltcappath,
     f_infiltration_reduction,
 )
-    soilinf = potential_infiltration * (1.0 - pathfrac)
+    soilinf = potential_infiltration * (ONE - pathfrac)
     pathinf = potential_infiltration * pathfrac
-    if actinfilt > 0.0
+    if actinfilt > ZERO
         max_infiltsoil = min(infiltcapsoil * f_infiltration_reduction, soilinf)
         max_infiltpath = min(infiltcappath * f_infiltration_reduction, pathinf)
 
@@ -261,8 +261,8 @@ function actual_infiltration_soil_path(
         actinfiltpath = actinfilt * max_infiltpath / (max_infiltpath + max_infiltsoil)
 
     else
-        actinfiltsoil = 0.0
-        actinfiltpath = 0.0
+        actinfiltsoil = ZERO
+        actinfiltpath = ZERO
     end
 
     return actinfiltsoil, actinfiltpath

--- a/Wflow/src/standard_name/standard_name_routing.jl
+++ b/Wflow/src/standard_name/standard_name_routing.jl
@@ -214,7 +214,7 @@ const routing_standard_name_map = OrderedDict{String, ParameterMetadata}(
     "river_bank_water__depth" => ParameterMetadata(;
         lens = @optic(_.routing.river_flow.parameters.bankfull_depth),
         unit = Unit(; m = 1),
-        default = 1.0,
+        default = ONE,
         fill = 0.0,
         description = "Bankfull river depth",
         tags = [:kinematic_wave_river_flow_input, :local_inertial_river_input],
@@ -378,7 +378,7 @@ const routing_standard_name_map = OrderedDict{String, ParameterMetadata}(
     #### Input
     "model_boundary_condition_river__length" => ParameterMetadata(;
         unit = Unit(; m = 1),
-        default = 1.0e4,
+        default = 1e4,
         description = "Boundary condition river length downstream river outlets",
         tags = [:local_inertial_river_input],
     ),

--- a/Wflow/src/standard_name/standard_name_sbm.jl
+++ b/Wflow/src/standard_name/standard_name_sbm.jl
@@ -664,7 +664,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
         ParameterMetadata(;
             lens = @optic(_.land.soil.parameters.alpha_h1),
             default = ONE,
-            description = "Root water uptake reduction at soil water pressure head h1 (0.0 or ONE)",
+            description = "Root water uptake reduction at soil water pressure head h1 (0.0 or 1.0)",
             tags = [:soil_input],
         ),
     "vegetation_root__feddes_critical_pressure_head_h2" => ParameterMetadata(;

--- a/Wflow/src/standard_name/standard_name_sbm.jl
+++ b/Wflow/src/standard_name/standard_name_sbm.jl
@@ -8,7 +8,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     "atmosphere_air__snowfall_temperature_interval" => ParameterMetadata(;
         lens = @optic(_.land.snow.parameters.tti),
         unit = Unit(; degC = 1),
-        default = 1.0,
+        default = ONE,
         description = "Threshold temperature interval length",
         tags = [:snow_input],
     ),
@@ -136,7 +136,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     ),
     "irrigated_non_paddy__irrigation_efficiency" => ParameterMetadata(;
         lens = @optic(_.land.demand.nonpaddy.parameters.irrigation_efficiency),
-        default = 1.0,
+        default = ONE,
         description = "Irrigation efficiency",
         tags = [:demand_non_paddy_irrigation_input],
     ),
@@ -162,7 +162,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     ),
     "irrigated_paddy__irrigation_efficiency" => ParameterMetadata(;
         lens = @optic(_.land.demand.paddy.parameters.irrigation_efficiency),
-        default = 1.0,
+        default = ONE,
         description = "Irrigation efficiency",
         tags = [:demand_paddy_irrigation_input],
     ),
@@ -230,7 +230,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     ),
     "land_surface_water__withdrawal_fraction" => ParameterMetadata(;
         lens = @optic(_.land.allocation.parameters.frac_sw_used),
-        default = 1.0,
+        default = ONE,
         description = "Fraction surface water used",
         tags = [:demand_allocation_input],
     ),
@@ -414,7 +414,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     "soil_layer_water__vertical_saturated_hydraulic_conductivity_factor" =>
         ParameterMetadata(;
             lens = @optic(_.land.soil.parameters.kvfrac),
-            default = 1.0,
+            default = ONE,
             description = "Multiplication factor applied to vertical saturated hydraulic conductivity per soil layer",
             dimname = :layer,
             tags = [:soil_input],
@@ -613,7 +613,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     ),
     "vegetation__crop_factor" => ParameterMetadata(;
         lens = @optic(_.land.vegetation_parameters.kc),
-        default = 1.0,
+        default = ONE,
         description = "Crop coefficient",
         tags = [:vegetation_input],
     ),
@@ -663,8 +663,8 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     "vegetation_root__feddes_critical_pressure_head_h1_reduction_coefficient" =>
         ParameterMetadata(;
             lens = @optic(_.land.soil.parameters.alpha_h1),
-            default = 1.0,
-            description = "Root water uptake reduction at soil water pressure head h1 (0.0 or 1.0)",
+            default = ONE,
+            description = "Root water uptake reduction at soil water pressure head h1 (0.0 or ONE)",
             tags = [:soil_input],
         ),
     "vegetation_root__feddes_critical_pressure_head_h2" => ParameterMetadata(;
@@ -698,7 +698,7 @@ const sbm_standard_name_map = OrderedDict{String, ParameterMetadata}(
     "vegetation_water__storage_capacity" => ParameterMetadata(;
         lens = @optic(_.land.vegetation_parameters.cmax),
         unit = Unit(; mm = 1),
-        default = 1.0,
+        default = ONE,
         description = "Maximum canopy storage",
         tags = [:vegetation_input],
     ),

--- a/Wflow/src/standard_name/standard_name_sediment.jl
+++ b/Wflow/src/standard_name/standard_name_sediment.jl
@@ -368,7 +368,7 @@ const sediment_standard_name_map = OrderedDict{String, ParameterMetadata}(
         lens = @optic(
             _.routing.river_flow.sediment_flux.parameters.reservoir_trapping_efficiency
         ),
-        default = 1.0,
+        default = ONE,
         fill = 0.0,
         description = "Reservoir sediment bedload trapping efficiency",
         tags = [:sediment_river_transport_input],

--- a/Wflow/src/standard_name/standard_name_utils.jl
+++ b/Wflow/src/standard_name/standard_name_utils.jl
@@ -5,7 +5,7 @@ get_standard_name_map(::Type{<:SoilLossModel}) = sediment_standard_name_map
 get_standard_name_map(::Type{<:Domain}) = domain_standard_name_map
 get_standard_name_map(::Type{<:Routing}) = routing_standard_name_map
 
-const PARAMETER_TYPES = Union{Float64, Int, Bool, Nothing}
+const PARAMETER_TYPES = Union{PRECISION, Int, Bool, Nothing}
 
 """
 Metadata associated with parameters and variables.
@@ -15,7 +15,7 @@ Metadata associated with parameters and variables.
 - `unit`: The unit of the parameter/variable in the Wflow input
 - `default`: The default (initial) value of the parameter/variable if it exists
 - `fill`: Missing input values are replaced by this value if allow_missing == false
-- `type`: The output type of the data. Assumed to be `Float64` if it is not provided and cannot be derived
+- `type`: The output type of the data. Assumed to be `PRECISION` if it is not provided and cannot be derived
     from `default` or `fill`
 - `description`: The description of the parameter/variable provided in the Wflow docs
 - `allow_missing`: Whether the parameter/variable is allowed to have missing entries
@@ -58,12 +58,18 @@ Metadata associated with parameters and variables.
             elseif !isnothing(fill)
                 F
             else
-                # Assume the type is Float64 if it is not provided and cannot be derived
+                # Assume the type is PRECISION if it is not provided and cannot be derived
                 # from the default or fill
-                Float64
+                PRECISION
             end
         end
-        return new{L, D, F, type, N}(
+
+        if type <: AbstractFloat
+            type = PRECISION
+            default = (default isa AbstractFloat) ? PRECISION(default) : default
+            fill = (fill isa AbstractFloat) ? PRECISION(fill) : fill
+        end
+        return new{L, typeof(default), typeof(fill), type, N}(
             lens,
             unit,
             default,

--- a/Wflow/src/surfacewater/runoff.jl
+++ b/Wflow/src/surfacewater/runoff.jl
@@ -4,23 +4,23 @@ abstract type AbstractRunoffModel end
 @with_kw struct OpenWaterRunoffVariables
     n::Int
     # Runoff from river based on riverfrac [mm Δt⁻¹]
-    runoff_river::Vector{Float64} = fill(MISSING_VALUE, n)
+    runoff_river::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Net runoff from river [mm Δt⁻¹]
-    net_runoff_river::Vector{Float64} = fill(MISSING_VALUE, n)
+    net_runoff_river::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Runoff from land based on waterfrac [mm Δt⁻¹]
-    runoff_land::Vector{Float64} = fill(MISSING_VALUE, n)
+    runoff_land::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual evaporation from open water (land) [mm Δt⁻¹]
-    ae_openw_l::Vector{Float64} = fill(MISSING_VALUE, n)
+    ae_openw_l::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Actual evaporation from river [mm Δt⁻¹]
-    ae_openw_r::Vector{Float64} = fill(MISSING_VALUE, n)
+    ae_openw_r::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing open water runoff boundary conditions"
 @with_kw struct OpenWaterRunoffBC
     n::Int
-    water_flux_surface::Vector{Float64} = fill(MISSING_VALUE, n) # [mm dt-1]
-    waterdepth_land::Vector{Float64} = fill(MISSING_VALUE, n) # [mm]
-    waterdepth_river::Vector{Float64} = zeros(n) # [mm]
+    water_flux_surface::Vector{PRECISION} = fill(MISSING_VALUE, n) # [mm dt-1]
+    waterdepth_land::Vector{PRECISION} = fill(MISSING_VALUE, n) # [mm]
+    waterdepth_river::Vector{PRECISION} = zeros(n) # [mm]
 end
 
 "Open water runoff model"
@@ -32,7 +32,7 @@ end
 
 "Return the water flux at the surface (boundary condition) when snow is not modelled"
 function get_water_flux_surface!(
-    water_flux_surface::Vector{Float64},
+    water_flux_surface::Vector{PRECISION},
     snow::NoSnowModel,
     glacier::AbstractGlacierModel,
     interception::AbstractInterceptionModel,
@@ -44,7 +44,7 @@ end
 
 "Return the water flux at the surface (boundary condition) when snow is modelled"
 function get_water_flux_surface!(
-    water_flux_surface::Vector{Float64},
+    water_flux_surface::Vector{PRECISION},
     snow::AbstractSnowModel,
     glacier::AbstractGlacierModel,
     interception::AbstractInterceptionModel,
@@ -89,8 +89,8 @@ function update_open_water_runoff_model!(
     (; potential_evaporation) = atmospheric_forcing
     (; river_fraction, water_fraction) = parameters
 
-    @. runoff_river = min(1.0, river_fraction) * water_flux_surface
-    @. runoff_land = min(1.0, water_fraction) * water_flux_surface
+    @. runoff_river = min(ONE, river_fraction) * water_flux_surface
+    @. runoff_land = min(ONE, water_fraction) * water_flux_surface
     @. ae_openw_r =
         min(waterdepth_river * river_fraction, river_fraction * potential_evaporation)
     @. ae_openw_l =

--- a/Wflow/src/units.jl
+++ b/Wflow/src/units.jl
@@ -45,7 +45,7 @@ struct Unit
     percentage::PowersType # percentage, converted to unitless fraction in the SI standard
     ppm::PowersType # parts per million, converted to unitless fraction in the SI standard
     # Factor for converting a value in this unit to the above mentioned standard SI units (apart from dt)
-    to_SI_factor_without_dt::Float64 # Expected to be last field!
+    to_SI_factor_without_dt::PRECISION # Expected to be last field!
 end
 
 const Units = fieldnames(Unit)[2:(end - 1)]
@@ -53,7 +53,7 @@ const N_UNITS = length(Units)
 const STANDARD_UNITS = [:K, :s, :m, :kg]
 
 function Unit(absolute_temperature, powers_all...)
-    to_SI_factor_without_dt = 1.0
+    to_SI_factor_without_dt = ONE
     for (i, powers) in enumerate(powers_all)
         unit = Units[i]
         (unit == :dt) && continue
@@ -74,48 +74,45 @@ end
 end
 
 function Unit(; absolute_temperature = false, kwargs...)
-    powers = ntuple(
-        i -> begin
-            unit = Units[i]
-            powers = return if unit in keys(kwargs)
-                val = kwargs[unit]
+    powers = ntuple(i -> begin
+        unit = Units[i]
+        powers = if unit in keys(kwargs)
+            val = kwargs[unit]
 
-                if val isa Number
-                    val > 0 ? (0, val) : (-val, 0)
-                else
-                    val
-                end
+            if val isa Number
+                val > 0 ? (0, val) : (-val, 0)
             else
-                (0 // 1, 0 // 1)
+                val
             end
-            PowersType(powers)
-        end,
-        N_UNITS,
-    )
+        else
+            (0 // 1, 0 // 1)
+        end
+        PowersType(powers)
+    end, N_UNITS)
     for unit in keys(kwargs)
         (unit ∉ Units) && argument_error("Unrecognized unit $unit.")
     end
     return Unit(absolute_temperature, powers...)
 end
 
-const to_SI_data = @NamedTuple{factor::Float64, unit_SI::Unit}[
-    (factor = 1.0, unit_SI = Unit(; K = 1)), # K
-    (factor = 1.0, unit_SI = Unit(; K = 1)), # degC
-    (factor = 1.0, unit_SI = Unit(; s = 1)), # s
+const to_SI_data = @NamedTuple{factor::PRECISION, unit_SI::Unit}[
+    (factor = ONE, unit_SI = Unit(; K = 1)), # K
+    (factor = ONE, unit_SI = Unit(; K = 1)), # degC
+    (factor = ONE, unit_SI = Unit(; s = 1)), # s
     (factor = 1e-3, unit_SI = Unit(; s = 1)), # ms
     (factor = 60.0, unit_SI = Unit(; s = 1)), # min
     (factor = 3600, unit_SI = Unit(; s = 1)), # h
     (factor = 86400.0, unit_SI = Unit(; s = 1)), # d
     (factor = NaN, unit_SI = Unit(; s = 1)), # dt
-    (factor = 1.0, unit_SI = Unit(; m = 1)), # m
+    (factor = ONE, unit_SI = Unit(; m = 1)), # m
     (factor = 1e-2, unit_SI = Unit(; m = 1)), # cm
     (factor = 1e-3, unit_SI = Unit(; m = 1)), # mm
     (factor = 1e-6, unit_SI = Unit(; m = 1)), # μm
     (factor = 1e-3, unit_SI = Unit(; m = 3)), # L
-    (factor = 1.0, unit_SI = Unit(; kg = 1)), # kg
+    (factor = ONE, unit_SI = Unit(; kg = 1)), # kg
     (factor = 1e-3, unit_SI = Unit(; kg = 1)), # g
     (factor = 1e3, unit_SI = Unit(; kg = 1)), # t
-    (factor = 1.0, unit_SI = Unit(; kg = 1, m = 2, s = -2)), # J
+    (factor = ONE, unit_SI = Unit(; kg = 1, m = 2, s = -2)), # J
     (factor = 1e-2, unit_SI = Unit()), # percentage
     (factor = 1e-6, unit_SI = Unit()), # ppm
 ]

--- a/Wflow/src/utils.jl
+++ b/Wflow/src/utils.jl
@@ -321,6 +321,9 @@ function ncread(
 
     var = convert(InputEntry, var)
     (; value, layer, scale, offset) = var
+    value = to_precision(value)
+    scale = to_precision(scale)
+    offset = to_precision(offset)
     variable_info(var)
 
     if !isnothing(value)
@@ -555,7 +558,7 @@ julia> tosecond(Day(1))
 tosecond(x::Hour) = PRECISION(Dates.value(Second(x)))
 tosecond(x::Minute) = PRECISION(Dates.value(Second(x)))
 tosecond(x::T) where {T <: DatePeriod} = PRECISION(Dates.value(Second(x)))
-tosecond(x::T) where {T <: TimePeriod} = x / convert(T, Second(1))
+tosecond(x::T) where {T <: TimePeriod} = PRECISION(x / convert(T, Second(1)))
 
 """
     adjacent_nodes_at_edge(graph)
@@ -977,7 +980,7 @@ function initialize_lateral_ssf_model!(
     kh_layered_profile!(soil_model, subsurface_flow_model, kv_profile, dt)
     for i in eachindex(q)
         q[i] = kh[i] * (soilthickness[i] - zi[i]) * slope[i] * flow_width[i]
-        kh_max = 0.0
+        kh_max = ZERO
         for j in 1:nlayers[i]
             if j <= nlayers_kv[i]
                 kh_max += kv[i][j] * act_thickl[i][j]
@@ -1033,7 +1036,7 @@ function water_table_change(
         dh = net_flux / specific_yield
     else
         dh = ZERO
-        f_conv = 0.001 # convert units from [mm] to [m]
+        f_conv = to_precision(0.001) # convert units from [mm] to [m]
         for k in n_unsatlayers[i]:-1:1
             capacity = max(
                 f_conv * (ustorelayerthickness[i][k] * theta_e - ustorelayerdepth[i][k]),
@@ -1056,6 +1059,6 @@ function water_table_change(
 end
 
 "Set lower bound for drainable porosity"
-function lower_bound_drainable_porosity(theta_s, theta_fc; lower_bound = 0.02)
+function lower_bound_drainable_porosity(theta_s, theta_fc; lower_bound = to_precision(0.02))
     return max(theta_s - theta_fc, lower_bound)
 end

--- a/Wflow/src/utils.jl
+++ b/Wflow/src/utils.jl
@@ -113,18 +113,18 @@ function active_indices(domain::Domain, key::AbstractString)::Vector{CartesianIn
     end
 end
 
-function lattometres(lat::Real)::Tuple{Float64, Float64}
-    m1 = 111132.92     # latitude calculation term 1
-    m2 = -559.82       # latitude calculation term 2
-    m3 = 1.175         # latitude calculation term 3
-    m4 = -0.0023       # latitude calculation term 4
-    p1 = 111412.84     # longitude calculation term 1
-    p2 = -93.5         # longitude calculation term 2
-    p3 = 0.118         # longitude calculation term 3
+function lattometres(lat::Real)::Tuple{PRECISION, PRECISION}
+    m1 = to_precision(111132.92)     # latitude calculation term 1
+    m2 = to_precision(-559.82)       # latitude calculation term 2
+    m3 = to_precision(1.175)         # latitude calculation term 3
+    m4 = to_precision(-0.0023)       # latitude calculation term 4
+    p1 = to_precision(111412.84)     # longitude calculation term 1
+    p2 = to_precision(-93.5)         # longitude calculation term 2
+    p3 = to_precision(0.118)         # longitude calculation term 3
 
     # Calculate the length of a degree of latitude and longitude in meters
-    latlen = m1 + (m2 * cosd(2.0 * lat)) + (m3 * cosd(4.0 * lat)) + (m4 * cosd(6.0 * lat))
-    longlen = (p1 * cosd(lat)) + (p2 * cosd(3.0 * lat)) + (p3 * cosd(5.0 * lat))
+    latlen = m1 + (m2 * cosd(2 * lat)) + (m3 * cosd(4 * lat)) + (m4 * cosd(6 * lat))
+    longlen = (p1 * cosd(lat)) + (p2 * cosd(3 * lat)) + (p3 * cosd(5 * lat))
 
     return longlen, latlen
 end
@@ -133,7 +133,7 @@ function cell_lengths(
     y::AbstractVector{<:Real},
     celllength::Real,
     cell_length_in_meter::Bool,
-)::Tuple{Vector{Float64}, Vector{Float64}}
+)::Tuple{Vector{PRECISION}, Vector{PRECISION}}
     n = length(y)
     xl = fill(MISSING_VALUE, n)
     yl = fill(MISSING_VALUE, n)
@@ -404,7 +404,7 @@ function set_layerthickness(
     for i in 1:length(thicknesslayers)
         if reference_depth > cum_depth[i + 1]
             thicknesslayers = setindex(thicknesslayers, thickness[i], i)
-        elseif reference_depth - cum_depth[i] > 0.0
+        elseif reference_depth - cum_depth[i] > ZERO
             thicknesslayers = setindex(thicknesslayers, reference_depth - cum_depth[i], i)
         end
     end
@@ -481,7 +481,7 @@ function sum_at(A::AbstractVector{T}, inds::AbstractVector{Int})::T where {T}
     mapreduce(i -> A[i], +, inds; init = zero(T))
 end
 
-sum_at(f::Function, inds::AbstractVector{Int}; T::Type{<:Number} = Float64) =
+sum_at(f::Function, inds::AbstractVector{Int}; T::Type{<:Number} = PRECISION) =
     mapreduce(f, +, inds; init = zero(T))
 
 # https://juliaarrays.github.io/StaticArrays.jl/latest/pages/api/#Arrays-of-static-arrays-1
@@ -503,7 +503,7 @@ function get_flow_fraction_to_river(
     ldd::Vector{UInt8},
     inds_river::Vector{Int},
     slope::Vector{<:Real},
-)::Vector{Float64}
+)::Vector{PRECISION}
     n = length(slope)
     fraction = zeros(n)
     for i in inds_river
@@ -543,7 +543,7 @@ end
 """
     tosecond(x::Period)
 
-Convert a Period into a Float64, which represents the number of seconds. Will fail if this
+Convert a Period into a PRECISION, which represents the number of seconds. Will fail if this
 is not well defined, such as for Month.
 
 # Examples
@@ -552,9 +552,9 @@ julia> tosecond(Day(1))
 86400.0
 ```
 """
-tosecond(x::Hour) = Float64(Dates.value(Second(x)))
-tosecond(x::Minute) = Float64(Dates.value(Second(x)))
-tosecond(x::T) where {T <: DatePeriod} = Float64(Dates.value(Second(x)))
+tosecond(x::Hour) = PRECISION(Dates.value(Second(x)))
+tosecond(x::Minute) = PRECISION(Dates.value(Second(x)))
+tosecond(x::T) where {T <: DatePeriod} = PRECISION(Dates.value(Second(x)))
 tosecond(x::T) where {T <: TimePeriod} = x / convert(T, Second(1))
 
 """
@@ -599,7 +599,7 @@ function add_vertex_edge_graph!(graph::SimpleDiGraph{Int}, pits::Vector{Int})::N
 end
 
 """
-    set_effective_flowwidth!(we_x::Vector{Float64}, we_y::Vector{Float64}, domain::Domain)
+    set_effective_flowwidth!(we_x::Vector{PRECISION}, we_y::Vector{PRECISION}, domain::Domain)
 
 For river cells (D8 flow direction) in a staggered grid the effective flow width at cell
 edges (floodplain) `we_x` in the x-direction and `we_y` in the y-direction is corrected by
@@ -610,8 +610,8 @@ x and (+ CartesianIndex(0, 1)) for y. For cells that contain a `reservoir_outlet
 (reservoir), the effective flow width is set to zero.
 """
 function set_effective_flowwidth!(
-    we_x::Vector{Float64},
-    we_y::Vector{Float64},
+    we_x::Vector{PRECISION},
+    we_y::Vector{PRECISION},
     domain::Domain,
 )::Nothing
     (; local_drain_direction, indices) = domain.river.network
@@ -630,47 +630,47 @@ function set_effective_flowwidth!(
         idx = reverse_indices[v]
         # loop over river D8 directions
         if dir == CartesianIndex(1, 1)
-            we_x[idx] = reservoir_outlet[v] ? 0.0 : max(we_x[idx] - 0.5 * w, 0.0)
-            we_y[idx] = reservoir_outlet[v] ? 0.0 : max(we_y[idx] - 0.5 * w, 0.0)
+            we_x[idx] = reservoir_outlet[v] ? ZERO : max(we_x[idx] - w / 2, ZERO)
+            we_y[idx] = reservoir_outlet[v] ? ZERO : max(we_y[idx] - w / 2, ZERO)
         elseif dir == CartesianIndex(-1, -1)
             if edge_indices.xd[idx] <= n
                 we_y[edge_indices.xd[idx]] =
-                    reservoir_outlet[v] ? 0.0 :
-                    max(we_y[edge_indices.xd[idx]] - 0.5 * w, 0.0)
+                    reservoir_outlet[v] ? ZERO :
+                    max(we_y[edge_indices.xd[idx]] - w / 2, ZERO)
             end
             if edge_indices.yd[idx] <= n
                 we_x[edge_indices.yd[idx]] =
-                    reservoir_outlet[v] ? 0.0 :
-                    max(we_x[edge_indices.yd[idx]] - 0.5 * w, 0.0)
+                    reservoir_outlet[v] ? ZERO :
+                    max(we_x[edge_indices.yd[idx]] - w / 2, ZERO)
             end
         elseif dir == CartesianIndex(1, 0)
-            we_y[idx] = reservoir_outlet[v] ? 0.0 : max(we_y[idx] - w, 0.0)
+            we_y[idx] = reservoir_outlet[v] ? ZERO : max(we_y[idx] - w, ZERO)
         elseif dir == CartesianIndex(0, 1)
-            we_x[idx] = reservoir_outlet[v] ? 0.0 : max(we_x[idx] - w, 0.0)
+            we_x[idx] = reservoir_outlet[v] ? ZERO : max(we_x[idx] - w, ZERO)
         elseif dir == CartesianIndex(-1, 0)
             if edge_indices.xd[idx] <= n
                 we_y[edge_indices.xd[idx]] =
-                    reservoir_outlet[v] ? 0.0 : max(we_y[edge_indices.xd[idx]] - w, 0.0)
+                    reservoir_outlet[v] ? ZERO : max(we_y[edge_indices.xd[idx]] - w, ZERO)
             end
         elseif dir == CartesianIndex(0, -1)
             if edge_indices.yd[idx] <= n
                 we_x[edge_indices.yd[idx]] =
-                    reservoir_outlet[v] ? 0.0 : max(we_x[edge_indices.yd[idx]] - w, 0.0)
+                    reservoir_outlet[v] ? ZERO : max(we_x[edge_indices.yd[idx]] - w, ZERO)
             end
         elseif dir == CartesianIndex(1, -1)
-            we_y[idx] = max(we_y[idx] - 0.5 * w, 0.0)
+            we_y[idx] = max(we_y[idx] - 0.5 * w, ZERO)
             if edge_indices.yd[idx] <= n
                 we_x[edge_indices.yd[idx]] =
-                    reservoir_outlet[v] ? 0.0 :
-                    max(we_x[edge_indices.yd[idx]] - 0.5 * w, 0.0)
+                    reservoir_outlet[v] ? ZERO :
+                    max(we_x[edge_indices.yd[idx]] - w / 2, ZERO)
             end
         elseif dir == CartesianIndex(-1, 1)
             if edge_indices.xd[idx] <= n
                 we_y[edge_indices.xd[idx]] =
-                    reservoir_outlet[v] ? 0.0 :
-                    max(we_y[edge_indices.xd[idx]] - 0.5 * w, 0.0)
+                    reservoir_outlet[v] ? ZERO :
+                    max(we_y[edge_indices.xd[idx]] - w / 2, ZERO)
             end
-            we_x[idx] = reservoir_outlet[v] ? 0.0 : max(we_x[idx] - 0.5 * w, 0.0)
+            we_x[idx] = reservoir_outlet[v] ? ZERO : max(we_x[idx] - w / 2, ZERO)
         end
     end
     return nothing
@@ -782,7 +782,7 @@ function kh_layered_profile!(
         m = nlayers[i]
 
         if soilthickness[i] > zi[i]
-            transmissivity = 0.0
+            transmissivity = ZERO
             _sumlayers = @view sumlayers[i][2:end]
             n = max(n_unsatlayers[i], 1)
             transmissivity += (_sumlayers[n] - zi[i]) * kv_profile.kv[i][n]
@@ -819,7 +819,7 @@ function kh_layered_profile!(
         m = nlayers[i]
 
         if soilthickness[i] > zi[i]
-            transmissivity = 0.0
+            transmissivity = ZERO
             n = max(n_unsatlayers[i], 1)
             if zi[i] >= z_layered[i]
                 zt = soilthickness[i] - z_layered[i]
@@ -837,7 +837,7 @@ function kh_layered_profile!(
                 if n > nlayers_kv[i]
                     zt = soilthickness[i] - z_layered[i]
                     j = nlayers_kv[i]
-                    transmissivity += kv[i][j] / f[i] * (1.0 - exp(-f[i] * zt))
+                    transmissivity += kv[i][j] / f[i] * (ONE - exp(-f[i] * zt))
                     n = m
                 else
                     transmissivity += act_thickl[i][n] * kv[i][n]
@@ -889,7 +889,7 @@ function initialize_lateral_ssf_model!(
     (; soilthickness) = subsurface_flow_model.parameters
     (; slope, flow_width) = parameters
 
-    @. q_max = ((kh_0 * slope) / f) * (1.0 - exp(-f * soilthickness))
+    @. q_max = ((kh_0 * slope) / f) * (ONE - exp(-f * soilthickness))
     @. q = ((kh_0 * slope) / f) * (exp(-f * zi) - exp(-f * soilthickness)) * flow_width
     return nothing
 end
@@ -908,7 +908,7 @@ function initialize_lateral_ssf_model!(
     q_constant = @. kh_0 * exp(-f * z_exp) * slope * (soilthickness - z_exp)
     for i in eachindex(q)
         q_max[i] =
-            ((kh_0[i] * slope[i]) / f[i]) * (1.0 - exp(-f[i] * z_exp[i])) + q_constant[i]
+            ((kh_0[i] * slope[i]) / f[i]) * (ONE - exp(-f[i] * z_exp[i])) + q_constant[i]
         if zi[i] < z_exp[i]
             q[i] =
                 (
@@ -950,7 +950,7 @@ function initialize_lateral_ssf_model!(
     kh_layered_profile!(soil_model, subsurface_flow_model, kv_profile, dt)
     for i in eachindex(q)
         q[i] = kh[i] * (soilthickness[i] - zi[i]) * slope[i] * flow_width[i]
-        kh_max = 0.0
+        kh_max = ZERO
         for j in 1:nlayers[i]
             kh_max += kv_profile.kv[i][j] * act_thickl[i][j]
         end
@@ -984,7 +984,7 @@ function initialize_lateral_ssf_model!(
             else
                 zt = soil_model.parameters.soilthickness[i] - z_layered[i]
                 k = max(j - 1, 1)
-                kh_max += kv[i][k] / f[i] * (1.0 - exp(-f[i] * zt))
+                kh_max += kv[i][k] / f[i] * (ONE - exp(-f[i] * zt))
                 break
             end
         end
@@ -995,13 +995,13 @@ function initialize_lateral_ssf_model!(
 end
 
 """
-    bounded_divide(x, y; max = 1.0, default = 0.0)
+    bounded_divide(x, y; max = ONE, default = ZERO)
 
-Return the division of `x` by `y`, bounded by a maximum value `max`, when `y` > 0.0.
+Return the division of `x` by `y`, bounded by a maximum value `max`, when `y` > ZERO.
 Otherwise return a `default` value.
 """
-function bounded_divide(x::Real, y::Real; max::Real = 1.0, default::Real = 0.0)::Real
-    z = y > 0.0 ? min(x / y, max) : default
+function bounded_divide(x::Real, y::Real; max::Real = ONE, default::Real = ZERO)::Real
+    z = y > ZERO ? min(x / y, max) : default
     return z
 end
 
@@ -1019,8 +1019,8 @@ layer). For a rising water table a dynamic specific yield is computed.
 """
 function water_table_change(
     soil_model::SbmSoilModel,
-    net_flux::Float64,
-    specific_yield::Float64,
+    net_flux::PRECISION,
+    specific_yield::PRECISION,
     i::Int,
 )
     (; n_unsatlayers, ustorelayerthickness, ustorelayerdepth) = soil_model.variables
@@ -1029,15 +1029,15 @@ function water_table_change(
     # effective porosity (difference between saturated and residual water content)
     theta_e = theta_s[i] - theta_r[i]
 
-    if net_flux <= 0.0
+    if net_flux <= ZERO
         dh = net_flux / specific_yield
     else
-        dh = 0.0
+        dh = ZERO
         f_conv = 0.001 # convert units from [mm] to [m]
         for k in n_unsatlayers[i]:-1:1
             capacity = max(
                 f_conv * (ustorelayerthickness[i][k] * theta_e - ustorelayerdepth[i][k]),
-                0.0,
+                ZERO,
             )
             flux_layer = min(net_flux, capacity)
             if capacity <= net_flux
@@ -1048,10 +1048,10 @@ function water_table_change(
                 dh += flux_layer / sy
             end
             net_flux -= flux_layer
-            net_flux == 0.0 && break
+            iszero(net_flux) && break
         end
     end
-    exfilt = max(net_flux, 0.0)
+    exfilt = max(net_flux, ZERO)
     return dh, exfilt
 end
 

--- a/Wflow/src/vegetation/canopy.jl
+++ b/Wflow/src/vegetation/canopy.jl
@@ -4,21 +4,21 @@ abstract type AbstractInterceptionModel end
 @with_kw struct InterceptionVariables
     n::Int
     # Canopy potential evaporation [mm Δt⁻¹]
-    canopy_potevap::Vector{Float64} = fill(MISSING_VALUE, n)
+    canopy_potevap::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Interception loss by evaporation [mm Δt⁻¹]
-    interception_rate::Vector{Float64} = fill(MISSING_VALUE, n)
+    interception_rate::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Canopy storage [mm]
-    canopy_storage::Vector{Float64} = zeros(n)
+    canopy_storage::Vector{PRECISION} = zeros(n)
     # Stemflow [mm Δt⁻¹]
-    stemflow::Vector{Float64} = fill(MISSING_VALUE, n)
+    stemflow::Vector{PRECISION} = fill(MISSING_VALUE, n)
     # Throughfall [mm Δt⁻¹]
-    throughfall::Vector{Float64} = fill(MISSING_VALUE, n)
+    throughfall::Vector{PRECISION} = fill(MISSING_VALUE, n)
 end
 
 "Struct for storing Gash interception model parameters"
 @with_kw struct GashParameters
     # ratio [-] of wet canopy [mm Δt⁻¹] and the average precipitation intensity [mm Δt⁻¹] on a saturated canopy
-    e_r::Vector{Float64}
+    e_r::Vector{PRECISION}
     vegetation_parameter_set::VegetationParameters
 end
 
@@ -63,7 +63,7 @@ function update_interception_model!(
     if !isnothing(leaf_area_index)
         update_canopy_parameters!(interception_model.parameters.vegetation_parameter_set)
         threaded_foreach(1:n; basesize = 1000) do i
-            canopyfraction = 1.0 - canopygapfraction[i]
+            canopyfraction = ONE - canopygapfraction[i]
             ewet = canopyfraction * potential_evaporation[i] * kc[i]
             e_r[i] =
                 precipitation[i] > 0.0 ?
@@ -71,7 +71,7 @@ function update_interception_model!(
         end
     end
     threaded_foreach(1:n; basesize = 1000) do i
-        canopy_potevap[i] = kc[i] * potential_evaporation[i] * (1.0 - canopygapfraction[i])
+        canopy_potevap[i] = kc[i] * potential_evaporation[i] * (ONE - canopygapfraction[i])
         throughfall[i], interception_rate[i], stemflow[i], canopy_storage[i] =
             rainfall_interception_gash(
                 cmax[i],
@@ -113,7 +113,7 @@ function update_interception_model!(
     end
     n = length(precipitation)
     threaded_foreach(1:n; basesize = 1000) do i
-        canopy_potevap[i] = kc[i] * potential_evaporation[i] * (1.0 - canopygapfraction[i])
+        canopy_potevap[i] = kc[i] * potential_evaporation[i] * (ONE - canopygapfraction[i])
         throughfall[i], interception_rate[i], stemflow[i], canopy_storage[i] =
             rainfall_interception_modrut(
                 precipitation[i],

--- a/Wflow/src/vegetation/parameters.jl
+++ b/Wflow/src/vegetation/parameters.jl
@@ -1,21 +1,21 @@
 "Struct to store (shared) vegetation parameters"
 @with_kw struct VegetationParameters
     # Leaf area index [m² m⁻²]
-    leaf_area_index::Union{Vector{Float64}, Nothing}
+    leaf_area_index::Union{Vector{PRECISION}, Nothing}
     # Storage woody part of vegetation [mm]
-    storage_wood::Union{Vector{Float64}, Nothing}
+    storage_wood::Union{Vector{PRECISION}, Nothing}
     # Extinction coefficient [-] (to calculate canopy gap fraction)
-    kext::Union{Vector{Float64}, Nothing}
+    kext::Union{Vector{PRECISION}, Nothing}
     # Specific leaf storage [mm]
-    storage_specific_leaf::Union{Vector{Float64}, Nothing}
+    storage_specific_leaf::Union{Vector{PRECISION}, Nothing}
     # Canopy gap fraction [-]
-    canopygapfraction::Vector{Float64}
+    canopygapfraction::Vector{PRECISION}
     # Maximum canopy storage [mm]
-    cmax::Vector{Float64}
+    cmax::Vector{PRECISION}
     # Rooting depth [mm]
-    rootingdepth::Vector{Float64}
+    rootingdepth::Vector{PRECISION}
     # Crop coefficient Kc [-]
-    kc::Vector{Float64}
+    kc::Vector{PRECISION}
 end
 
 "Initialize (shared) vegetation parameters"

--- a/Wflow/src/vegetation/rainfall_interception.jl
+++ b/Wflow/src/vegetation/rainfall_interception.jl
@@ -20,15 +20,15 @@ function rainfall_interception_gash(
     if cmax > 0.0
         if canopy_gap_fraction < inv(1.1)
             pt = 0.1 * canopy_gap_fraction
-            pfrac = 1.0 - 1.1 * canopy_gap_fraction # > 0
+            pfrac = ONE - 1.1 * canopy_gap_fraction # > 0
 
             if e_r > pfrac
                 p_sat = 0.0
             else
-                p_sat = -cmax / e_r * log(1.0 - e_r / pfrac)
+                p_sat = -cmax / e_r * log(ONE - e_r / pfrac)
             end
         else
-            pt = 1.0 - canopy_gap_fraction
+            pt = ONE - canopy_gap_fraction
             pfrac = 0
             p_sat = 0
         end
@@ -78,9 +78,9 @@ function rainfall_interception_modrut(
     # TODO: improve computation of stemflow partitioning coefficient pt (0.1 * canopy_gap_fraction)
     if canopy_gap_fraction < inv(1.1)
         pt = 0.1 * canopy_gap_fraction
-        precip_canopy = (1.0 - canopy_gap_fraction - pt) * precipitation
+        precip_canopy = (ONE - canopy_gap_fraction - pt) * precipitation
     else
-        pt = 1.0 - canopy_gap_fraction
+        pt = ONE - canopy_gap_fraction
         precip_canopy = 0.0
     end
 

--- a/docs/developments/model_struct.qmd
+++ b/docs/developments/model_struct.qmd
@@ -7,10 +7,10 @@ such as the domain and shared parameters, routing concepts, land model, clock, m
 configuration and input and output.
 
 ```julia
-struct Model{R <: Routing, L <: AbstractLandModel, T <: AbstractModelType} <:
+struct Model{R <: Routing, L <: AbstractLandModel, T <: AbstractModelType, F <: AbstractFloat} <:
        AbstractModel{T}
     config::Config                  # all configuration options
-    domain::Domain                  # domain connectivity (network) and shared parameters
+    domain::Domain{F}               # domain connectivity (network) and shared parameters
     routing::R                      # routing model (horizontal fluxes), moves along network
     land::L                         # land model simulating vertical fluxes, independent of each other
     clock::Clock                    # to keep track of simulation time


### PR DESCRIPTION
## Issue addressed
Fixes https://github.com/Deltares/Wflow.jl/issues/646

## Explanation
The precision is read from an environment variable:

```julia
ENV["WFLOW_PRECISION"] = "SINGLE" # defaults to DOUBLE
using Wflow
```

## Checklist
- [ ] Updated tests or added new tests
- [ ] Branch is up to date with `master`
- [ ] Tests & pre-commit hooks pass
- [ ] Updated documentation if needed
- [ ] Updated changelog.qmd if needed
- [ ] A review by Copilot was done to ensure the requirements in `AGENTS.md` are satisfied

## Additional Notes (optional)
Add any additional notes or information that may be helpful.
