### PR TITLE
build: Collect only Wflow dependency licenses

### DIFF
--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -9,6 +9,34 @@ Add the following metadata files to the newly created build:
 - dep_licenses/
 """
 
+function collect_dependency_licenses(project_dir, license_dir)
+    ctx = PackageCompiler.create_pkg_context(project_dir)
+    pending_uuids = collect(values(ctx.env.project.deps))
+    visited_uuids = Set{eltype(pending_uuids)}()
+
+    while !isempty(pending_uuids)
+        package_uuid = pop!(pending_uuids)
+        package_uuid in visited_uuids && continue
+        push!(visited_uuids, package_uuid)
+
+        pkg_entry = ctx.env.manifest.deps[package_uuid]
+        append!(pending_uuids, values(pkg_entry.deps))
+
+        if isnothing(pkg_entry.tree_hash)
+            # Stdlib packages do not have a tree hash.
+            continue
+        end
+
+        install_path =
+            Pkg.Operations.find_installed(pkg_entry.name, package_uuid, pkg_entry.tree_hash)
+        license = LicenseCheck.find_license(install_path)
+        if !isnothing(license)
+            license_file_path = joinpath(install_path, license.license_filename)
+            cp(license_file_path, joinpath(license_dir, pkg_entry.name); force = true)
+        end
+    end
+end
+
 function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file)
     # save some environment variables in a Build.toml file for debugging purposes
     vars = ["BUILD_NUMBER", "BUILD_VCS_NUMBER"]
@@ -71,24 +99,8 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file
 
     cp(sbom_file, normpath(output_dir, "Wflow.spdx.json"); force = true)
 
-    # collect licences of all dependencies
-    ctx = PackageCompiler.create_pkg_context(project_dir)
+    # collect licences of Wflow dependencies
     license_dir = joinpath(output_dir, "dep_licenses")
     mkpath(license_dir)
-
-    for (uuid, pkg_entry) in ctx.env.manifest.deps
-        if isnothing(pkg_entry.tree_hash)
-            # seems as though stdlib packages don't have a tree_sha. as there doesn't seem to be
-            # a different way of detecting those, I'm going to assume that is characteristic
-            continue
-        end
-        install_path =
-            Pkg.Operations.find_installed(pkg_entry.name, uuid, pkg_entry.tree_hash)
-
-        license = LicenseCheck.find_license(install_path)
-        if !isnothing(license)
-            license_file_path = joinpath(install_path, license.license_filename)
-            cp(license_file_path, joinpath(license_dir, pkg_entry.name); force = true)
-        end
-    end
+    collect_dependency_licenses(normpath(git_repo, "Wflow"), license_dir)
 end


### PR DESCRIPTION
## Summary

- collect dependency licenses by traversing the dependency graph rooted at the `Wflow` subproject
- exclude packages that belong only to other projects in the shared workspace
- preserve traversal through stdlibs while skipping license lookup for packages without a tree hash

## Why

`add_metadata.jl` previously iterated over every entry in the workspace-wide manifest. The binary build only instantiates the dependencies needed by the builder and Wflow CLI, so workspace-only packages are not guaranteed to exist in the build user's Julia depot.

After JSON was introduced elsewhere in the workspace, metadata generation attempted to scan its computed installation path even though that package had not been installed, causing the otherwise completed PackageCompiler build to fail with:

```text
ERROR: LoadError: IOError: readdir("C:\\Users\\svc-teamcity-ansible\\.julia\\packages\\JSON\\gMdcG"): no such file or directory (ENOENT)
...
[8] find_licenses
    @ LicenseCheck ...\\src\\find_licenses.jl:114
[11] add_metadata(...)
    @ Main ...\\build\\create_binaries\\add_metadata.jl:88
```

The binary metadata is intended to include licenses only for Wflow's dependency closure, not for the full workspace. Restricting collection to that closure fixes the binary build and avoids accessing uninstalled workspace-only packages.

## Validation

- loaded Wflow successfully with `pixi run julia --project=Wflow -e 'using Wflow'`
- ran the license collector against the Wflow project and collected 86 licenses
- asserted that `NCDatasets` is included and workspace-only `JSON` and `PackageCompiler` are excluded
- pre-commit formatting and hygiene hooks passed