### PR TITLE
Fix test failure due to outdated General registry

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
         with:
           pixi-version: "latest"
-      - name: Prepare pixi
-        run: pixi run install-ci
+      - name: Instantiate Julia project
+        run: pixi run instantiate-julia docs
 
       - name: Check Quarto installation and all engines
         run: pixi run quarto-check

--- a/.github/workflows/julia-auto-update.yml
+++ b/.github/workflows/julia-auto-update.yml
@@ -16,9 +16,7 @@ jobs:
         with:
           pixi-version: "latest"
       - name: Update Julia manifest
-        run: |
-          pixi run update-registry-julia
-          pixi run update-manifest-julia
+        run: pixi run update-manifest-julia
         env:
           JULIA_PKG_PRECOMPILE_AUTO: "0"
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,14 +17,7 @@ platforms = ["win-64", "linux-64"]
 install-julia = "juliaup add 1.12.6 && juliaup override set 1.12.6"
 # Prek
 install-prek = "prek install --overwrite"
-update-registry-julia = "julia --eval='using Pkg; Registry.update()'"
 update-manifest-julia = "julia --project utils/update-manifest.jl"
-initialize-julia = { depends-on = [
-	"update-registry-julia",
-	{ "task" = "instantiate-julia", "args" = [
-		"Wflow",
-	] },
-] }
 install = { depends-on = ["install-prek"] }
 # Test data
 download-test-data = { cmd = "julia --project ../utils/download_test_data.jl", cwd = "Wflow" }
@@ -43,7 +36,9 @@ test-wflow-cli = { cmd = "julia --project --eval 'using Pkg; Pkg.test(allow_rere
 	"download-test-data",
 ] }
 test-wflow-cov = { cmd = "julia --project --eval 'using Pkg; Pkg.test(allow_reresolve=false, coverage=true, julia_args=[\"--check-bounds=yes\"])'", cwd = "Wflow", depends-on = [
-	"initialize-julia",
+	{ "task" = "instantiate-julia", "args" = [
+		"Wflow",
+	] },
 	"download-test-data",
 ] }
 # Server
@@ -60,7 +55,6 @@ test-wflow-server = { cmd = "julia --project=server --eval 'using Pkg; Pkg.test(
 instantiate-formatting = { cmd = "julia --project=utils/formatting --eval 'using Pkg; Pkg.instantiate(); using JuliaFormatter'" }
 format-code = { cmd = "julia --project=utils/formatting --eval 'using JuliaFormatter; format(isempty(ARGS) ? \".\" : ARGS) || exit(1)'" }
 # Docs
-install-ci = { depends-on = ["update-registry-julia"] }
 quarto-check = { cmd = "quarto check all" }
 quarto-render = { cmd = "julia --project=docs --eval 'using Pkg; Pkg.build(\"IJulia\")' && quarto render docs --to html --execute" }
 quarto-preview = { cmd = "quarto preview docs" }
@@ -69,7 +63,7 @@ parameter_metadata_json_gen = { cmd = "julia --project=utils/export_parameter_da
 
 [tasks.instantiate-julia]
 args = [{ "arg" = "cwd", "default" = "." }]
-cmd = "julia --project={{cwd}} --eval='using Pkg; Pkg.instantiate()'"
+cmd = "julia --project={{cwd}} --eval='using Pkg; Pkg.Registry.update(); Pkg.instantiate()'"
 
 [tasks.generate-sbom]
 depends-on = ["instantiate-julia"]

--- a/utils/update-manifest.jl
+++ b/utils/update-manifest.jl
@@ -19,6 +19,7 @@ function (@main)(_)
     redirect_stdio(; stdout = path, stderr = path) do
         println("Update the Julia Manifest.toml to get the latest dependencies.\n")
         println("__Changed packages__\n```")
+        Pkg.Registry.update()
         Pkg.update()
         println("```\n\n__Packages still outdated after update__\n```")
         Pkg.status(; outdated = true)


### PR DESCRIPTION
Last night's test binaries CI failed due to the General registry being outdated. This makes sure the registry is updated first to avoid that.

Rather than calling `update-registry-julia` first, this simplifies, just like https://github.com/Deltares/Ribasim/pull/3183, to less tasks.