### PR TITLE
ZMQ server: Encode NaN, Inf, -Inf as null in JSON

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.12.6"
 manifest_format = "2.0"
-project_hash = "e2befe19ff5c1295bd2940acc6918c0e8108ca9a"
+project_hash = "da5c19b508f2a3db9db131c8059fd312a181cb81"
 
 [[deps.AbstractFFTs]]
 deps = ["LinearAlgebra"]
@@ -1012,21 +1012,15 @@ uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.8.0"
 
 [[deps.JSON]]
-deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "31e996f0a15c7b280ba9f76636b3ff9e2ae58c9a"
+deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
+git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.4"
+version = "1.6.1"
 
-[[deps.JSON3]]
-deps = ["Dates", "Mmap", "Parsers", "PrecompileTools", "StructTypes", "UUIDs"]
-git-tree-sha1 = "411eccfe8aba0814ffa0fdf4860913ed09c34975"
-uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.14.3"
+    [deps.JSON.extensions]
+    JSONArrowExt = ["ArrowTypes"]
 
-    [deps.JSON3.extensions]
-    JSON3ArrowExt = ["ArrowTypes"]
-
-    [deps.JSON3.weakdeps]
+    [deps.JSON.weakdeps]
     ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 
 [[deps.JSONSchema]]
@@ -1034,10 +1028,12 @@ deps = ["Downloads", "JSON", "URIs"]
 git-tree-sha1 = "d13f79c4242969874da7d00bda17d59bc7699aa7"
 uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
 version = "1.5.0"
-weakdeps = ["JSON3"]
 
     [deps.JSONSchema.extensions]
     JSONSchemaJSON3Ext = "JSON3"
+
+    [deps.JSONSchema.weakdeps]
+    JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 
 [[deps.JpegTurbo]]
 deps = ["CEnum", "FileIO", "ImageCore", "JpegTurbo_jll", "TOML"]
@@ -1568,9 +1564,9 @@ weakdeps = ["REPL"]
 
 [[deps.PkgToSoftwareBOM]]
 deps = ["Artifacts", "Downloads", "LicenseCheck", "Logging", "Pkg", "Reexport", "RegistryInstances", "SPDX", "UUIDs"]
-git-tree-sha1 = "771fac9b511e2c626cf31bb27b3b711c225f3e7a"
+git-tree-sha1 = "30a1cf0b8fac0400f7f9790b1ad8ad89db325b84"
 uuid = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
-version = "0.1.18"
+version = "0.1.19"
 
 [[deps.PkgVersion]]
 deps = ["Pkg"]
@@ -1803,10 +1799,10 @@ uuid = "94e857df-77ce-4151-89e5-788b33177be4"
 version = "0.1.0"
 
 [[deps.SPDX]]
-deps = ["DataStructures", "Dates", "JSON", "Logging", "SHA", "TimeZones", "UUIDs"]
-git-tree-sha1 = "b8a683ba47344db3bf9d91c848da375c1f280c3b"
+deps = ["Dates", "JSON", "Logging", "SHA", "TimeZones", "UUIDs"]
+git-tree-sha1 = "03332121e01c5191a1c12d9fbda2284a102a5155"
 uuid = "47358f48-d834-4249-91f5-f6185eb3d540"
-version = "0.4.2"
+version = "0.5.0"
 
 [[deps.SciMLPublic]]
 git-tree-sha1 = "912a1a941afb2a232183a485d86a437a25f88520"
@@ -2029,11 +2025,21 @@ git-tree-sha1 = "c25735d6db95bb307b6b69ee66dc808be114924c"
 uuid = "4093c41a-2008-41fd-82b8-e3f9d02b504f"
 version = "1.6.0"
 
-[[deps.StructTypes]]
+[[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "159331b30e94d7b11379037feeb9b690950cace8"
-uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.11.0"
+git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
+version = "2.8.2"
+
+    [deps.StructUtils.extensions]
+    StructUtilsMeasurementsExt = ["Measurements"]
+    StructUtilsStaticArraysCoreExt = ["StaticArraysCore"]
+    StructUtilsTablesExt = ["Tables"]
+
+    [deps.StructUtils.weakdeps]
+    Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+    StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+    Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [[deps.StyledStrings]]
 uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
@@ -2202,7 +2208,7 @@ uuid = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
 version = "1.1.0-dev"
 
 [[deps.WflowServer]]
-deps = ["JSON3", "Logging", "StructTypes", "Wflow", "ZMQ"]
+deps = ["JSON", "Logging", "Wflow", "ZMQ"]
 path = "server"
 uuid = "6f3aa2dc-f527-41f4-85fc-b3cbabe74cf6"
 version = "0.1.0"

--- a/server/Project.toml
+++ b/server/Project.toml
@@ -7,16 +7,14 @@ authors = ["Deltares and contributors"]
 projects = ["test"]
 
 [deps]
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
-StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"
 ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 
 [compat]
-JSON3 = "1.14"
+JSON = "1"
 Logging = "1"
-StructTypes = "1.10"
 Wflow = "1"
 ZMQ = "1.2"
 julia = "1.10"

--- a/server/src/WflowServer.jl
+++ b/server/src/WflowServer.jl
@@ -1,7 +1,6 @@
 module WflowServer
 using ZMQ: ZMQ
-using JSON3: JSON3
-using StructTypes: StructTypes
+using JSON: JSON
 using Wflow: Wflow
 
 include("bmi_service.jl")

--- a/server/src/server.jl
+++ b/server/src/server.jl
@@ -49,18 +49,29 @@ function shutdown(s::ZMQ.Socket, ctx::ZMQ.Context)
     return ZMQ.close(ctx)
 end
 
+"""
+    serialize_response(ret)
+
+Serialize the return value `ret` of a Wflow BMI function to a JSON string. JSON has no
+representation for the non-finite floating point values `NaN`, `Inf` and `-Inf`, so these
+are encoded as `null`.
+"""
+function serialize_response(ret)
+    return JSON.json(ret; allownan = true, nan = "null", inf = "null", ninf = "null")
+end
+
 "Error response ZMQ server"
 function response(err::AbstractString, s::ZMQ.Socket)
     @info "Send error response"
     resp = Dict{String, String}("status" => "ERROR", "error" => err)
-    return ZMQ.send(s, JSON3.write(resp))
+    return ZMQ.send(s, JSON.json(resp))
 end
 
 "Status response ZMQ server"
 function response(s::ZMQ.Socket)
     @info "Send status response"
     resp = Dict{String, String}("status" => "OK")
-    return ZMQ.send(s, JSON3.write(resp))
+    return ZMQ.send(s, JSON.json(resp))
 end
 
 "Validate JSON request against mapped Struct"
@@ -89,7 +100,7 @@ function wflow_bmi(s::ZMQ.Socket, handler::ModelHandler, f)
             response(s)
         else
             @info "Send response including output from Wflow function `$(f.fn)`"
-            ZMQ.send(s, JSON3.write(ret; allow_inf = true))
+            ZMQ.send(s, serialize_response(ret))
         end
     catch e
         @error "Wflow function `$(f.fn)` failed" exception = (e, catch_backtrace())
@@ -151,13 +162,13 @@ function start(port::Int)
         while true
             # Wait for next request from client
             req = ZMQ.recv(socket)
-            json = JSON3.read(req; allow_inf = true)
+            json = JSON.parse(req; allownan = true)
             @info "Received request to run function `$(json.fn)`..."
 
             if haskey(MAP_STRUCTS, json.fn)
                 v = valid_request(json)
                 if isnothing(v)
-                    f = StructTypes.constructfrom(MAP_STRUCTS[json.fn], json)
+                    f = JSON.parse(req, MAP_STRUCTS[json.fn]; allownan = true)
                     wflow_bmi(socket, handler, f)
                 else
                     err = (

--- a/server/test/Project.toml
+++ b/server/test/Project.toml
@@ -1,10 +1,9 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
-JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
 Wflow = "d48b7d99-76e7-47ae-b1d5-ff0c1cf9a818"

--- a/server/test/client.jl
+++ b/server/test/client.jl
@@ -1,5 +1,5 @@
 @testitem "Client server Wflow ZMQ Server" begin
-    import ZMQ, JSON3, StructTypes, Wflow
+    import ZMQ, JSON, Wflow
     using Statistics: mean
     using Logging: with_logger, NullLogger
     using Wflow: to_SI, MM
@@ -15,8 +15,8 @@
     ZMQ.connect(socket, "tcp://localhost:5555")
 
     function request(message)
-        ZMQ.send(socket, JSON3.write(message))
-        ret_value = JSON3.read(ZMQ.recv(socket), Dict; allow_inf = true)
+        ZMQ.send(socket, JSON.json(message))
+        ret_value = JSON.parse(ZMQ.recv(socket); dicttype = Dict{String, Any})
         return ret_value
     end
 
@@ -33,13 +33,21 @@
         @test request((fn = "get_time_units",)) == Dict("time_units" => "s")
     end
 
-    @testset "Reading and writing NaN values allowed" begin
+    @testset "non-finite responses encoded as null" begin
+        # the server encoder maps NaN, Inf and -Inf to null, since JSON cannot represent them.
+        encoded = WflowServer.serialize_response(Dict("value" => [NaN, Inf, -Inf, 1.0]))
+        @test !occursin("NaN", encoded)
+        @test !occursin("Infinity", encoded)
+        @test occursin("[null,null,null,1.0]", encoded)
+        @test JSON.parse(encoded)["value"] == [nothing, nothing, nothing, 1.0]
+
+        # end-to-end check that a model response containing NaN arrives as null
         msg = (
             fn = "get_value",
             name = "soil_layer_1_water__volume_fraction",
             dest = fill(0.0, 50063),
         )
-        @test isnan(mean(request(msg)["value"]))
+        @test any(isnothing, request(msg)["value"])
     end
 
     @testset "update functions" begin


### PR DESCRIPTION
@erikpelgrim tried to get data of `atmosphere_water__precipitation_volume_flux` via the ZMQ API, and ran into this error:

```
com.fasterxml.jackson.core.JsonParseException: Non-standard token 'NaN': enable JsonParser.Feature.ALLOW_NON_NUMERIC_NUMBERS to allow
at [Source: (String)"{"value":[NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,NaN,Na"[truncated 23139 chars]; line: 1, column: 14]
```

Since NaN is not standard JSON, we should probably convert NaN to null. Originally it threw an error, but after https://github.com/Deltares/Wflow.jl/issues/392 it just put NaN in the JSON, which some parsers can handle, but others not.

By using `JSON.json(ret; allownan = true, nan = "null", inf = "null", ninf = "null")` we don't throw an error, and serialize these special floats as null.

This PR directly switches from JSON3.jl to JSON.jl v1, following https://juliaio.github.io/JSON.jl/stable/migrate/#Migration-guide-for-JSON3.jl. JSON v1 supesedes JSON3.

This updates these packages:

```
  [682c06a0] ↑ JSON v0.21.4 ⇒ v1.6.1
  [6254a0f9] ↑ PkgToSoftwareBOM v0.1.18 ⇒ v0.1.19
  [47358f48] ↑ SPDX v0.4.2 ⇒ v0.5.0
  [ec057cc2] + StructUtils v2.8.2
```