### PR TITLE
Add RollingDataset to close past forcing data

### DIFF
--- a/Wflow/src/Wflow.jl
+++ b/Wflow/src/Wflow.jl
@@ -93,7 +93,7 @@ function Clock(config)
 end
 
 function Clock(config, reader)
-    nctimes = reader.dataset["time"][:]
+    nctimes = reader.dataset_times
 
     # if the timestep is not given, use the difference between netCDF time 1 and 2
     if isnothing(config.time.timestepsecs)

--- a/Wflow/src/io.jl
+++ b/Wflow/src/io.jl
@@ -1,3 +1,41 @@
+"NetCDF forcing files with only the currently selected file open."
+mutable struct RollingDataset{D <: NCDataset}
+    paths::Vector{String}
+    file_end_indices::Vector{Int}
+    dataset::D
+    file_index::Int
+end
+
+function RollingDataset(paths::Vector{String})
+    times_per_file = map(paths) do path
+        NCDataset(path) do dataset
+            dataset["time"][:]
+        end
+    end
+    file_end_indices = cumsum(length.(times_per_file))
+    times = reduce(vcat, times_per_file)
+    dataset = NCDataset(first(paths))
+    return RollingDataset(paths, file_end_indices, dataset, 1), times
+end
+
+"Select the forcing dataset and local index for a global time index."
+function dataset_index!(dataset::RollingDataset, index::Int)
+    file_index = searchsortedfirst(dataset.file_end_indices, index)
+    checkbounds(dataset.paths, file_index)
+    if file_index != dataset.file_index
+        close(dataset.dataset)
+        dataset.file_index = 0
+        dataset.dataset = NCDataset(dataset.paths[file_index])
+        dataset.file_index = file_index
+    end
+    previous_end =
+        file_index == firstindex(dataset.file_end_indices) ? 0 :
+        dataset.file_end_indices[file_index - 1]
+    return dataset.dataset, index - previous_end
+end
+
+Base.close(dataset::RollingDataset) = close(dataset.dataset)
+
 """Turn "a.aa.aaa" into (:a, :aa, :aaa)"""
 symbols(s::AbstractString) = Tuple(Symbol(x) for x in split(s, '.'))
 
@@ -7,7 +45,7 @@ param(obj, fields::AbstractString) = param(obj, symbols(fields))
 
 "Extract a netCDF variable at a given time"
 function get_at(
-    ds::CFDataset,
+    ds::RollingDataset,
     var::InputEntry,
     metadata,
     times::AbstractVector{<:TimeType},
@@ -19,6 +57,11 @@ function get_at(
     t < first(times) && throw(DomainError("time $t before dataset begin $(first(times))"))
     i === nothing && throw(DomainError("time $t after dataset end $(last(times))"))
     return get_at(ds, var, metadata, i, dt)
+end
+
+function get_at(ds::RollingDataset, var::InputEntry, metadata, i::Int, dt::Float64)
+    dataset, local_index = dataset_index!(ds, i)
+    return get_at(dataset, var, metadata, local_index, dt)
 end
 
 function get_at(ds::CFDataset, var::InputEntry, metadata, i::Int, dt::Float64)
@@ -430,7 +473,7 @@ function add_time(ds, time)
 end
 
 struct NCReader{T}
-    dataset::CFDataset
+    dataset::RollingDataset
     dataset_times::Vector{T}
     cyclic_dataset::Union{NCDataset, Nothing}
     cyclic_times::Dict{String, Vector{Tuple{Int, Int}}}
@@ -507,11 +550,10 @@ function NCReader(config)
     if isempty(dynamic_paths)
         error("No files found with name '$glob_path' in '$glob_dir'")
     end
-    dataset = NCDataset(dynamic_paths; aggdim = "time", deferopen = false)
+    dataset, nctimes = RollingDataset(dynamic_paths)
 
-    if haskey(dataset["time"].attrib, "_FillValue")
+    if haskey(dataset.dataset["time"].attrib, "_FillValue")
         @warn "Time dimension contains `_FillValue` attribute, this is not in line with CF conventions."
-        nctimes = dataset["time"][:]
         times_dropped = collect(skipmissing(nctimes))
         # check if length has changed (missing in time dimension are not allowed), and throw
         # an error if the lengths are different
@@ -522,7 +564,6 @@ function NCReader(config)
             nctimes_type = eltype(nctimes)
         end
     else
-        nctimes = dataset["time"][:]
         nctimes_type = eltype(nctimes)
     end
 

--- a/Wflow/test/io.jl
+++ b/Wflow/test/io.jl
@@ -54,7 +54,7 @@ end
     # mock a NCReader object
     ncpath = Wflow.input_path(config, config.input.path_forcing)
     ds = NCDataset(ncpath)
-    reader = (; dataset = ds)
+    reader = (; dataset_times = ds["time"][:])
 
     clock = Wflow.Clock(config, reader)
 


### PR DESCRIPTION
## Issue addressed
Fixes #1037

## Explanation
Wflow uses `deferopen=false` in opening multifile forcing data, so every monthly file remains open. Each accessed forcing variable in each file gets a 64 MB HDF5 chunk cache.
For 10.5 years, 126 monthly files * 3 variables * 64 MB that results in roughly 24 GiB.

This adds a `RollingDataset` instead of the MFD NCDataset, that only holds one forcing file open at a time.

## Reproduction

Standalone repro, no Wflow needed: 12 monthly forcing files x 3 variables, 400x400 grid, chunked per timestep, zlib level 4. One time slice per variable is read per step, for 1440 steps. Every scenario runs in a fresh process; peak RSS:

| scenario | peak RSS | wall |
| --- | --- | --- |
| single combined file | 738 MiB | 9.4 s |
| `MFDataset` (what `main` does) | 2946 MiB | 40.0 s |
| `MFDataset` + 4 MiB global chunk cache | 708 MiB | 41.0 s |
| `MFDataset` + `deferopen = true` | 565 MiB | 438 s |
| **`RollingDataset` (this PR)** | **747 MiB** | **11.3 s** |

Memory grows with the number of *files touched*, not with the number of timesteps, which matches the issue report.

`NCDatasets.get_chunk_cache()` reports 64 MiB / 1000 elements for the netCDF build we ship, and netCDF-C hands that cache to every variable of every open file, filling it lazily and releasing it only on close:

```
RSS growth ~ n_files * n_variables * min(64 MiB, bytes read from that variable)
```

12 * 3 * 64 MiB = 2304 MiB, which accounts for the 2946 - 738 = ~2200 MiB of extra memory measured. For the 10.5 year Rhine run from the issue, 126 * 3 * 64 MiB ~ 24 GiB. The output-side HDF5 flushing suggested in the issue thread is not involved; a no-output run shows the same growth.

The fix is also **~4x faster** (40.0 -> 11.3 s), which is a second, independent problem with aggregating the files into one virtual dataset. Each read is copied once more than necessary by `CatArrays`, on top of the copy `CFVariable` already makes, and `ds[name]` rebuilds a `CFVariable` *and* a `Variable` for every file on every lookup (~0.08 ms per file, so ~13 ms per timestep for a 126 file run, three times per timestep).

The two rejected alternatives in the table: shrinking the chunk cache globally fixes the memory but keeps ~9 MiB per file of open-file overhead (~1.1 GiB for 126 files), keeps the read penalty, and is a process-global setting that also degrades output writing; `deferopen = true` is 44x slower.

## Checklist
- [x] Updated tests or added new tests
- [x] Branch is up to date with `main`
- [x] Tests & prek hooks pass
- [x] Updated documentation if needed
- [x] Updated changelog.qmd if needed
- [ ] A review by Copilot was done to ensure the requirements in `AGENTS.md` are satisfied

## Additional Notes (optional)
Changing `deferopen=true` makes the model slower, as it would reopen the file on each var access. Ideally we upstream this to NCDatasets, I will make an issue.

Partially AI generated with GPT-5.6 Sol.

---

Follow-up commits on top of the original (also AI assisted), after a rebase onto `main` (the only conflict was the Runic reformatting of the `get_at` signature):

- **Sort the forcing files chronologically.** `RollingDataset` maps a global time index onto a file with a cumulative index, so it assumes the paths are in time order. `glob` sorts them lexicographically, which is not the same thing (`part10` before `part2`). The times are read in the constructor anyway, so sorting on the first timestamp is free.
- **Forward `read_x_axis`/`read_y_axis`.** `BMI.get_grid_x`/`get_grid_y` call these on `reader.dataset`, which would have thrown a `MethodError` on a `RollingDataset`.
- **Check for `_FillValue` on the time dimension across all files** instead of only the first. Testing `Missing <: eltype(nctimes)` on the concatenated times covers every file and needs no extra file opens.
- **Test.** `unit: RollingDataset` writes the first 9 timesteps of `forcing-moselle.nc` both as a single file and split over three, deliberately naming the parts so that lexicographic order is *not* chronological, then asserts the file ordering, the index bookkeeping, both axes and `get_at` for indices `1:9` followed by `9:-1:1`, so every file boundary is crossed in both directions.
- **Drop the `CFDataset` and `CFVariable_MF` unions.** Both only existed to also cover `MFDataset`/`MFCFVariable`, which are now unused, so they become plain `NCDataset` and `CFVariable`.

An NCDatasets-side fix was also prototyped (exposing the per-variable chunk cache, so each variable can be bounded to a few MiB). It does cut multifile memory to ~716 MiB, but multifile stays ~3x slower than this PR and still keeps N file handles open, so it is not an alternative to `RollingDataset` — it is worth upstreaming on its own merits, separately.
