### PR TITLE
Replace LibGit2 metadata calls with Git CLI

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "482acc7db8c93f28834012aa31510c18af1ce6ea"
+project_hash = "e2befe19ff5c1295bd2940acc6918c0e8108ca9a"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]

--- a/build/create_binaries/Project.toml
+++ b/build/create_binaries/Project.toml
@@ -1,5 +1,4 @@
 [deps]
-LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
 LicenseCheck = "726dbf0d-6eb6-41af-b36c-cd770e0f00cc"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -40,22 +40,17 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file
         manifest = TOML.parsefile(normpath(git_repo, "Manifest.toml"))
         julia_version = manifest["julia_version"]
         version = TOML.parsefile(normpath(git_repo, "Wflow/Project.toml"))["version"]
-        repo = GitRepo(git_repo)
-        branch = LibGit2.head(repo)
-        commit = LibGit2.peel(LibGit2.GitCommit, branch)
-        short_name = LibGit2.shortname(branch)
-        short_commit = string(LibGit2.GitShortHash(LibGit2.GitHash(commit), 10))
+        short_name =
+            chomp(read(Cmd(`git rev-parse --abbrev-ref HEAD`; dir = git_repo), String))
+        short_commit =
+            chomp(read(Cmd(`git rev-parse --short=10 HEAD`; dir = git_repo), String))
 
         # get the release from the current tag, like `git describe --tags`
         # if it is a commit after a tag, it will be <tag>-g<short-commit>
-        options =
-            LibGit2.DescribeOptions(; describe_strategy = LibGit2.Consts.DESCRIBE_TAGS)
-        result = LibGit2.GitDescribeResult(repo; options)
-        suffix = "-dirty"
-        foptions = LibGit2.DescribeFormatOptions(;
-            dirty_suffix = Base.unsafe_convert(Cstring, suffix),
+        described_tag = chomp(
+            read(Cmd(`git describe --tags --dirty --abbrev=7`; dir = git_repo), String),
         )
-        GC.@preserve suffix tag = LibGit2.format(result; options = foptions)[2:end]  # skip v prefix
+        tag = replace(described_tag, r"^v" => "")
 
         url = "https://github.com/Deltares/Wflow.jl/tree"
         version_info = """

--- a/build/create_binaries/create_app.jl
+++ b/build/create_binaries/create_app.jl
@@ -1,6 +1,5 @@
 using PackageCompiler
 using TOML
-using LibGit2
 using Pkg
 using LicenseCheck
 


### PR DESCRIPTION
Use git rev-parse and git describe when adding build metadata.

This avoid issues with packed refs in TeamCity checkouts. We now require git during build, but I don't think that is an issue.

Fixes https://github.com/Deltares/Wflow.jl/issues/1003
