### PR TITLE
Add release/v1.0 to workflow triggers and publish its docs as v1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v1
+      - release/v1.0
     tags: '*'
 
 # needed to allow julia-actions/cache to delete old caches that it has created

--- a/.github/workflows/CIWflowServer.yml
+++ b/.github/workflows/CIWflowServer.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - v1
+      - release/v1.0
     tags: '*'
 
 # needed to allow julia-actions/cache to delete old caches that it has created

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Quarto documentation
 on:
   push:
-    branches: [main]
+    branches: [main, release/v1.0]
     tags: [v*]
   pull_request:
 
@@ -52,6 +52,16 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/_site
           destination_dir: dev
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Quarto Project as v1.0
+        if: github.event_name == 'push' && github.ref == 'refs/heads/release/v1.0'
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_site
+          destination_dir: v1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/getting_started/download_example_models.qmd
+++ b/docs/getting_started/download_example_models.qmd
@@ -50,7 +50,7 @@ instates = "https://github.com/visr/wflow-artifacts/releases/download/v1.0.0/ins
 testdir = @__DIR__
 inputdir = joinpath(testdir, "data/input")
 isdir(inputdir) || mkpath(inputdir)
-toml_path = joinpath(@testdir, "sbm_gwf_piave_demand_config.toml")
+toml_path = joinpath(testdir, "sbm_gwf_piave_demand_config.toml")
 
 # download resources to current and data dirs
 download(staticmaps, joinpath(inputdir, "staticmaps-piave.nc"))


### PR DESCRIPTION
## Issue addressed
Companion to #1034, part of https://github.com/Deltares/Wflow.jl/issues/1033.

## Explanation
The workflows trigger on a `v1` branch, which does not exist. Replace it with
`release/v1.0`, so pushes to the release branch run CI and publish their documentation
to the `v1.0` directory on gh-pages. That lets the `stable` symlink point at a maintained
release series rather than at a frozen tag directory, making documentation fixes visible
without cutting a release.

The `release/v1.0` publish step is inert on `main`; it is included here to keep the
workflow files in sync between the two branches.

Also fixes a `@testdir` typo in the example model download instructions.

## Checklist
- [ ] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [ ] Tests & prek hooks pass
- [x] Updated documentation if needed
- [ ] Updated changelog.qmd if needed
- [ ] A review by Copilot was done to ensure the requirements in `AGENTS.md` are satisfied
