### PR TITLE
Fix unit conversion after reduction

### DIFF
--- a/Wflow/src/io.jl
+++ b/Wflow/src/io.jl
@@ -840,12 +840,12 @@ function write_netcdf_timestep(model::AbstractModel, writer::NCWriter{<:NCDatase
         elseif elemtype <: SVector
             # check if an extra dimension and index is specified in the TOML file
             if haskey(output_dataset, extra_dim.name)
-                v = from_SI(reducer_(getindex.(A, layer)), unit; dt_val)
+                v = from_SI(reducer_(getindex.(vector, layer)), unit; dt_val)
                 output_dataset[name][:, time_index] .= v
             else
-                nlayer = length(first(A))
+                nlayer = length(first(vector))
                 for i in 1:nlayer
-                    v = from_SI(reducer_(getindex.(A, layer)), unit; dt_val)
+                    v = from_SI(reducer_(getindex.(vector, layer)), unit; dt_val)
                     output_dataset[name][:, i, time_index] .= v
                 end
             end
@@ -1028,7 +1028,7 @@ function reducer(col, rev_inds, indices, x_nc, y_nc, config, dataset)::Function
             end
             push!(inds[v], ind)
         end
-        return A -> (f(A[inds[id]]) for id in ids)
+        return A -> [f(A[inds[id]]) for id in ids]
     elseif !isnothing(reducer)
         # reduce over all active cells
         # needs to be behind the map if statement, because it also can use a reducer

--- a/Wflow/src/units.jl
+++ b/Wflow/src/units.jl
@@ -309,6 +309,12 @@ function from_SI(x::AbstractFloat, unit::Unit; kwargs...)
     end
 end
 
+function from_SI(x::AbstractArray, unit::Unit; kwargs...)
+    out = copy(x)
+    from_SI!(out, unit; kwargs...)
+    return out
+end
+
 # Fallback method for non-Floats, e.g. nothing, missing, Bool, Int
 from_SI(x, unit::Unit; kwargs...) = x
 


### PR DESCRIPTION
## Issue addressed
Fixes https://github.com/Deltares/Wflow.jl/issues/974

## Explanation
Some reducers created `Generator` objects instead of a `Float64` or `Vector{Float64}`, which then dispatched to the fallback method of `from_SI` as @JoostBuitink mentioned. 

@JoostBuitink regarding the testing you mentioned: can you make an issue with an overview of what should be tested and ideally also which test models can be used for it? See also https://github.com/Deltares/Wflow.jl/issues/864.
