### PR TITLE
Rename default branch from master to main

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/documentation.yaml
@@ -10,7 +10,7 @@ body:
       options:
         - label: >
             I have checked that the issue still exists on the latest versions of the docs
-            on `master` [here](https://github.com/Deltares/Wflow.jl)
+            on `main` [here](https://github.com/Deltares/Wflow.jl)
           required: true
   - type: dropdown
     id: kind

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@ Explain how you addressed the bug/feature request, what choices you made and why
 
 ## Checklist
 - [ ] Updated tests or added new tests
-- [ ] Branch is up to date with `master`
+- [ ] Branch is up to date with `main`
 - [ ] Tests & prek hooks pass
 - [ ] Updated documentation if needed
 - [ ] Updated changelog.qmd if needed

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - v1
     tags: '*'
 

--- a/.github/workflows/CIWflowServer.yml
+++ b/.github/workflows/CIWflowServer.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
       - v1
     tags: '*'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Quarto documentation
 on:
   push:
-    branches: [master]
+    branches: [main]
     tags: [v*]
   pull_request:
 
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Quarto Project as dev
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/parameter_metadata_json_gen.yml
+++ b/.github/workflows/parameter_metadata_json_gen.yml
@@ -2,7 +2,7 @@ name: Parameter & variable metadata JSON generation
 on:
   workflow_dispatch:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths: [ "Wflow/src/standard_name/**" ]
   pull_request:
     paths: [ "Wflow/src/standard_name/**" ]

--- a/.github/workflows/trivy_security.yml
+++ b/.github/workflows/trivy_security.yml
@@ -2,7 +2,7 @@ name: Trivy Security Scan
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
   workflow_dispatch:
 jobs:

--- a/.github/workflows/update-sbom.yml
+++ b/.github/workflows/update-sbom.yml
@@ -2,7 +2,7 @@ name: Update SBOM
 on:
   push:
       branches:
-        - 'master'
+        - 'main'
       paths:
         - 'Manifest.toml'
   # on demand

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Wflow
 
 [![Build Status](https://github.com/Deltares/Wflow.jl/workflows/CI/badge.svg)](https://github.com/Deltares/Wflow.jl/actions)
-[![Coverage](https://codecov.io/gh/Deltares/Wflow.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/Deltares/Wflow.jl)
+[![Coverage](https://codecov.io/gh/Deltares/Wflow.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Deltares/Wflow.jl)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://deltares.github.io/Wflow.jl/dev)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://deltares.github.io/Wflow.jl/stable)
 [![DOI](https://zenodo.org/badge/246787232.svg)](https://zenodo.org/badge/latestdoi/246787232)

--- a/docs/developments/guide.qmd
+++ b/docs/developments/guide.qmd
@@ -63,7 +63,7 @@ pixi run parameter_metadata_json_gen
 ### CI guardrail
 
 A GitHub Actions workflow (`parameter_metadata_json_gen.yml`) runs automatically on pushes to
-`master` and on PRs that modify files under `Wflow/src/standard_name/`. It re-generates the JSON
+`main` and on PRs that modify files under `Wflow/src/standard_name/`. It re-generates the JSON
 files and runs `git diff --exit-code` to ensure the committed JSON stays in sync with the source
 standard name maps. If you update any standard name metadata, re-run the export and commit the
 updated JSON files.

--- a/docs/getting_started/download_example_models.qmd
+++ b/docs/getting_started/download_example_models.qmd
@@ -8,9 +8,9 @@ listed in the Table below:
 
 |  model  | TOML configuration file |
 |:--------------- | ------------------|
-| wflow\_sbm + kinematic wave | [sbm_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_config.toml) |
-| wflow\_sbm + groundwater flow | [sbm\_gwf\_piave\_demand\_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_gwf_piave_demand_config.toml) |
-| wflow_sediment | [sediment_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sediment_config.toml) |
+| wflow\_sbm + kinematic wave | [sbm_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sbm_config.toml) |
+| wflow\_sbm + groundwater flow | [sbm\_gwf\_piave\_demand\_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sbm_gwf_piave_demand_config.toml) |
+| wflow_sediment | [sediment_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sediment_config.toml) |
 
 The associated Model files (input static, forcing and state files) can easily be downloaded and
 for this we share the following Julia code (per Model) that downloads the required files to
@@ -20,7 +20,7 @@ and [Command Line Interface](./running_wflow.qmd#using-the-command-line-interfac
 ## wflow\_sbm + kinematic wave
 ```julia
 # urls to TOML and netCDF of the Moselle example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sbm_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-moselle.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-moselle.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-moselle.nc"
@@ -41,7 +41,7 @@ download(toml_url, toml_path)
 ## wflow\_sbm + groundwater flow
 ```julia
 # urls to TOML and netCDF of the Piave example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_gwf_piave_demand_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sbm_gwf_piave_demand_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-piave.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-piave.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-piave-gwf.nc"
@@ -62,7 +62,7 @@ download(toml_url, toml_path)
 ## wflow\_sediment
 ```julia
 # urls to TOML and netCDF of the Moselle example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sediment_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/main/Wflow/test/sediment_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-moselle-sed.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-moselle-sed.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-moselle-sed.nc"

--- a/docs/getting_started/install.qmd
+++ b/docs/getting_started/install.qmd
@@ -48,13 +48,13 @@ automatically resolved and installed from the Pkg General registry.
 
 ### Install from GitHub
 
-You can also install wflow from the `master` branch on the repository as follows:
+You can also install wflow from the `main` branch on the repository as follows:
 
 ```bash
-pkg> add Wflow:Wflow#master
+pkg> add Wflow:Wflow#main
 ```
 
-This command tracks the `master` branch and updates to the latest commit on that branch when
+This command tracks the `main` branch and updates to the latest commit on that branch when
 you run `update`, or simply `up`, in the Pkg REPL. The `add` installs wflow in your home
 directory under `.julia/packages/Wflow`. Note that packages installed under `packages` by `add`
 should not be changed in the directory, as the change could disrupt Pkg's automatic dependency

--- a/docs/home/publications.qmd
+++ b/docs/home/publications.qmd
@@ -21,7 +21,7 @@ van Verseveld, Willem, Visser, Martijn, Buitink, Joost, Boisgontier, Hélène, B
 Laurène, Weerts, Albrecht, Bootsma, Huite,  Baptista, Carlos Fernando, de Koning, Bart,
 Hartgring, Sebastian, Shin, Peter, Pronk, Maarten, Dalmijn, Brendan, Eilander, Dirk, Hofer,
 Julian, Hegnauer, Mark, Mendoza, Raul, Nelemans, Peter, & Meshgi, Ali, (YEAR).
-Deltares/Wflow.jl: unstable-master. <https://github.com/Deltares/Wflow.jl>, obtained:
+Deltares/Wflow.jl: unstable-main. <https://github.com/Deltares/Wflow.jl>, obtained:
 DATE\_OF\_DOWNLOAD.
 
 ## Publications using wflow

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -10,7 +10,7 @@ format:
 ---
 
 [![Build Status](https://github.com/Deltares/Wflow.jl/workflows/CI/badge.svg)](https://github.com/Deltares/Wflow.jl/actions)
-[![Coverage](https://codecov.io/gh/Deltares/Wflow.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/Deltares/Wflow.jl)
+[![Coverage](https://codecov.io/gh/Deltares/Wflow.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/Deltares/Wflow.jl)
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://deltares.github.io/Wflow.jl/dev)
 [![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://deltares.github.io/Wflow.jl/stable)
 [![DOI](https://zenodo.org/badge/246787232.svg)](https://zenodo.org/badge/latestdoi/246787232)
@@ -38,7 +38,7 @@ scale. With the intention being to encourage greater scientific collaboration. F
    * Contribution to the wflow code development is encouraged.
 
 From 2021 the [wflow code](https://github.com/Deltares/Wflow.jl) is distributed under the [MIT
-License](https://github.com/Deltares/Wflow.jl/blob/master/LICENSE). Wflow is also available as
+License](https://github.com/Deltares/Wflow.jl/blob/main/LICENSE). Wflow is also available as
 a [compiled executable](https://download.deltares.nl/en/download/wflow/) under the Deltares
 terms and conditions. The wflow computational engine is built in the
 [Julia](https://julialang.org/) language, a high-performance computing language. Wflow does not

--- a/docs/user_guide/zmq_server.qmd
+++ b/docs/user_guide/zmq_server.qmd
@@ -5,4 +5,4 @@ title: Run wflow as a ZMQ Server
 It is possible to run wflow as a ZMQ Server, for example for the coupling to the
 [OpenDA](https://openda.org/) software for data-assimilation. The code for the wflow ZMQ Server
 is not part of the Wflow.jl package, and is located
-[here](https://github.com/Deltares/Wflow.jl/tree/master/server).
+[here](https://github.com/Deltares/Wflow.jl/tree/main/server).


### PR DESCRIPTION
Some years ago the default branch name for new GitHub repos changed from master to main. Most repos related to Wflow have main, like: hydromt, hydromt_wflow, Ribasim. It trips me up sometimes that Wflow is different. Hence I propose to change the default branch name. This PR changes all references in the repo from master to main, which would be the first step.

Next up we can use GitHub to rename the branch, like this:

<img width="461" height="606" alt="image" src="https://github.com/user-attachments/assets/8fc9863c-caf3-4035-a4d3-8cc837133a8d" />

Here is the code you can run locally to update your clone, after this is done:

```sh
git branch -m master main
git fetch origin
git branch -u origin/main main
git remote set-head origin -a
```

If you want your git to start new repos with main, you can run this:
```sh
git config --global init.defaultBranch main
```

We did this for Ribasim as well, and old links redirect to main, the rename was quite smooth: https://github.com/Deltares/Ribasim/tree/master

After renaming I will also update TeamCity.
