### PR TITLE
build: Use recursion instead of explicit stack in license collection

### DIFF
--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -9,8 +9,17 @@ Add the following metadata files to the newly created build:
 - dep_licenses/
 """
 
-function collect_dependency_license(ctx, license_dir, visited_uuids, package_uuid)
-    package_uuid in visited_uuids && return
+"""
+Recursively copy the license of `package_uuid` and all of its transitive dependencies (as
+found in `ctx`'s manifest) into `license_dir`, skipping uuids already in `visited_uuids`.
+"""
+function collect_dependency_license(
+    ctx::Pkg.Types.Context,
+    license_dir::AbstractString,
+    visited_uuids::Set{Base.UUID},
+    package_uuid::Base.UUID,
+)::Nothing
+    package_uuid in visited_uuids && return nothing
     push!(visited_uuids, package_uuid)
 
     pkg_entry = ctx.env.manifest.deps[package_uuid]
@@ -20,7 +29,7 @@ function collect_dependency_license(ctx, license_dir, visited_uuids, package_uui
 
     if isnothing(pkg_entry.tree_hash)
         # Stdlib packages do not have a tree hash.
-        return
+        return nothing
     end
 
     install_path =
@@ -30,14 +39,23 @@ function collect_dependency_license(ctx, license_dir, visited_uuids, package_uui
         license_file_path = joinpath(install_path, license.license_filename)
         cp(license_file_path, joinpath(license_dir, pkg_entry.name); force = true)
     end
+    return nothing
 end
 
-function collect_dependency_licenses(project_dir, license_dir)
+"""
+Collect the licenses of all (transitive) dependencies of the project at `project_dir`,
+copying each into `license_dir`.
+"""
+function collect_dependency_licenses(
+    project_dir::AbstractString,
+    license_dir::AbstractString,
+)::Nothing
     ctx = PackageCompiler.create_pkg_context(project_dir)
-    visited_uuids = Set{eltype(values(ctx.env.project.deps))}()
+    visited_uuids = Set{Base.UUID}()
     for package_uuid in values(ctx.env.project.deps)
         collect_dependency_license(ctx, license_dir, visited_uuids, package_uuid)
     end
+    return nothing
 end
 
 function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file)

--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -1,15 +1,4 @@
 """
-Add the following metadata files to the newly created build:
-
-- Build.toml
-- Project.toml
-- Manifest.toml
-- README.md
-- LICENSE
-- dep_licenses/
-"""
-
-"""
 Recursively copy the license of `package_uuid` and all of its transitive dependencies (as
 found in `ctx`'s manifest) into `license_dir`, skipping uuids already in `visited_uuids`.
 """
@@ -58,7 +47,25 @@ function collect_dependency_licenses(
     return nothing
 end
 
-function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file)
+"""
+Add the following metadata to the app bundle at `output_dir`, built from `project_dir`
+within the `git_repo` checkout:
+
+- Build.toml
+- Project.toml
+- Manifest.toml
+- README.md
+- LICENSE
+- Wflow.spdx.json
+- dep_licenses/
+"""
+function add_metadata(
+    project_dir::AbstractString,
+    license_file::AbstractString,
+    output_dir::AbstractString,
+    git_repo::AbstractString,
+    sbom_file::AbstractString,
+)::Nothing
     # save some environment variables in a Build.toml file for debugging purposes
     vars = ["BUILD_NUMBER", "BUILD_VCS_NUMBER"]
     dict = Dict(var => ENV[var] for var in vars if haskey(ENV, var))
@@ -124,4 +131,5 @@ function add_metadata(project_dir, license_file, output_dir, git_repo, sbom_file
     license_dir = joinpath(output_dir, "dep_licenses")
     mkpath(license_dir)
     collect_dependency_licenses(normpath(git_repo, "Wflow"), license_dir)
+    return nothing
 end

--- a/build/create_binaries/add_metadata.jl
+++ b/build/create_binaries/add_metadata.jl
@@ -9,31 +9,34 @@ Add the following metadata files to the newly created build:
 - dep_licenses/
 """
 
+function collect_dependency_license(ctx, license_dir, visited_uuids, package_uuid)
+    package_uuid in visited_uuids && return
+    push!(visited_uuids, package_uuid)
+
+    pkg_entry = ctx.env.manifest.deps[package_uuid]
+    for dep_uuid in values(pkg_entry.deps)
+        collect_dependency_license(ctx, license_dir, visited_uuids, dep_uuid)
+    end
+
+    if isnothing(pkg_entry.tree_hash)
+        # Stdlib packages do not have a tree hash.
+        return
+    end
+
+    install_path =
+        Pkg.Operations.find_installed(pkg_entry.name, package_uuid, pkg_entry.tree_hash)
+    license = LicenseCheck.find_license(install_path)
+    if !isnothing(license)
+        license_file_path = joinpath(install_path, license.license_filename)
+        cp(license_file_path, joinpath(license_dir, pkg_entry.name); force = true)
+    end
+end
+
 function collect_dependency_licenses(project_dir, license_dir)
     ctx = PackageCompiler.create_pkg_context(project_dir)
-    pending_uuids = collect(values(ctx.env.project.deps))
-    visited_uuids = Set{eltype(pending_uuids)}()
-
-    while !isempty(pending_uuids)
-        package_uuid = pop!(pending_uuids)
-        package_uuid in visited_uuids && continue
-        push!(visited_uuids, package_uuid)
-
-        pkg_entry = ctx.env.manifest.deps[package_uuid]
-        append!(pending_uuids, values(pkg_entry.deps))
-
-        if isnothing(pkg_entry.tree_hash)
-            # Stdlib packages do not have a tree hash.
-            continue
-        end
-
-        install_path =
-            Pkg.Operations.find_installed(pkg_entry.name, package_uuid, pkg_entry.tree_hash)
-        license = LicenseCheck.find_license(install_path)
-        if !isnothing(license)
-            license_file_path = joinpath(install_path, license.license_filename)
-            cp(license_file_path, joinpath(license_dir, pkg_entry.name); force = true)
-        end
+    visited_uuids = Set{eltype(values(ctx.env.project.deps))}()
+    for package_uuid in values(ctx.env.project.deps)
+        collect_dependency_license(ctx, license_dir, visited_uuids, package_uuid)
     end
 end
 


### PR DESCRIPTION
## Summary

Follow-up to #1025. Replaces the explicit uuid stack/worklist in `collect_dependency_licenses` with plain recursion, per review feedback that recursion reads more naturally for this dependency-graph walk.

- `collect_dependency_license` recurses into each dependency's own deps before checking/copying its license
- `visited_uuids` still guards against revisiting shared transitive dependencies (the manifest dependency graph is not a tree)
- behavior is unchanged: only dependencies reachable from the `Wflow` subproject are scanned; stdlib packages (no tree hash) are skipped for license lookup but still traversed

## Validation

- ran the license collector against the `Wflow` project on top of latest `main`; collected 86 licenses
- asserted `NCDatasets` is included and workspace-only `JSON`/`PackageCompiler` are excluded
- pre-commit formatting and hygiene hooks passed