### PR TITLE
Update julia to 1.12.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.12.6
+FROM julia:1.12.7
 LABEL maintainer="Maarten Pronk <maarten.pronk@deltares.nl>"
 
 RUN apt-get update && apt-get install -y \

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.12.6"
+julia_version = "1.12.7"
 manifest_format = "2.0"
 project_hash = "574610c5d6a18639f596ff8cdc87f0ebf5fb6a3f"
 
@@ -404,7 +404,7 @@ version = "0.1.1"
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "1.3.0+1"
+version = "1.3.1+2"
 
 [[deps.CompositionsBase]]
 git-tree-sha1 = "802bb88cd69dfd1509f6670416bd4434015693ad"
@@ -1481,7 +1481,7 @@ version = "5.0.11+0"
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.5.4+0"
+version = "3.5.6+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl"]

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,7 +1,15 @@
 version: 7
 platforms:
 - name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -340,7 +348,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/widgetsnbextension-4.0.13-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zc.lockfile-4.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/zipp-3.21.0-pyhd8ed1ab_1.conda
-      - conda: https://prefix.dev/julia-forge/linux-64/julia-1.12.6-hb0f4dca_0.conda
+      - conda: https://prefix.dev/julia-forge/linux-64/julia-1.12.7-hb0f4dca_0.conda
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiobotocore-3.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.7.1-pyhd8ed1ab_0.conda
@@ -635,7 +643,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zeromq-4.3.5-ha9f60a1_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstandard-0.23.0-py313h574b89f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.6-h0ea2cb4_0.conda
-      - conda: https://prefix.dev/julia-forge/win-64/julia-1.12.6-h9490d1a_0.conda
+      - conda: https://prefix.dev/julia-forge/win-64/julia-1.12.7-h9490d1a_0.conda
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -6392,17 +6400,17 @@ packages:
   license_family: BSD
   size: 349143
   timestamp: 1714723445995
-- conda: https://prefix.dev/julia-forge/linux-64/julia-1.12.6-hb0f4dca_0.conda
-  sha256: f5a8355458eac135f28502904b6ca28af18e1ad812b66b9b497caecb0b04086f
-  md5: e8b3e39e2d8c1ddfb7a9f41741ecafc6
+- conda: https://prefix.dev/julia-forge/linux-64/julia-1.12.7-hb0f4dca_0.conda
+  sha256: 474a1a9c3d72419cdc6658aa4c0f5b761adce334de69a53b4118bf2154d8538e
+  md5: 2f335e89b5ca43614a504d59cb2a41fd
   license: MIT
   run_exports: {}
-  size: 219623335
-  timestamp: 1784621704266
-- conda: https://prefix.dev/julia-forge/win-64/julia-1.12.6-h9490d1a_0.conda
-  sha256: c1118c2db24e3c3c740c31ba3b232bfdcec30374d95d62167220d80a74904430
-  md5: 85a715209f9a968f323ec8e7d907d930
+  size: 219656705
+  timestamp: 1786911661964
+- conda: https://prefix.dev/julia-forge/win-64/julia-1.12.7-h9490d1a_0.conda
+  sha256: d6a823832141d86fdeae2d4fcf840c109cde447c4042b64e3859fee159215000
+  md5: 14704cf411316de6a0f888f95135cb3d
   license: MIT
   run_exports: {}
-  size: 213243591
-  timestamp: 1784624009463
+  size: 215592524
+  timestamp: 1786911668752

--- a/pixi.toml
+++ b/pixi.toml
@@ -14,7 +14,7 @@ platforms = ["win-64", "linux-64"]
 # Julia
 # Note: this is for developers to have their global julia use the right version.
 # Use `pixi run julia` for the package used by CI.
-install-julia = "juliaup add 1.12.6 && juliaup override set 1.12.6"
+install-julia = "juliaup add 1.12.7 && juliaup override set 1.12.7"
 # Prek
 install-prek = "prek install --overwrite"
 update-manifest-julia = "julia --project utils/update-manifest.jl"

--- a/pixi.toml
+++ b/pixi.toml
@@ -74,7 +74,7 @@ outputs = ["Wflow.spdx.json"]
 [dependencies]
 dvc = "*"
 dvc-s3 = "*"
-julia = { version = "==1.12.6", channel = "https://prefix.dev/julia-forge" }
+julia = { version = "==1.12.7", channel = "https://prefix.dev/julia-forge" }
 python = ">=3.10"
 jupyter = ">=1.1.1,<2"
 quarto = ">=1.8.26,<2"


### PR DESCRIPTION
Now that Julia comes from julia-forge, I did `pixi upgrade julia`. After that I did `Pkg.resolve()`, and replaced the final instances of 1.12.6.

https://discourse.julialang.org/t/julia-v1-12-7-has-been-released/138832
