### PR TITLE
Build v1.0 docs from release/v1.0 and fix example model URLs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - v1
+      - main
+      - release/v1.0
     tags: '*'
 
 # needed to allow julia-actions/cache to delete old caches that it has created

--- a/.github/workflows/CIWflowServer.yml
+++ b/.github/workflows/CIWflowServer.yml
@@ -3,8 +3,8 @@ on:
   pull_request:
   push:
     branches:
-      - master
-      - v1
+      - main
+      - release/v1.0
     tags: '*'
 
 # needed to allow julia-actions/cache to delete old caches that it has created

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Quarto documentation
 on:
   push:
-    branches: [master]
+    branches: [main, release/v1.0]
     tags: [v*]
   pull_request:
 
@@ -49,12 +49,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish Quarto Project as dev
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_site
           destination_dir: dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Quarto Project as v1.0
+        if: github.event_name == 'push' && github.ref == 'refs/heads/release/v1.0'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_site
+          destination_dir: v1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/getting_started/download_example_models.qmd
+++ b/docs/getting_started/download_example_models.qmd
@@ -8,9 +8,9 @@ listed in the Table below:
 
 |  model  | TOML configuration file |
 |:--------------- | ------------------|
-| wflow\_sbm + kinematic wave | [sbm_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_config.toml) |
-| wflow\_sbm + groundwater flow | [sbm\_gwf\_piave\_demand\_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_gwf_piave_demand_config.toml) |
-| wflow_sediment | [sediment_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sediment_config.toml) |
+| wflow\_sbm + kinematic wave | [sbm_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sbm_config.toml) |
+| wflow\_sbm + groundwater flow | [sbm\_gwf\_piave\_demand\_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sbm_gwf_piave_demand_config.toml) |
+| wflow_sediment | [sediment_config.toml](https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sediment_config.toml) |
 
 The associated Model files (input static, forcing and state files) can easily be downloaded and
 for this we share the following Julia code (per Model) that downloads the required files to
@@ -20,7 +20,7 @@ and [Command Line Interface](./running_wflow.qmd#using-the-command-line-interfac
 ## wflow\_sbm + kinematic wave
 ```julia
 # urls to TOML and netCDF of the Moselle example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sbm_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-moselle.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-moselle.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-moselle.nc"
@@ -41,7 +41,7 @@ download(toml_url, toml_path)
 ## wflow\_sbm + groundwater flow
 ```julia
 # urls to TOML and netCDF of the Piave example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sbm_gwf_piave_demand_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sbm_gwf_piave_demand_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-piave.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-piave.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-piave-gwf.nc"
@@ -50,7 +50,7 @@ instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/ins
 testdir = @__DIR__
 inputdir = joinpath(testdir, "data/input")
 isdir(inputdir) || mkpath(inputdir)
-toml_path = joinpath(@testdir, "sbm_gwf_piave_demand_config.toml")
+toml_path = joinpath(testdir, "sbm_gwf_piave_demand_config.toml")
 
 # download resources to current and data dirs
 download(staticmaps, joinpath(inputdir, "staticmaps-piave.nc"))
@@ -62,7 +62,7 @@ download(toml_url, toml_path)
 ## wflow\_sediment
 ```julia
 # urls to TOML and netCDF of the Moselle example model
-toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/sediment_config.toml"
+toml_url = "https://raw.githubusercontent.com/Deltares/Wflow.jl/release/v1.0/Wflow/test/sediment_config.toml"
 staticmaps = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/staticmaps-moselle-sed.nc"
 forcing = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/forcing-moselle-sed.nc"
 instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/instates-moselle-sed.nc"

--- a/docs/getting_started/install.qmd
+++ b/docs/getting_started/install.qmd
@@ -48,17 +48,18 @@ automatically resolved and installed from the Pkg General registry.
 
 ### Install from GitHub
 
-You can also install wflow from the `master` branch on the repository as follows:
+You can also install wflow from the `main` branch on the repository as follows:
 
 ```bash
-pkg> add Wflow:Wflow#master
+pkg> add Wflow:Wflow#main
 ```
 
-This command tracks the `master` branch and updates to the latest commit on that branch when
-you run `update`, or simply `up`, in the Pkg REPL. The `add` installs wflow in your home
-directory under `.julia/packages/Wflow`. Note that packages installed under `packages` by `add`
-should not be changed in the directory, as the change could disrupt Pkg's automatic dependency
-handling.
+This command tracks the `main` branch and updates to the latest commit on that branch when
+you run `update`, or simply `up`, in the Pkg REPL. Note that `main` is the development branch,
+which may be incompatible with the configuration files documented here. The `add` installs
+wflow in your home directory under `.julia/packages/Wflow`. Note that packages installed under
+`packages` by `add` should not be changed in the directory, as the change could disrupt Pkg's
+automatic dependency handling.
 
 If you want to modify any files in the repository, you need to do a development install. This
 can be done using:


### PR DESCRIPTION
## Issue addressed
Fixes part of https://github.com/Deltares/Wflow.jl/issues/1033

## Explanation
The stable documentation instructs users to download example model TOML files from
`https://raw.githubusercontent.com/Deltares/Wflow.jl/master/Wflow/test/...`. The `master`
branch no longer exists, but GitHub silently redirects it to `main`, so users of the
released version download **development** configuration files. On v1.0.4 that produces
`wflow_version = "1.1"` warnings and an `ArgumentError` on
`subsurface_water__instantaneous_volume_flow_rate`, which was renamed on `main`.

Changes:

- Point the example model URLs at `release/v1.0` instead of the non-existing `master`.
- `install.qmd`: `Wflow#master` -> `Wflow#main`, with a note that `main` is the
  development branch and may be incompatible with the configuration files documented here.
- `docs.yml`: publish the docs built from this branch to the `v1.0` directory on gh-pages,
  so documentation fixes for the 1.0 series become visible without cutting a release. The
  `stable` symlink on gh-pages can then be pointed at `v1.0` (follow-up), instead of being
  manually bumped to a fixed tag directory at every release. Tag builds still archive exact
  `v1.0.x/` snapshots.
- `CI.yml`, `CIWflowServer.yml`, `docs.yml`: replace the `master` and `v1` push triggers,
  neither of which refers to an existing branch, with `release/v1.0`.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `release/v1.0`
- [ ] Tests & prek hooks pass
- [x] Updated documentation if needed
- [ ] Updated changelog.qmd if needed
- [ ] A review by Copilot was done to ensure the requirements in `AGENTS.md` are satisfied

## Additional Notes
Merging this triggers the first build of `gh-pages/v1.0/`. Only after that exists should the
`stable` symlink (currently pointing at `v1.0.0`, i.e. the December 2025 build) be repointed
at `v1.0`, together with the corresponding `switcher.json` / `versions.json` entries.

The companion PR against `main` keeps the workflow files in sync across branches.
