### PR TITLE
Don't update SBOM in Julia manifest update

### DIFF
--- a/.github/workflows/julia-auto-update.yml
+++ b/.github/workflows/julia-auto-update.yml
@@ -20,7 +20,6 @@ jobs:
           pixi run install-julia
           pixi run update-registry-julia
           pixi run update-manifest-julia
-          pixi run generate-sbom
         env:
           JULIA_PKG_PRECOMPILE_AUTO: "0"
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/.github/workflows/julia-auto-update.yml
+++ b/.github/workflows/julia-auto-update.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: "latest"
-      - name: Update Julia manifest and SBOM file
+      - name: Update Julia manifest
         run: |
           pixi run install-julia
           pixi run update-registry-julia

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ platforms = ["win-64", "linux-64"]
 # Julia
 install-julia = "juliaup add 1.12.6 && juliaup override set 1.12.6"
 # Prek
-install-prek = "prek install"
+install-prek = "prek install --overwrite"
 update-registry-julia = "julia --eval='using Pkg; Registry.update()'"
 update-manifest-julia = "julia --project utils/update-manifest.jl"
 initialize-julia = { depends-on = [
@@ -82,6 +82,3 @@ jupyter = ">=1.1.1,<2"
 quarto = ">=1.8.26,<2"
 prek = "*"
 typos = "*"
-
-[system-requirements]
-linux = "3.10.0"


### PR DESCRIPTION
Don't run `pixi run generate-sbom`.
The `update-sbom.yml` workflow is triggered automatically when Manifest.toml changes on master. That will keep the SBOM up to date, whether the Manifest.toml changes due to the automated Julia update or a manual merge to main.

Also removes the deprecated system-requirements section, I don't think we still need this.

```
 WARN Encountered 1 warning while parsing the manifest:
  ⚠ the `[system-requirements]` table is deprecated in favor of virtual packages on `platforms`
    ╭─[C:\ProgramData\DevDrive\.julia\dev\Wflow\pixi.toml:86:1]
 85 │
 86 │ ╭─▶ [system-requirements]
 87 │ ├─▶ linux = "3.10.0"
    · ╰──── declare these on the `platforms` entries instead
    ╰────
  help: e.g. platforms = [{ platform = "linux-64", cuda = "12" }]
  ```

Also adds `--overwrite` to `prek install`. Otherwise it will not remove the old hooks, which no longer work. I got this:

```
✨ Pixi task (install-prek): prek install
Hook already exists at `.git\hooks\pre-commit`, moved it to `.git\hooks\pre-commit.legacy` Migration mode: prek will also run legacy hook `.git\hooks\pre-commit.legacy`. Use `--overwrite` to remove legacy hooks. prek installed at `.git\hooks\pre-commit`
```
