### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -382,9 +382,9 @@ uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
 version = "0.2.12"
 
 [[deps.CommonWorldInvalidations]]
-git-tree-sha1 = "cde75cb34c9ee07b4c37981b0f32378d0dc19ffe"
+git-tree-sha1 = "ef2022bff55342a8c9846cdf218f62e475f0444d"
 uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -773,9 +773,9 @@ version = "5.2.3+0"
 
 [[deps.Glib_jll]]
 deps = ["Artifacts", "GettextRuntime_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE2_jll", "Zlib_jll"]
-git-tree-sha1 = "24f6def62397474a297bfcec22384101609142ed"
+git-tree-sha1 = "090526e65de8f69648ac156daae153de8b56df62"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.86.3+0"
+version = "2.88.3+0"
 
 [[deps.Glob]]
 git-tree-sha1 = "246c628cec062230b7d183aab88841fa94fcabe9"
@@ -835,9 +835,9 @@ version = "2.14.0+0"
 
 [[deps.HypergeometricFunctions]]
 deps = ["Gamma", "LinearAlgebra"]
-git-tree-sha1 = "18d7deab5fb0440dc6a7b6993c5c27b25420de10"
+git-tree-sha1 = "31bb6c92405c084617facc1d7ed9eb6c402d061e"
 uuid = "34004b35-14d8-5ef3-9330-4cdb6864b03a"
-version = "0.3.29"
+version = "0.3.30"
 
 [[deps.IJulia]]
 deps = ["Base64", "Conda", "Dates", "InteractiveUtils", "Logging", "Markdown", "Pkg", "PrecompileTools", "Printf", "REPL", "Random", "SHA", "Sockets", "UUIDs", "ZMQ"]
@@ -1380,9 +1380,9 @@ version = "2025.11.4"
 
 [[deps.MuladdMacro]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "e8dcbeef032ba2f9051a44ac22b4e54e3a1a0099"
+git-tree-sha1 = "283bf85d4a767481dd924dff0eee1735e95f449e"
 uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.6"
+version = "0.2.7"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
@@ -1507,9 +1507,9 @@ version = "10.44.0+1"
 
 [[deps.PDMats]]
 deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "26766d4b5f1a410c218a19b85a672c6edb693c65"
+git-tree-sha1 = "123266c25174ef6c8d4718920abc206452cf8de6"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
-version = "0.11.40"
+version = "0.11.41"
 weakdeps = ["StatsBase"]
 
     [deps.PDMats.extensions]
@@ -1954,9 +1954,9 @@ version = "0.1.2"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "5ef96deaf82834d64e1456c6a6665ca4188afd48"
+git-tree-sha1 = "4abff9ad312e476839c25b9398f619255af9a0e4"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.4"
+version = "1.4.5"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
@@ -2026,9 +2026,9 @@ version = "0.5.9"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "532e983cd333609f95d618c744fc40d01ea6e17a"
+git-tree-sha1 = "8a90c1d77c3277a5d43b83927b3cbe2c70a37484"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.6"
+version = "0.4.7"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2175,9 +2175,9 @@ uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
 version = "0.1.0"
 
 [[deps.URIs]]
-git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+git-tree-sha1 = "3b0738bd7c5645641845da25cbd99800b8718689"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.6.1"
+version = "1.6.2"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
  Installing 77 artifacts
     Project No packages added to or removed from `~/work/Wflow.jl/Wflow.jl/Project.toml`
    Updating `~/work/Wflow.jl/Wflow.jl/Manifest.toml`
  [f70d9fcc] ↑ CommonWorldInvalidations v1.1.1 ⇒ v1.1.2
  [aedffcd0] ↑ Static v1.4.4 ⇒ v1.4.5
    Building Conda ─→ `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/8f06b0cfa4c514c7b9546756dbae91fcfbc92dc9/build.log`
    Building IJulia → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/d9ea0eeac84e4a7397858847c8b5f1d4ef515ded/build.log`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 84 found
      Active scratchspaces: 2 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Wflow.jl/Wflow.jl/Project.toml`
```
<details>
<summary>
All package versions
</summary>

```

AbstractFFTs ───────────────────── v1.5.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.44
AccessorsExtra ─────────────────── v0.1.102
Adapt ──────────────────────────── v4.7.0
AdaptivePredicates ─────────────── v1.2.0
AliasTables ────────────────────── v1.1.3
Animations ─────────────────────── v0.4.2
Aqua ───────────────────────────── v0.8.14
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.28.1
Automa ─────────────────────────── v1.2.0
AxisAlgorithms ─────────────────── v1.1.0
AxisArrays ─────────────────────── v0.4.8
BaseDirs ───────────────────────── v1.4.0
BasicModelInterface ────────────── v0.1.1
BitTwiddlingConvenienceFunctions ─ v0.1.6
Blosc_jll ──────────────────────── v1.21.7+0
Bzip2_jll ──────────────────────── v1.0.9+0
CEnum ──────────────────────────── v0.5.0
CFTime ─────────────────────────── v0.2.10
CPUSummary ─────────────────────── v0.2.7
CRlibm ─────────────────────────── v1.0.2
CRlibm_jll ─────────────────────── v1.0.1+0
Cairo ──────────────────────────── v1.1.1
CairoMakie ─────────────────────── v0.13.10
Cairo_jll ──────────────────────── v1.18.7+0
ChainRulesCore ─────────────────── v1.26.1
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v3.0.2
CodecZstd ──────────────────────── v0.8.7
ColorBrewer ────────────────────── v0.4.2
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
Combinatorics ──────────────────── v1.1.0
CommonDataModel ────────────────── v0.4.4
CommonMark ─────────────────────── v1.0.3
CommonSolve ────────────────────── v0.2.12
CommonWorldInvalidations ───────── v1.1.2
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
Conda ──────────────────────────── v1.10.3
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
CoreMath ───────────────────────── v0.1.0
CoreMath_jll ───────────────────── v0.1.0+0
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.2.0
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.1
DataManipulation ───────────────── v0.1.22
DataPipes ──────────────────────── v0.3.19
DataStructures ─────────────────── v0.19.6
DataValueInterfaces ────────────── v1.0.0
DelaunayTriangulation ──────────── v1.6.6
DelimitedFiles ─────────────────── v1.9.1
Dictionaries ───────────────────── v0.4.6
DiskArrays ─────────────────────── v0.4.22
DisplayAs ──────────────────────── v0.1.6
Distributions ──────────────────── v0.25.130
DocStringExtensions ────────────── v0.9.5
EarCut_jll ─────────────────────── v2.2.4+0
EnumX ──────────────────────────── v1.0.7
ExactPredicates ────────────────── v2.2.9
Expat_jll ──────────────────────── v2.8.2+0
ExprTools ──────────────────────── v0.1.11
FFMPEG_jll ─────────────────────── v6.1.3+0
FFTA ───────────────────────────── v0.3.1
FileIO ─────────────────────────── v1.20.0
FilePaths ──────────────────────── v0.8.3
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.16.0
FixedPointNumbers ──────────────── v0.8.6
FlexiGroups ────────────────────── v0.1.31
FlexiMaps ──────────────────────── v0.1.29
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
FreeType ───────────────────────── v4.1.1
FreeType2_jll ──────────────────── v2.14.3+1
FreeTypeAbstraction ────────────── v0.10.8
FriBidi_jll ────────────────────── v1.0.17+0
Gamma ──────────────────────────── v1.1.0
GeometryBasics ─────────────────── v0.5.11
GettextRuntime_jll ─────────────── v0.22.4+0
Giflib_jll ─────────────────────── v5.2.3+0
Glib_jll ───────────────────────── v2.88.3+0
Glob ───────────────────────────── v1.5.0
Graphics ───────────────────────── v1.1.3
Graphite2_jll ──────────────────── v1.3.16+0
Graphs ─────────────────────────── v1.14.0
GridLayoutBase ─────────────────── v0.11.2
Grisu ──────────────────────────── v1.0.2
HDF5_jll ───────────────────────── v2.1.2+0
HarfBuzz_jll ───────────────────── v8.5.1+0
Hwloc_jll ──────────────────────── v2.14.0+0
HypergeometricFunctions ────────── v0.3.30
IJulia ─────────────────────────── v1.34.2
IfElse ─────────────────────────── v0.1.1
ImageAxes ──────────────────────── v0.6.12
ImageBase ──────────────────────── v0.1.7
ImageCore ──────────────────────── v0.10.5
ImageIO ────────────────────────── v0.6.9
ImageMetadata ──────────────────── v0.9.10
Imath_jll ──────────────────────── v3.2.2+0
Indexing ───────────────────────── v1.1.1
IndirectArrays ─────────────────── v1.0.0
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntegerMathUtils ───────────────── v0.1.4
Interpolations ─────────────────── v0.15.1
IntervalArithmetic ─────────────── v1.0.10
IntervalSets ───────────────────── v0.7.14
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.6
Isoband ────────────────────────── v0.1.1
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLLWrappers ────────────────────── v1.8.0
JSON ───────────────────────────── v1.6.1
JSONSchema ─────────────────────── v1.5.0
JpegTurbo ──────────────────────── v0.1.6
JpegTurbo_jll ──────────────────── v3.2.0+0
JuliaFormatter ─────────────────── v2.6.10
JuliaInterpreter ───────────────── v0.11.4
JuliaSyntax ────────────────────── v1.0.2
KernelDensity ──────────────────── v0.6.12
KwdefHelpers ───────────────────── v0.1.0
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.1.0+0
LLVMOpenMP_jll ─────────────────── v22.1.7+0
LRUCache ───────────────────────── v1.6.2
LaTeXStrings ───────────────────── v1.4.0
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LazyModules ────────────────────── v0.3.1
LeftChildRightSiblingTrees ─────── v0.2.1
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.42.0+0
Libtiff_jll ────────────────────── v4.7.3+0
Libuuid_jll ────────────────────── v2.42.0+0
LicenseCheck ───────────────────── v0.2.3
LogExpFunctions ────────────────── v0.3.29
LoggingExtras ──────────────────── v1.2.0
LoweredCodeUtils ───────────────── v3.8.0
Lz4_jll ────────────────────────── v1.10.1+0
MPIABI_jll ─────────────────────── v0.1.5+0
MPICH_jll ──────────────────────── v5.0.1+0
MPIPreferences ─────────────────── v0.1.12
MPItrampoline_jll ──────────────── v5.5.6+0
MacroTools ─────────────────────── v0.5.16
Makie ──────────────────────────── v0.22.10
MakieCore ──────────────────────── v0.9.5
MakieExtra ─────────────────────── v0.1.69
ManualMemory ───────────────────── v0.1.8
MappedArrays ───────────────────── v0.4.3
MarkdownTables ─────────────────── v1.1.0
MathTeXEngine ──────────────────── v0.6.9
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MosaicViews ────────────────────── v0.3.4
MuladdMacro ────────────────────── v0.2.7
NCDatasets ─────────────────────── v0.14.15
NaNMath ────────────────────────── v1.1.4
NetCDF_jll ─────────────────────── v401.1000.100+0
Netpbm ─────────────────────────── v1.1.1
NonNegLeastSquares ─────────────── v0.4.1
Observables ────────────────────── v0.5.5
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenBLASConsistentFPCSR_jll ────── v0.3.34+0
OpenEXR ────────────────────────── v0.3.3
OpenEXR_jll ────────────────────── v3.4.13+0
OpenMPI_jll ────────────────────── v5.0.11+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.6.1+0
OrderedCollections ─────────────── v1.8.2
PDMats ─────────────────────────── v0.11.41
PNGFiles ───────────────────────── v0.4.5
PackageCompiler ────────────────── v2.3.0
Packing ────────────────────────── v0.5.1
PaddedViews ────────────────────── v0.5.12
Pango_jll ──────────────────────── v1.57.1+0
Parameters ─────────────────────── v0.12.3
Parsers ────────────────────────── v2.8.6
Pixman_jll ─────────────────────── v0.46.4+0
PkgToSoftwareBOM ───────────────── v0.1.19
PkgVersion ─────────────────────── v0.3.3
PlotUtils ──────────────────────── v1.4.4
Polyester ──────────────────────── v0.7.19
PolyesterWeave ─────────────────── v0.2.2
PolygonOps ─────────────────────── v0.1.2
Polynomials ────────────────────── v4.0.19
PooledArrays ───────────────────── v1.4.3
PrecompileTools ────────────────── v1.3.4
Preferences ────────────────────── v1.5.2
PrettyTables ───────────────────── v3.3.2
Primes ─────────────────────────── v0.5.7
ProgressLogging ────────────────── v0.1.6
ProgressMeter ──────────────────── v1.11.0
PropertyDicts ──────────────────── v0.2.1
PtrArrays ──────────────────────── v1.4.0
PyFormattedStrings ─────────────── v0.1.13
QOI ────────────────────────────── v1.0.2
QuadGK ─────────────────────────── v2.11.2
RangeArrays ────────────────────── v0.3.2
Ratios ─────────────────────────── v0.4.5
RecipesBase ────────────────────── v1.3.4
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.16.2
Rmath ──────────────────────────── v0.9.0
Rmath_jll ──────────────────────── v0.5.1+0
Roots ──────────────────────────── v3.0.6
RoundingEmulator ───────────────── v0.2.1
SIMD ───────────────────────────── v3.7.2
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.5.0
SciMLPublic ────────────────────── v1.2.4
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.10
Setfield ───────────────────────── v1.1.2
ShaderAbstractions ─────────────── v0.5.0
Showoff ────────────────────────── v1.0.3
SignedDistanceFields ───────────── v0.4.1
SimpleTraits ───────────────────── v0.9.6
Sixel ──────────────────────────── v0.1.5
Skipper ────────────────────────── v0.1.16
SortingAlgorithms ──────────────── v1.2.3
SpecialFunctions ───────────────── v2.7.1
StableRNGs ─────────────────────── v1.0.4
StackViews ─────────────────────── v0.1.2
Static ─────────────────────────── v1.4.5
StaticArrayInterface ───────────── v1.10.0
StaticArrays ───────────────────── v1.9.18
StaticArraysCore ───────────────── v1.4.4
Statistics ─────────────────────── v1.11.1
StatsAPI ───────────────────────── v1.8.0
StatsBase ──────────────────────── v0.34.12
StatsFuns ──────────────────────── v1.5.2
StrideArraysCore ───────────────── v0.5.9
StringManipulation ─────────────── v0.4.7
StructArrays ───────────────────── v0.7.3
StructHelpers ──────────────────── v1.6.0
StructUtils ────────────────────── v2.8.2
TZJData ────────────────────────── v1.5.0+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.13.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.7
TestItemRunner ─────────────────── v1.1.4
TestItems ──────────────────────── v1.0.0
ThreadingUtilities ─────────────── v0.5.6
TiffImages ─────────────────────── v0.11.9
TimeZones ──────────────────────── v1.22.2
TranscodingStreams ─────────────── v0.11.3
TriplotBase ────────────────────── v0.1.0
URIs ───────────────────────────── v1.6.2
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
Unitful ────────────────────────── v1.28.0
VersionParsing ─────────────────── v1.3.0
WebP ───────────────────────────── v0.1.3
WoodburyMatrices ───────────────── v1.1.0
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.3+0
Xorg_libX11_jll ────────────────── v1.8.13+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.8+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.19.0+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_xtrans_jll ────────────────── v1.6.0+0
ZMQ ────────────────────────────── v1.5.1
ZeroMQ_jll ─────────────────────── v4.3.6+0
Zstd_jll ───────────────────────── v1.5.7+1
artifact Blosc                   44.2 KiB
artifact Bzip2                   503.5 KiB
artifact CRlibm                  169.5 KiB
artifact Cairo                   2.2 MiB
artifact CoreMath                643.9 KiB
artifact EarCut                  80.5 KiB
artifact Expat                   297.5 KiB
artifact FFMPEG                  11.0 MiB
artifact Fontconfig              984.8 KiB
artifact FreeType2               1.5 MiB
artifact FriBidi                 78.9 KiB
artifact GettextRuntime          543.0 KiB
artifact Giflib                  154.6 KiB
artifact Glib                    7.8 MiB
artifact Graphite2               120.3 KiB
artifact HDF5                    6.1 MiB
artifact HarfBuzz                1.7 MiB
artifact Hwloc                   3.5 MiB
artifact Imath                   184.9 KiB
artifact JpegTurbo               1.9 MiB
artifact LAME                    292.5 KiB
artifact LERC                    267.4 KiB
artifact LLVMOpenMP              680.4 KiB
artifact Libffi                  44.2 KiB
artifact Libglvnd                833.5 KiB
artifact Libiconv                1.9 MiB
artifact Libmount                6.9 MiB
artifact Libtiff                 2.4 MiB
artifact Libuuid                 3.9 MiB
artifact Lz4                     239.7 KiB
artifact MPICH                   8.8 MiB
artifact NetCDF                  970.6 KiB
artifact Ogg                     250.3 KiB
artifact OpenBLASConsistentFPCSR 10.2 MiB
artifact OpenEXR                 1.3 MiB
artifact OpenSpecFun             194.9 KiB
artifact Opus                    960.9 KiB
artifact Pango                   2.1 MiB
artifact Pixman                  390.8 KiB
artifact Rmath                   121.9 KiB
artifact XML2                    2.5 MiB
artifact XZ                      1.6 MiB
artifact Xorg_libX11             4.8 MiB
artifact Xorg_libXau             36.6 KiB
artifact Xorg_libXdmcp           67.7 KiB
artifact Xorg_libXext            286.6 KiB
artifact Xorg_libXrender         435.9 KiB
artifact Xorg_libpciaccess       26.2 KiB
artifact Xorg_libxcb             2.1 MiB
artifact Xorg_xtrans             48.2 KiB
artifact ZeroMQ                  316.1 KiB
artifact Zstd                    646.0 KiB
artifact aws_c_auth              130.3 KiB
artifact aws_c_cal               1.2 MiB
artifact aws_c_common            285.2 KiB
artifact aws_c_compression       13.4 KiB
artifact aws_c_http              387.4 KiB
artifact aws_c_io                181.7 KiB
artifact aws_c_s3                143.0 KiB
artifact aws_c_sdkutils          54.9 KiB
artifact aws_checksums           87.0 KiB
artifact isoband                 25.7 KiB
artifact libaec                  50.4 KiB
artifact libaom                  6.4 MiB
artifact libass                  427.8 KiB
artifact libfdk_aac              2.8 MiB
artifact libpng                  329.4 KiB
artifact libsixel                177.3 KiB
artifact libsodium               1.6 MiB
artifact libvorbis               271.0 KiB
artifact libwebp                 2.6 MiB
artifact libzip                  177.6 KiB
artifact licensecheck            2.4 MiB
artifact s2n_tls                 1.8 MiB
artifact tzjdata                 112.5 KiB
artifact x264                    2.1 MiB
artifact x265                    1.4 MiB
aws_c_auth_jll ─────────────────── v0.9.6+0
aws_c_cal_jll ──────────────────── v0.9.13+0
aws_c_common_jll ───────────────── v0.12.6+0
aws_c_compression_jll ──────────── v0.3.2+0
aws_c_http_jll ─────────────────── v0.10.13+0
aws_c_io_jll ───────────────────── v0.26.3+0
aws_c_s3_jll ───────────────────── v0.11.5+0
aws_c_sdkutils_jll ─────────────── v0.2.4+1
aws_checksums_jll ──────────────── v0.2.10+0
dlfcn_win32_jll ────────────────── v1.4.2+0
isoband_jll ────────────────────── v0.2.3+0
libaec_jll ─────────────────────── v1.1.7+0
libaom_jll ─────────────────────── v3.13.3+0
libass_jll ─────────────────────── v0.17.4+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libpng_jll ─────────────────────── v1.6.58+0
libsixel_jll ───────────────────── v1.10.5+0
libsodium_jll ──────────────────── v1.0.21+0
libvorbis_jll ──────────────────── v1.3.8+0
libwebp_jll ────────────────────── v1.6.0+0
libzip_jll ─────────────────────── v1.11.3+0
licensecheck_jll ───────────────── v0.4.0+0
mpif_jll ───────────────────────── v0.1.7+0
s2n_tls_jll ────────────────────── v1.7.3+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
