### PR TITLE
Update Julia manifest

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -22,9 +22,9 @@ version = "0.4.5"
 
 [[deps.Accessors]]
 deps = ["CompositionsBase", "ConstructionBase", "Dates", "InverseFunctions", "MacroTools"]
-git-tree-sha1 = "2eeb2c9bef11013efc6f8f97f32ee59b146b09fb"
+git-tree-sha1 = "7063ad1083578215c7c4bf410368150abe8d5524"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
-version = "0.1.44"
+version = "0.1.45"
 
     [deps.Accessors.extensions]
     AxisKeysExt = "AxisKeys"
@@ -123,9 +123,9 @@ version = "0.4.2"
 
 [[deps.Aqua]]
 deps = ["Compat", "Pkg", "Test"]
-git-tree-sha1 = "d57fd255a8932b6509baf43284c416fc44d0b903"
+git-tree-sha1 = "4537cc8ed3fba5d88b844a18f7e9bb93f07d2742"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.8.14"
+version = "0.8.16"
 
 [[deps.ArgCheck]]
 git-tree-sha1 = "f9e9a66c9b7be1ad7372bbd9b062d9230c30c5ce"
@@ -144,9 +144,9 @@ version = "0.4.0"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra"]
-git-tree-sha1 = "60f11b38ebeabd984f5535838d91e197d97202f0"
+git-tree-sha1 = "daf5b2aab5b1c1fdcb65b05883cdb4b18abac1b9"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.28.1"
+version = "7.30.1"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceAMDGPUExt = "AMDGPU"
@@ -158,6 +158,7 @@ version = "7.28.1"
     ArrayInterfaceChainRulesExt = "ChainRules"
     ArrayInterfaceFillArraysExt = "FillArrays"
     ArrayInterfaceGPUArraysCoreExt = "GPUArraysCore"
+    ArrayInterfaceGPUArraysCoreTrackerExt = ["GPUArraysCore", "Tracker"]
     ArrayInterfaceMetalExt = "Metal"
     ArrayInterfaceReverseDiffExt = "ReverseDiff"
     ArrayInterfaceSparseArraysExt = "SparseArrays"
@@ -275,9 +276,9 @@ version = "1.1.1"
 
 [[deps.CairoMakie]]
 deps = ["CRC32c", "Cairo", "Cairo_jll", "Colors", "FileIO", "FreeType", "GeometryBasics", "LinearAlgebra", "Makie", "PrecompileTools"]
-git-tree-sha1 = "9bd45574379e50579a78774334f4a1f1238c0af5"
+git-tree-sha1 = "3495bfc164949714579501b825b8e5e2cce7c56f"
 uuid = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
-version = "0.13.10"
+version = "0.15.14"
 
 [[deps.Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "CompilerSupportLibraries_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "Libdl", "Pixman_jll", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
@@ -363,14 +364,16 @@ uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
 version = "0.4.4"
 
 [[deps.CommonSolve]]
-git-tree-sha1 = "f54afab101687a7049833d07636418a83e9a250b"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "6c389fa857f6ca5a95474b52a52023fd77f24cb7"
 uuid = "38540f10-b2f7-11e9-35d8-d573e4eb0ff2"
-version = "0.2.12"
+version = "0.2.14"
 
 [[deps.CommonWorldInvalidations]]
-git-tree-sha1 = "ef2022bff55342a8c9846cdf218f62e475f0444d"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "bc209b1a67dd03551fe305d72e88128764b89cf5"
 uuid = "f70d9fcc-98c5-4d4a-abd7-e4cdeebd8ca8"
-version = "1.1.2"
+version = "1.2.0"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -400,6 +403,12 @@ weakdeps = ["InverseFunctions"]
 
     [deps.CompositionsBase.extensions]
     CompositionsBaseInverseFunctionsExt = "InverseFunctions"
+
+[[deps.ComputePipeline]]
+deps = ["Observables", "Preferences"]
+git-tree-sha1 = "7bc84b769c1d384315e7b5c4ac03a6c303e6cf35"
+uuid = "95dc2771-c249-4cd0-9c9f-1f3b4330693c"
+version = "0.1.8"
 
 [[deps.Conda]]
 deps = ["Downloads", "JSON", "VersionParsing"]
@@ -453,9 +462,9 @@ version = "1.16.0"
 
 [[deps.DataFrames]]
 deps = ["Compat", "DataAPI", "DataStructures", "Future", "InlineStrings", "InvertedIndices", "IteratorInterfaceExtensions", "LinearAlgebra", "Markdown", "Missings", "PooledArrays", "PrecompileTools", "PrettyTables", "Printf", "Random", "Reexport", "SentinelArrays", "SortingAlgorithms", "Statistics", "TableTraits", "Tables", "Unicode"]
-git-tree-sha1 = "d8928e9169ff76c6281f39a659f9bca3a573f24c"
+git-tree-sha1 = "5fab31e2e01e70ad66e3e24c968c264d1cf166d6"
 uuid = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-version = "1.8.1"
+version = "1.8.2"
 
 [[deps.DataManipulation]]
 deps = ["Accessors", "AccessorsExtra", "DataPipes", "Dictionaries", "FlexiGroups", "FlexiMaps", "InverseFunctions", "Reexport", "Skipper", "StructArrays"]
@@ -528,9 +537,9 @@ version = "1.11.0"
 
 [[deps.Distributions]]
 deps = ["AliasTables", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "Roots", "SpecialFunctions", "Statistics", "StatsAPI", "StatsBase", "StatsFuns"]
-git-tree-sha1 = "d2facc77c08c1c2bfb1a77c148edd05b3db5410b"
+git-tree-sha1 = "a958ab3a40c755563f5e1405c0846cb0446bf19d"
 uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
-version = "0.25.130"
+version = "0.25.131"
 
     [deps.Distributions.extensions]
     DistributionsChainRulesCoreExt = "ChainRulesCore"
@@ -573,9 +582,9 @@ version = "2.2.9"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "e6c4a6407a949e79a9d3f249bf49e6987c80e01f"
+git-tree-sha1 = "f4d39eee89f1e58c26bf447f1d4156c0125d6838"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.8.2+0"
+version = "2.8.3+0"
 
 [[deps.ExprTools]]
 git-tree-sha1 = "d2e49e7efd29719d6f28b891b0e0e159daa9d2b4"
@@ -583,10 +592,10 @@ uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
 version = "0.1.11"
 
 [[deps.FFMPEG_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "eaa040768ea663ca695d442be1bc97edfe6824f2"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "PCRE2_jll", "Zlib_jll", "libaom_jll", "libass_jll", "libfdk_aac_jll", "libva_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "7a58e45171b63ed4782f2d36fdee8713a469e6e0"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "6.1.3+0"
+version = "8.1.2+0"
 
 [[deps.FFTA]]
 deps = ["AbstractFFTs", "DocStringExtensions", "LinearAlgebra", "MuladdMacro", "Primes", "Random", "Reexport"]
@@ -607,10 +616,20 @@ version = "1.20.0"
     HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [[deps.FilePaths]]
-deps = ["FilePathsBase", "MacroTools", "Reexport", "Requires"]
-git-tree-sha1 = "919d9412dbf53a2e6fe74af62a73ceed0bce0629"
+deps = ["FilePathsBase", "MacroTools", "Reexport"]
+git-tree-sha1 = "a1b2fbfe98503f15b665ed45b3d149e5d8895e4c"
 uuid = "8fc22ac5-c921-52a6-82fd-178b2807b824"
-version = "0.8.3"
+version = "0.9.0"
+
+    [deps.FilePaths.extensions]
+    FilePathsGlobExt = "Glob"
+    FilePathsURIParserExt = "URIParser"
+    FilePathsURIsExt = "URIs"
+
+    [deps.FilePaths.weakdeps]
+    Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+    URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+    URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [[deps.FilePathsBase]]
 deps = ["Compat", "Dates"]
@@ -629,9 +648,9 @@ version = "1.11.0"
 
 [[deps.FillArrays]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "2f979084d1e13948a3352cf64a25df6bd3b4dca3"
+git-tree-sha1 = "5bad39456d9f0166184fce2248783dd9862645c1"
 uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
-version = "1.16.0"
+version = "1.17.0"
 weakdeps = ["PDMats", "SparseArrays", "StaticArrays", "Statistics"]
 
     [deps.FillArrays.extensions]
@@ -725,15 +744,16 @@ uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
 version = "1.11.0"
 
 [[deps.Gamma]]
-git-tree-sha1 = "86f86b6168a016ed88e4ae4e64577b98c3b59e8e"
+deps = ["LogExpFunctions"]
+git-tree-sha1 = "becc397f7cfb06e343496ae6ffb04818a851da51"
 uuid = "a0844989-3bd2-4988-8bea-c9407ab0941b"
-version = "1.1.0"
+version = "1.2.0"
 
 [[deps.GeometryBasics]]
 deps = ["EarCut_jll", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
-git-tree-sha1 = "364685f5ffde25deb1bbcfd5bb278a5c6b7a9b37"
+git-tree-sha1 = "592cfb5ed8b02804f6a9c04091571c393081f73a"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.5.11"
+version = "0.5.12"
 
     [deps.GeometryBasics.extensions]
     ExtentsExt = "Extents"
@@ -792,26 +812,21 @@ weakdeps = ["Distributed", "SharedArrays"]
 
 [[deps.GridLayoutBase]]
 deps = ["GeometryBasics", "InteractiveUtils", "Observables"]
-git-tree-sha1 = "93d5c27c8de51687a2c70ec0716e6e76f298416f"
+git-tree-sha1 = "ef70da5e123a06a29e2d6ddff0f09985bc226491"
 uuid = "3955a311-db13-416c-9275-1d80ed98e5e9"
-version = "0.11.2"
-
-[[deps.Grisu]]
-git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
-uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
-version = "1.0.2"
+version = "0.11.3"
 
 [[deps.HDF5_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "aws_c_s3_jll", "dlfcn_win32_jll", "libaec_jll", "mpif_jll"]
-git-tree-sha1 = "45337643a2d97262d5fe72ce1f13e8a662d13d62"
+git-tree-sha1 = "8dd4e7d13617134fccede29e5b576380ab5d9199"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "2.1.2+0"
+version = "2.2.1+0"
 
 [[deps.HarfBuzz_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll"]
-git-tree-sha1 = "f923f9a774fcf3f5cb761bfa43aeadd689714813"
+git-tree-sha1 = "c3f99f8e7c98031b8845ece9db86dca713ab9bf8"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
-version = "8.5.1+0"
+version = "100.14003.0+0"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "XML2_jll", "Xorg_libpciaccess_jll"]
@@ -827,9 +842,9 @@ version = "0.3.30"
 
 [[deps.IJulia]]
 deps = ["Base64", "Conda", "Dates", "InteractiveUtils", "Logging", "Markdown", "Pkg", "PrecompileTools", "Printf", "REPL", "Random", "SHA", "Sockets", "UUIDs", "ZMQ"]
-git-tree-sha1 = "d9ea0eeac84e4a7397858847c8b5f1d4ef515ded"
+git-tree-sha1 = "102656c4efc9737f892e1bca7e66ae374c650740"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.34.2"
+version = "1.34.4"
 
     [deps.IJulia.extensions]
     IJuliaPythonCallExt = "PythonCall"
@@ -864,9 +879,9 @@ version = "0.10.5"
 
 [[deps.ImageIO]]
 deps = ["FileIO", "IndirectArrays", "JpegTurbo", "LazyModules", "Netpbm", "OpenEXR", "PNGFiles", "QOI", "Sixel", "TiffImages", "UUIDs", "WebP"]
-git-tree-sha1 = "696144904b76e1ca433b886b4e7edd067d76cbf7"
+git-tree-sha1 = "f0f005f997dfb8c5fe23920d99458a9619873893"
 uuid = "82e4d734-157c-48bb-816b-45c225c6df19"
-version = "0.6.9"
+version = "0.6.10"
 
 [[deps.ImageMetadata]]
 deps = ["AxisArrays", "ImageAxes", "ImageBase", "ImageCore"]
@@ -919,20 +934,24 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 version = "1.11.0"
 
 [[deps.Interpolations]]
-deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "Requires", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
-git-tree-sha1 = "88a101217d7cb38a7b481ccd50d21876e1d1b0e0"
+deps = ["Adapt", "AxisAlgorithms", "ChainRulesCore", "LinearAlgebra", "OffsetArrays", "Random", "Ratios", "SharedArrays", "SparseArrays", "StaticArrays", "WoodburyMatrices"]
+git-tree-sha1 = "48922d06068130f87e43edef52382e6a94305ae6"
 uuid = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
-version = "0.15.1"
-weakdeps = ["Unitful"]
+version = "0.16.3"
 
     [deps.Interpolations.extensions]
+    InterpolationsForwardDiffExt = "ForwardDiff"
     InterpolationsUnitfulExt = "Unitful"
+
+    [deps.Interpolations.weakdeps]
+    ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+    Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [[deps.IntervalArithmetic]]
 deps = ["CRlibm", "CoreMath", "MacroTools", "OpenBLASConsistentFPCSR_jll", "Printf", "Random", "RoundingEmulator"]
-git-tree-sha1 = "c3ee408ae340565f41699e3a3fa1053698c7626e"
+git-tree-sha1 = "ff294afb9a15d31d8d7422da138844641a73135f"
 uuid = "d1acc4aa-44c8-5952-acd4-ba5d80a2a253"
-version = "1.0.10"
+version = "1.0.11"
 
     [deps.IntervalArithmetic.extensions]
     IntervalArithmeticArblibExt = "Arblib"
@@ -958,12 +977,16 @@ version = "1.0.10"
 git-tree-sha1 = "79d6bd28c8d9bccc2229784f1bd637689b256377"
 uuid = "8197267c-284f-5f27-9208-e0e47529a953"
 version = "0.7.14"
-weakdeps = ["Random", "RecipesBase", "Statistics"]
 
     [deps.IntervalSets.extensions]
     IntervalSetsRandomExt = "Random"
     IntervalSetsRecipesBaseExt = "RecipesBase"
     IntervalSetsStatisticsExt = "Statistics"
+
+    [deps.IntervalSets.weakdeps]
+    Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[deps.InverseFunctions]]
 git-tree-sha1 = "a779299d77cd080bf77b97535acecd73e1c5e5cb"
@@ -1009,9 +1032,9 @@ version = "1.8.0"
 
 [[deps.JSON]]
 deps = ["Dates", "Logging", "Parsers", "PrecompileTools", "StructUtils", "UUIDs", "Unicode"]
-git-tree-sha1 = "c89d196f5ffb64bfbf80985b699ea913b0d2c211"
+git-tree-sha1 = "c7345ab1a7ca4dc8a02c9f6510da0d9857bbe513"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "1.6.1"
+version = "1.7.1"
 
     [deps.JSON.extensions]
     JSONArrowExt = ["ArrowTypes"]
@@ -1039,9 +1062,9 @@ version = "0.1.6"
 
 [[deps.JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1dae3057da6f2b9c857afef03177bbdc7c4afe92"
+git-tree-sha1 = "037babc10853eeb8e585418922246cb97b8e5b74"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "3.2.0+0"
+version = "3.2.0+1"
 
 [[deps.JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
@@ -1099,9 +1122,9 @@ weakdeps = ["Serialization"]
     SerializationExt = ["Serialization"]
 
 [[deps.LaTeXStrings]]
-git-tree-sha1 = "dda21b8cbd6a6c40d9d02a73230f9d70fed6918c"
+git-tree-sha1 = "f88f3ccef05a6a72a0cf0ed417c8fd68530f4ab2"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.4.0"
+version = "1.4.1"
 
 [[deps.LayoutPointers]]
 deps = ["ArrayInterface", "LinearAlgebra", "ManualMemory", "SIMDTypes", "Static", "StaticArrayInterface"]
@@ -1126,9 +1149,9 @@ version = "0.3.1"
 
 [[deps.LeftChildRightSiblingTrees]]
 deps = ["AbstractTrees"]
-git-tree-sha1 = "95ba48564903b43b2462318aa243ee79d81135ff"
+git-tree-sha1 = "d4816abce26971e3237b46a47b99991f306e4832"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
-version = "0.2.1"
+version = "0.3.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -1208,9 +1231,9 @@ version = "1.12.0"
 
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
+git-tree-sha1 = "bba2d9aa057d8f126415de240573e86a8f39d2a1"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.29"
+version = "1.0.1"
 
     [deps.LogExpFunctions.extensions]
     LogExpFunctionsChainRulesCoreExt = "ChainRulesCore"
@@ -1246,9 +1269,9 @@ version = "1.10.1+0"
 
 [[deps.MPIABI_jll]]
 deps = ["Artifacts", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
-git-tree-sha1 = "9be143b6045719e8fb019d2b3bc2aebad1184fef"
+git-tree-sha1 = "c0ab44a826d1a8219715078f79c265a11292db86"
 uuid = "b5ada748-db0f-5fc0-8972-9331c762740c"
-version = "0.1.5+0"
+version = "1.0.0+0"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "Libdl", "MPIPreferences", "TOML"]
@@ -1274,22 +1297,22 @@ uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 version = "0.5.16"
 
 [[deps.Makie]]
-deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "MakieCore", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "PNGFiles", "Packing", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "Showoff", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
-git-tree-sha1 = "1d7d16f0e02ec063becd7a140f619b2ffe5f2b11"
+deps = ["Animations", "Base64", "CRC32c", "ColorBrewer", "ColorSchemes", "ColorTypes", "Colors", "ComputePipeline", "Contour", "Dates", "DelaunayTriangulation", "Distributions", "DocStringExtensions", "Downloads", "FFMPEG_jll", "FileIO", "FilePaths", "FixedPointNumbers", "Format", "FreeType", "FreeTypeAbstraction", "GeometryBasics", "GridLayoutBase", "ImageBase", "ImageIO", "InteractiveUtils", "Interpolations", "IntervalSets", "InverseFunctions", "Isoband", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "MacroTools", "Markdown", "MathTeXEngine", "Observables", "OffsetArrays", "PNGFiles", "Packing", "Pkg", "PlotUtils", "PolygonOps", "PrecompileTools", "Printf", "REPL", "Random", "RelocatableFolders", "Scratch", "ShaderAbstractions", "SignedDistanceFields", "SparseArrays", "Statistics", "StatsBase", "StatsFuns", "StructArrays", "TriplotBase", "UnicodeFun", "Unitful"]
+git-tree-sha1 = "37b10d17f74f54dc5fa7d3c6c20fd75613c71d80"
 uuid = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
-version = "0.22.10"
+version = "0.24.14"
 
-[[deps.MakieCore]]
-deps = ["ColorTypes", "GeometryBasics", "IntervalSets", "Observables"]
-git-tree-sha1 = "c3159eb1e3aa3e409edbb71f4035ed8b1fc16e23"
-uuid = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
-version = "0.9.5"
+    [deps.Makie.extensions]
+    MakieDynamicQuantitiesExt = "DynamicQuantities"
+
+    [deps.Makie.weakdeps]
+    DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 
 [[deps.MakieExtra]]
 deps = ["AccessorsExtra", "DataManipulation", "InverseFunctions", "KwdefHelpers", "LinearAlgebra", "Makie", "NonNegLeastSquares", "PyFormattedStrings", "Reexport", "StructHelpers"]
-git-tree-sha1 = "99efafd998e4065cc6a720629a1da2fbf1003954"
+git-tree-sha1 = "633b2cb43500ba6aa92955e58985fd979f7ab94d"
 uuid = "54e234d5-9986-40d8-815f-a5e42de435f6"
-version = "0.1.69"
+version = "0.2.8"
 
     [deps.MakieExtra.extensions]
     GLMakieExt = "GLMakie"
@@ -1384,9 +1407,9 @@ version = "1.1.4"
 
 [[deps.NetCDF_jll]]
 deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libaec_jll", "libzip_jll"]
-git-tree-sha1 = "b9584045c11c1c89d24083bb654c37b73a447877"
+git-tree-sha1 = "bbd7ae15594503021b388a1090cca6ea431e0a8f"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
-version = "401.1000.100+0"
+version = "401.1000.101+0"
 
 [[deps.Netpbm]]
 deps = ["FileIO", "ImageCore", "ImageMetadata"]
@@ -1443,9 +1466,9 @@ version = "0.3.3"
 
 [[deps.OpenEXR_jll]]
 deps = ["Artifacts", "Imath_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "0d621a4beb5e48d195f907c3c5b0bea285d9ff9d"
+git-tree-sha1 = "fd09db52a90efaae33a3d91f0bc71a22c429e8f1"
 uuid = "18a262bb-aa17-5467-a713-aee519bc75cb"
-version = "3.4.13+0"
+version = "3.4.14+0"
 
 [[deps.OpenLibm_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -1476,9 +1499,9 @@ uuid = "91d4177d-7536-5919-b921-800302f37372"
 version = "1.6.1+0"
 
 [[deps.OrderedCollections]]
-git-tree-sha1 = "94ba93778373a53bfd5a0caaf7d809c445292ff4"
+git-tree-sha1 = "05f45c2e0de6259db764adbfd2f1dc6d3f8de13c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.8.2"
+version = "2.0.1"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -1503,9 +1526,9 @@ version = "0.4.5"
 
 [[deps.PackageCompiler]]
 deps = ["Artifacts", "Glob", "LazyArtifacts", "Libdl", "Pkg", "Printf", "RelocatableFolders", "TOML", "UUIDs", "p7zip_jll"]
-git-tree-sha1 = "5193091a937c1e84cab042d55f8071dd2116c6f2"
+git-tree-sha1 = "9ca7f3bd9d704c9f78ed80400641b0a1472e6814"
 uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
-version = "2.3.0"
+version = "2.4.1"
 
 [[deps.Packing]]
 deps = ["GeometryBasics"]
@@ -1521,21 +1544,21 @@ version = "0.5.12"
 
 [[deps.Pango_jll]]
 deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "FriBidi_jll", "Glib_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "58e5ed5e386e156bd93e86b305ebd21ac63d2d04"
+git-tree-sha1 = "1912a9f1b9ca55005b03ba075f8e19993583e237"
 uuid = "36c8627f-9965-5494-a995-c6b170f724f3"
-version = "1.57.1+0"
+version = "1.58.2+0"
 
 [[deps.Parameters]]
 deps = ["OrderedCollections", "UnPack"]
-git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
+git-tree-sha1 = "0ed04c372da78ff5b98e35e3bd4f4ca9931299cc"
 uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
-version = "0.12.3"
+version = "0.13.1"
 
 [[deps.Parsers]]
 deps = ["Dates", "PrecompileTools", "UUIDs"]
-git-tree-sha1 = "32a4e09c5f29402573d673901778a0e03b0807b9"
+git-tree-sha1 = "3de8f5e6e90ebfa8d6d1f86997d6cdcd6a912ff3"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.8.6"
+version = "2.8.7"
 
 [[deps.Pixman_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl"]
@@ -1554,9 +1577,9 @@ weakdeps = ["REPL"]
 
 [[deps.PkgToSoftwareBOM]]
 deps = ["Artifacts", "Downloads", "LicenseCheck", "Logging", "Pkg", "Reexport", "RegistryInstances", "SPDX", "UUIDs"]
-git-tree-sha1 = "30a1cf0b8fac0400f7f9790b1ad8ad89db325b84"
+git-tree-sha1 = "5358d782f4d7c80d9398e304fedf8c2283edbbf5"
 uuid = "6254a0f9-6143-4104-aa2e-fd339a2830a6"
-version = "0.1.19"
+version = "0.2.0"
 
 [[deps.PkgVersion]]
 deps = ["Pkg"]
@@ -1588,22 +1611,24 @@ uuid = "647866c9-e3ac-4575-94e7-e3d426903924"
 version = "0.1.2"
 
 [[deps.Polynomials]]
-deps = ["LinearAlgebra", "OrderedCollections", "RecipesBase", "Requires", "Setfield", "SparseArrays"]
-git-tree-sha1 = "555c272d20fc80a2658587fb9bbda60067b93b7c"
+deps = ["LinearAlgebra", "OrderedCollections", "Setfield", "SparseArrays"]
+git-tree-sha1 = "da6a2b41f576505c800df8854d691670638449a0"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "4.0.19"
+version = "4.1.2"
 
     [deps.Polynomials.extensions]
     PolynomialsChainRulesCoreExt = "ChainRulesCore"
     PolynomialsFFTWExt = "FFTW"
-    PolynomialsMakieCoreExt = "MakieCore"
+    PolynomialsMakieExt = "Makie"
     PolynomialsMutableArithmeticsExt = "MutableArithmetics"
+    PolynomialsRecipesBaseExt = "RecipesBase"
 
     [deps.Polynomials.weakdeps]
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
     FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-    MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
     MutableArithmetics = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [[deps.PooledArrays]]
 deps = ["DataAPI", "Future"]
@@ -1625,15 +1650,17 @@ version = "1.5.2"
 
 [[deps.PrettyTables]]
 deps = ["Crayons", "LaTeXStrings", "Markdown", "PrecompileTools", "Printf", "REPL", "Reexport", "StringManipulation", "Tables"]
-git-tree-sha1 = "624de6279ab7d94fc9f672f0068107eb6619732c"
+git-tree-sha1 = "1b8aa19f229b1cea7fc93874a52e49db6a854450"
 uuid = "08abe8d2-0d0c-5749-adfa-8a2ac140af0d"
-version = "3.3.2"
+version = "3.4.8"
 
     [deps.PrettyTables.extensions]
+    PrettyTablesExcelExt = "XLSX"
     PrettyTablesTypstryExt = "Typstry"
 
     [deps.PrettyTables.weakdeps]
     Typstry = "f0ed7684-a786-439e-b1e3-3b82803b501e"
+    XLSX = "fdbf4ff8-1666-58a4-91e7-1b58723a45e0"
 
 [[deps.Primes]]
 deps = ["IntegerMathUtils"]
@@ -1682,9 +1709,9 @@ version = "1.0.2"
 
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "9da16da70037ba9d701192e27befedefb91ec284"
+git-tree-sha1 = "5e8e8b0ab68215d7a2b14b9921a946fee794749e"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.11.2"
+version = "2.11.3"
 
     [deps.QuadGK.extensions]
     QuadGKEnzymeExt = "Enzyme"
@@ -1716,12 +1743,6 @@ weakdeps = ["FixedPointNumbers"]
 
     [deps.Ratios.extensions]
     RatiosFixedPointNumbersExt = "FixedPointNumbers"
-
-[[deps.RecipesBase]]
-deps = ["PrecompileTools"]
-git-tree-sha1 = "5c3d09cc4f31f5fc6af001c250bf1278733100ff"
-uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.3.4"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -1764,15 +1785,15 @@ version = "0.9.0"
 
 [[deps.Rmath_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "58cdd8fb2201a6267e1db87ff148dd6c1dbd8ad8"
+git-tree-sha1 = "6d40b2fe70437b01397d2a4d5b020008da4e7019"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.5.1+0"
+version = "0.5.2+0"
 
 [[deps.Roots]]
 deps = ["Accessors", "CommonSolve", "Printf"]
-git-tree-sha1 = "7fb25a964849d90a0446366cdefca822e0e84900"
+git-tree-sha1 = "4db094d5e079abbda658acfe1c4d098430417717"
 uuid = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
-version = "3.0.6"
+version = "3.0.8"
 
     [deps.Roots.extensions]
     RootsChainRulesCoreExt = "ChainRulesCore"
@@ -1823,9 +1844,10 @@ uuid = "47358f48-d834-4249-91f5-f6185eb3d540"
 version = "0.5.0"
 
 [[deps.SciMLPublic]]
-git-tree-sha1 = "cf9aaf8b9ed5db993259ea8b24cf2b7ba9bd3b79"
+deps = ["PrecompileTools"]
+git-tree-sha1 = "74685afb51732a464fbce79a72708f7c4203ceb7"
 uuid = "431bcebd-1456-4ced-9d72-93c2757fff0b"
-version = "1.2.4"
+version = "1.3.0"
 
 [[deps.Scratch]]
 deps = ["Dates"]
@@ -1859,12 +1881,6 @@ version = "0.5.0"
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 version = "1.11.0"
-
-[[deps.Showoff]]
-deps = ["Dates", "Grisu"]
-git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
-uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-version = "1.0.3"
 
 [[deps.SignedDistanceFields]]
 deps = ["Statistics"]
@@ -1918,9 +1934,9 @@ version = "1.12.0"
 
 [[deps.SpecialFunctions]]
 deps = ["IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "5acc6a41b3082920f79ca3c759acbcecf18a8d78"
+git-tree-sha1 = "429071b23f4c9a13fb6582f807cc2ef454082408"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.7.1"
+version = "2.9.0"
 weakdeps = ["ChainRulesCore"]
 
     [deps.SpecialFunctions.extensions]
@@ -1940,9 +1956,9 @@ version = "0.1.2"
 
 [[deps.Static]]
 deps = ["CommonWorldInvalidations", "IfElse", "PrecompileTools", "SciMLPublic"]
-git-tree-sha1 = "4abff9ad312e476839c25b9398f619255af9a0e4"
+git-tree-sha1 = "474a5283ad435618090122872eea6a8165ea6bcf"
 uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
-version = "1.4.5"
+version = "1.4.6"
 
 [[deps.StaticArrayInterface]]
 deps = ["ArrayInterface", "Compat", "IfElse", "LinearAlgebra", "PrecompileTools", "SciMLPublic", "Static"]
@@ -1957,9 +1973,9 @@ weakdeps = ["OffsetArrays", "StaticArrays"]
 
 [[deps.StaticArrays]]
 deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
-git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+git-tree-sha1 = "e206cf4850fd7ac4255ffd2b98922f563e18ac53"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.9.18"
+version = "1.9.20"
 weakdeps = ["ChainRulesCore", "Statistics"]
 
     [deps.StaticArrays.extensions]
@@ -1973,9 +1989,9 @@ version = "1.4.4"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+git-tree-sha1 = "e2b53ce13a53367e96601081e33d34746b571bad"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.11.1"
+version = "1.11.5"
 weakdeps = ["SparseArrays"]
 
     [deps.Statistics.extensions]
@@ -1989,15 +2005,15 @@ version = "1.8.0"
 
 [[deps.StatsBase]]
 deps = ["AliasTables", "DataAPI", "DataStructures", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "e4d7a1a0edc20af42689ea6f4f3587a2175d50ee"
+git-tree-sha1 = "adb9da019510162e67a4493fc235c23203d8b09e"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.34.12"
+version = "0.34.13"
 
 [[deps.StatsFuns]]
 deps = ["HypergeometricFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
-git-tree-sha1 = "91f091a8716a6bb38417a6e6f274602a19aaa685"
+git-tree-sha1 = "91a5737baed20ee31f3faea0e51f57461f6a689e"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "1.5.2"
+version = "2.2.1"
 weakdeps = ["ChainRulesCore", "InverseFunctions"]
 
     [deps.StatsFuns.extensions]
@@ -2012,9 +2028,9 @@ version = "0.5.9"
 
 [[deps.StringManipulation]]
 deps = ["PrecompileTools"]
-git-tree-sha1 = "8a90c1d77c3277a5d43b83927b3cbe2c70a37484"
+git-tree-sha1 = "773065c6e0e903924a9d838259be74338422aef2"
 uuid = "892a3eda-7b42-436c-8928-eab12a02cf0e"
-version = "0.4.7"
+version = "0.5.0"
 
 [[deps.StructArrays]]
 deps = ["ConstructionBase", "DataAPI", "Tables"]
@@ -2045,9 +2061,9 @@ version = "1.6.0"
 
 [[deps.StructUtils]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "82bee338d650aa515f31866c460cb7e3bcef90b8"
+git-tree-sha1 = "2d0fc55c61321ba245c47be599570d11bac50303"
 uuid = "ec057cc2-7a8d-4b58-b3b3-92acb9f63b42"
-version = "2.8.2"
+version = "2.8.5"
 
     [deps.StructUtils.extensions]
     StructUtilsMeasurementsExt = ["Measurements"]
@@ -2079,9 +2095,9 @@ version = "1.0.3"
 
 [[deps.TZJData]]
 deps = ["Artifacts"]
-git-tree-sha1 = "72df96b3a595b7aab1e101eb07d2a435963a97e2"
+git-tree-sha1 = "d3b30a9f29a898e21fb4bdf280101b7a12e1f39c"
 uuid = "dc5dba14-91b3-4cab-a142-028a31da12f7"
-version = "1.5.0+2025b"
+version = "1.5.1+2025b"
 
 [[deps.TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -2091,9 +2107,9 @@ version = "1.0.1"
 
 [[deps.Tables]]
 deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "OrderedCollections", "TableTraits"]
-git-tree-sha1 = "0f38a06c83f0007bbab3cf911262841c9a0f07e0"
+git-tree-sha1 = "a94d9bdda1b7bed0046cea645639ab3f62196fac"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.13.0"
+version = "1.14.0"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
@@ -2108,9 +2124,9 @@ version = "0.1.1"
 
 [[deps.TerminalLoggers]]
 deps = ["LeftChildRightSiblingTrees", "Logging", "Markdown", "Printf", "ProgressLogging", "UUIDs"]
-git-tree-sha1 = "f133fab380933d042f6796eda4e130272ba520ca"
+git-tree-sha1 = "81c9b4137edfe56a56efcdcb35d721b2ce3e2416"
 uuid = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
-version = "0.1.7"
+version = "0.1.8"
 
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
@@ -2119,14 +2135,14 @@ version = "1.11.0"
 
 [[deps.TestItemRunner]]
 deps = ["Pkg", "TOML", "Test", "TestItems", "UUIDs"]
-git-tree-sha1 = "76f275a3f3d83ece88ec69d73058048de5acb1dc"
+git-tree-sha1 = "9edf3b25f95dd92da044289a5c13cbdcfa142a77"
 uuid = "f8b46487-2199-4994-9208-9a1283c18c0a"
-version = "1.1.4"
+version = "1.3.2"
 
 [[deps.TestItems]]
-git-tree-sha1 = "42fd9023fef18b9b78c8343a4e2f3813ffbcefcb"
+git-tree-sha1 = "a6dd904babc04670c784f81b67957a3545271610"
 uuid = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
-version = "1.0.0"
+version = "1.1.0"
 
 [[deps.ThreadingUtilities]]
 deps = ["ManualMemory"]
@@ -2145,10 +2161,12 @@ deps = ["Artifacts", "Dates", "Downloads", "InlineStrings", "Mocking", "Printf",
 git-tree-sha1 = "d422301b2a1e294e3e4214061e44f338cafe18a2"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 version = "1.22.2"
-weakdeps = ["RecipesBase"]
 
     [deps.TimeZones.extensions]
     TimeZonesRecipesBaseExt = "RecipesBase"
+
+    [deps.TimeZones.weakdeps]
+    RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -2161,9 +2179,9 @@ uuid = "981d1d27-644d-49a2-9326-4793e63143c3"
 version = "0.1.0"
 
 [[deps.URIs]]
-git-tree-sha1 = "3b0738bd7c5645641845da25cbd99800b8718689"
+git-tree-sha1 = "908fec9df6c5de98548ead82a468c95ccf6cd263"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.6.2"
+version = "1.7.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -2273,6 +2291,12 @@ git-tree-sha1 = "1a4a26870bf1e5d26cd585e38038d399d7e65706"
 uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
 version = "1.3.8+0"
 
+[[deps.Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
+git-tree-sha1 = "75e00946e43621e09d431d9b95818ee751e6b2ef"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "6.0.2+0"
+
 [[deps.Xorg_libXrender_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
 git-tree-sha1 = "7ed9347888fac59a618302ee38216dd0379c480d"
@@ -2346,9 +2370,9 @@ version = "0.3.2+0"
 
 [[deps.aws_c_http_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_compression_jll", "aws_c_io_jll"]
-git-tree-sha1 = "e358d5a001ef7afbd4f8c5225322512819cda2f2"
+git-tree-sha1 = "3fb8685778068de502c72fec5dd8075e037cee15"
 uuid = "3254fc65-9028-534d-aa9d-d76d128babc6"
-version = "0.10.13+0"
+version = "0.10.15+0"
 
 [[deps.aws_c_io_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "aws_c_cal_jll", "aws_c_common_jll", "s2n_tls_jll"]
@@ -2394,20 +2418,26 @@ version = "1.1.7+0"
 
 [[deps.libaom_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "850b06095ee71f0135d644ffd8a52850699581ed"
+git-tree-sha1 = "ef17c47d22224aaecc76e597ab21a072e025cf7b"
 uuid = "a4ae2306-e953-59d6-aa16-d00cac43593b"
-version = "3.13.3+0"
+version = "3.14.1+0"
 
 [[deps.libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Zlib_jll"]
-git-tree-sha1 = "125eedcb0a4a0bba65b657251ce1d27c8714e9d6"
+git-tree-sha1 = "cb007192783c56d8249db4cf0e3495001edfe414"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.17.4+0"
+version = "0.17.5+0"
 
 [[deps.libblastrampoline_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.15.0+0"
+
+[[deps.libdrm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libpciaccess_jll"]
+git-tree-sha1 = "28e57478e8a160d346a19c28b3fffb9273bcc9c2"
+uuid = "8e53e030-5e6c-5a89-a30b-be5b7263a166"
+version = "2.4.134+0"
 
 [[deps.libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2433,6 +2463,12 @@ git-tree-sha1 = "011b0a7331b41c25524b64dc42afc9683ee89026"
 uuid = "a9144af2-ca23-56d9-984f-0d03f7b5ccf8"
 version = "1.0.21+0"
 
+[[deps.libva_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll", "Xorg_libXext_jll", "Xorg_libXfixes_jll", "libdrm_jll"]
+git-tree-sha1 = "7dbf96baae3310fe2fa0df0ccbb3c6288d5816c9"
+uuid = "9a156e7d-b971-5f62-b2c9-67348b8fb97c"
+version = "2.23.0+0"
+
 [[deps.libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll"]
 git-tree-sha1 = "11e1772e7f3cc987e9d3de991dd4f6b2602663a5"
@@ -2447,9 +2483,9 @@ version = "1.6.0+0"
 
 [[deps.libzip_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "OpenSSL_jll", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "86addc139bca85fdf9e7741e10977c45785727b7"
+git-tree-sha1 = "363a1c43b8cb92e7b3ff7f504ef9a0a83c548e97"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
-version = "1.11.3+0"
+version = "1.11.4+0"
 
 [[deps.licensecheck_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -2459,9 +2495,9 @@ version = "0.4.0+0"
 
 [[deps.mpif_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIABI_jll", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML"]
-git-tree-sha1 = "a8083ee0737c243c8f40a4ba86a0956997facb73"
+git-tree-sha1 = "a06fcd368cfe6fe2c0eb7b63320d4d27ddcd010d"
 uuid = "9aeb927a-4695-514f-a259-621a69f20ec0"
-version = "0.1.7+0"
+version = "1.0.0+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -2475,9 +2511,9 @@ version = "17.7.0+0"
 
 [[deps.s2n_tls_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "64ae051c6f03044eb7d98027d1b552b4e21e650c"
+git-tree-sha1 = "f3a7831c8a44767ff9e36d41bb1f7b576bbce81c"
 uuid = "cddc5d3d-934d-5d3a-9747-62fc12ea3f48"
-version = "1.7.3+0"
+version = "1.7.8+0"
 
 [[deps.wflow_cli]]
 deps = ["Test", "TestItemRunner", "Wflow"]


### PR DESCRIPTION
Update the Julia Manifest.toml to get the latest dependencies.

__Changed packages__
```
  Installing known registries into `~/.julia`
       Added `General` registry to ~/.julia/registries
    Updating registry at `~/.julia/registries/General.toml`
  Installing 81 artifacts
    Updating `~/work/Wflow.jl/Wflow.jl/Project.toml`
  [6254a0f9] ↑ PkgToSoftwareBOM v0.1.19 ⇒ v0.2.0
    Updating `~/work/Wflow.jl/Wflow.jl/Manifest.toml`
  [7d9f7c33] ↑ Accessors v0.1.44 ⇒ v0.1.45
  [4fba245c] ↑ ArrayInterface v7.28.1 ⇒ v7.30.1
  [f70d9fcc] ↑ CommonWorldInvalidations v1.1.2 ⇒ v1.2.0
  [1a297f60] ↑ FillArrays v1.16.0 ⇒ v1.17.0
  [682c06a0] ↑ JSON v1.6.1 ⇒ v1.7.1
  [1d6d02ad] ↑ LeftChildRightSiblingTrees v0.2.1 ⇒ v0.3.0
  [bac558e1] ↑ OrderedCollections v1.8.2 ⇒ v2.0.1
  [d96e819e] ↑ Parameters v0.12.3 ⇒ v0.13.1
⌅ [69de0a69] ↑ Parsers v2.8.6 ⇒ v2.8.7
  [6254a0f9] ↑ PkgToSoftwareBOM v0.1.19 ⇒ v0.2.0
  [431bcebd] ↑ SciMLPublic v1.2.4 ⇒ v1.3.0
  [aedffcd0] ↑ Static v1.4.5 ⇒ v1.4.6
  [90137ffa] ↑ StaticArrays v1.9.18 ⇒ v1.9.20
  [10745b16] ↑ Statistics v1.11.1 ⇒ v1.11.5
  [ec057cc2] ↑ StructUtils v2.8.2 ⇒ v2.8.5
  [dc5dba14] ↑ TZJData v1.5.0+2025b ⇒ v1.5.1+2025b
  [5d786b92] ↑ TerminalLoggers v0.1.7 ⇒ v0.1.8
  [0234f1f7] ↑ HDF5_jll v2.1.2+0 ⇒ v2.2.1+0
  [b5ada748] ↑ MPIABI_jll v0.1.5+0 ⇒ v1.0.0+0
  [7243133f] ↑ NetCDF_jll v401.1000.100+0 ⇒ v401.1000.101+0
⌅ [3254fc65] ↑ aws_c_http_jll v0.10.13+0 ⇒ v0.10.15+0
  [337d8026] ↑ libzip_jll v1.11.3+0 ⇒ v1.11.4+0
  [9aeb927a] ↑ mpif_jll v0.1.7+0 ⇒ v1.0.0+0
  [cddc5d3d] ↑ s2n_tls_jll v1.7.3+0 ⇒ v1.7.8+0
        Info Packages marked with ⌅ have new versions available but compatibility constraints restrict them from upgrading. To see why use `status --outdated -m`
    Building Conda ─→ `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/8f06b0cfa4c514c7b9546756dbae91fcfbc92dc9/build.log`
    Building IJulia → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/102656c4efc9737f892e1bca7e66ae374c650740/build.log`
        Info We haven't cleaned this depot up for a bit, running Pkg.gc()...
      Active manifest files: 1 found
      Active artifact files: 88 found
      Active scratchspaces: 2 found
     Deleted no artifacts, repos, packages or scratchspaces
```

__Packages still outdated after update__
```
Status `~/work/Wflow.jl/Wflow.jl/Project.toml`
Status Wflow/test/Project.toml
Status server/test/Project.toml
Status build/wflow_cli/Project.toml
Status build/create_binaries/Project.toml
Status utils/formatting/Project.toml
Status utils/export_parameter_data/Project.toml
Status server/Project.toml
Status Wflow/Project.toml
Status docs/Project.toml
```
<details>
<summary>
All package versions
</summary>

```

AbstractFFTs ───────────────────── v1.5.0
AbstractTrees ──────────────────── v0.4.5
Accessors ──────────────────────── v0.1.45
AccessorsExtra ─────────────────── v0.1.102
Adapt ──────────────────────────── v4.7.0
AdaptivePredicates ─────────────── v1.2.0
AliasTables ────────────────────── v1.1.3
Animations ─────────────────────── v0.4.2
Aqua ───────────────────────────── v0.8.16
ArgCheck ───────────────────────── v2.5.0
ArnoldiMethod ──────────────────── v0.4.0
ArrayInterface ─────────────────── v7.30.1
Automa ─────────────────────────── v1.2.0
AxisAlgorithms ─────────────────── v1.1.0
AxisArrays ─────────────────────── v0.4.8
BaseDirs ───────────────────────── v1.4.0
BasicModelInterface ────────────── v0.1.1
BitTwiddlingConvenienceFunctions ─ v0.1.6
Blosc_jll ──────────────────────── v1.21.7+0
Bzip2_jll ──────────────────────── v1.0.9+0
CEnum ──────────────────────────── v0.5.0
CFTime ─────────────────────────── v0.2.10
CPUSummary ─────────────────────── v0.2.7
CRlibm ─────────────────────────── v1.0.2
CRlibm_jll ─────────────────────── v1.0.1+0
Cairo ──────────────────────────── v1.1.1
CairoMakie ─────────────────────── v0.15.14
Cairo_jll ──────────────────────── v1.18.7+0
ChainRulesCore ─────────────────── v1.26.1
CloseOpenIntervals ─────────────── v0.1.13
CodeTracking ───────────────────── v3.0.2
CodecZstd ──────────────────────── v0.8.7
ColorBrewer ────────────────────── v0.4.2
ColorSchemes ───────────────────── v3.31.0
ColorTypes ─────────────────────── v0.12.1
ColorVectorSpace ───────────────── v0.11.0
Colors ─────────────────────────── v0.13.1
Combinatorics ──────────────────── v1.1.0
CommonDataModel ────────────────── v0.4.4
CommonSolve ────────────────────── v0.2.14
CommonWorldInvalidations ───────── v1.2.0
Compat ─────────────────────────── v4.18.1
Compiler ───────────────────────── v0.1.1
CompositionsBase ───────────────── v0.1.2
ComputePipeline ────────────────── v0.1.8
Conda ──────────────────────────── v1.10.3
ConstructionBase ───────────────── v1.6.0
Contour ────────────────────────── v0.6.3
CoreMath ───────────────────────── v0.1.0
CoreMath_jll ───────────────────── v0.1.0+0
CpuId ──────────────────────────── v0.3.1
Crayons ────────────────────────── v4.2.0
DataAPI ────────────────────────── v1.16.0
DataFrames ─────────────────────── v1.8.2
DataManipulation ───────────────── v0.1.22
DataPipes ──────────────────────── v0.3.19
DataStructures ─────────────────── v0.19.6
DataValueInterfaces ────────────── v1.0.0
DelaunayTriangulation ──────────── v1.6.6
DelimitedFiles ─────────────────── v1.9.1
Dictionaries ───────────────────── v0.4.6
DiskArrays ─────────────────────── v0.4.22
DisplayAs ──────────────────────── v0.1.6
Distributions ──────────────────── v0.25.131
DocStringExtensions ────────────── v0.9.5
EarCut_jll ─────────────────────── v2.2.4+0
EnumX ──────────────────────────── v1.0.7
ExactPredicates ────────────────── v2.2.9
Expat_jll ──────────────────────── v2.8.3+0
ExprTools ──────────────────────── v0.1.11
FFMPEG_jll ─────────────────────── v8.1.2+0
FFTA ───────────────────────────── v0.3.1
FileIO ─────────────────────────── v1.20.0
FilePaths ──────────────────────── v0.9.0
FilePathsBase ──────────────────── v0.9.24
FillArrays ─────────────────────── v1.17.0
FixedPointNumbers ──────────────── v0.8.6
FlexiGroups ────────────────────── v0.1.31
FlexiMaps ──────────────────────── v0.1.29
Fontconfig_jll ─────────────────── v2.17.1+0
Format ─────────────────────────── v1.3.7
FreeType ───────────────────────── v4.1.1
FreeType2_jll ──────────────────── v2.14.3+1
FreeTypeAbstraction ────────────── v0.10.8
FriBidi_jll ────────────────────── v1.0.17+0
Gamma ──────────────────────────── v1.2.0
GeometryBasics ─────────────────── v0.5.12
GettextRuntime_jll ─────────────── v0.22.4+0
Giflib_jll ─────────────────────── v5.2.3+0
Glib_jll ───────────────────────── v2.88.3+0
Glob ───────────────────────────── v1.5.0
Graphics ───────────────────────── v1.1.3
Graphite2_jll ──────────────────── v1.3.16+0
Graphs ─────────────────────────── v1.14.0
GridLayoutBase ─────────────────── v0.11.3
HDF5_jll ───────────────────────── v2.2.1+0
HarfBuzz_jll ───────────────────── v100.14003.0+0
Hwloc_jll ──────────────────────── v2.14.0+0
HypergeometricFunctions ────────── v0.3.30
IJulia ─────────────────────────── v1.34.4
IfElse ─────────────────────────── v0.1.1
ImageAxes ──────────────────────── v0.6.12
ImageBase ──────────────────────── v0.1.7
ImageCore ──────────────────────── v0.10.5
ImageIO ────────────────────────── v0.6.10
ImageMetadata ──────────────────── v0.9.10
Imath_jll ──────────────────────── v3.2.2+0
Indexing ───────────────────────── v1.1.1
IndirectArrays ─────────────────── v1.0.0
Inflate ────────────────────────── v0.1.5
InlineStrings ──────────────────── v1.4.5
IntegerMathUtils ───────────────── v0.1.4
Interpolations ─────────────────── v0.16.3
IntervalArithmetic ─────────────── v1.0.11
IntervalSets ───────────────────── v0.7.14
InverseFunctions ───────────────── v0.1.17
InvertedIndices ────────────────── v1.3.1
IrrationalConstants ────────────── v0.2.6
Isoband ────────────────────────── v0.1.1
IterTools ──────────────────────── v1.10.0
IteratorInterfaceExtensions ────── v1.0.0
JLLWrappers ────────────────────── v1.8.0
JSON ───────────────────────────── v1.7.1
JSONSchema ─────────────────────── v1.5.0
JpegTurbo ──────────────────────── v0.1.6
JpegTurbo_jll ──────────────────── v3.2.0+1
JuliaInterpreter ───────────────── v0.11.4
JuliaSyntax ────────────────────── v1.0.2
KernelDensity ──────────────────── v0.6.12
KwdefHelpers ───────────────────── v0.1.0
LAME_jll ───────────────────────── v3.100.3+0
LERC_jll ───────────────────────── v4.1.0+0
LLVMOpenMP_jll ─────────────────── v22.1.7+0
LRUCache ───────────────────────── v1.6.2
LaTeXStrings ───────────────────── v1.4.1
LayoutPointers ─────────────────── v0.1.17
LazilyInitializedFields ────────── v1.3.0
LazyModules ────────────────────── v0.3.1
LeftChildRightSiblingTrees ─────── v0.3.0
Libffi_jll ─────────────────────── v3.4.7+0
Libglvnd_jll ───────────────────── v1.7.1+1
Libiconv_jll ───────────────────── v1.18.0+0
Libmount_jll ───────────────────── v2.42.0+0
Libtiff_jll ────────────────────── v4.7.3+0
Libuuid_jll ────────────────────── v2.42.0+0
LicenseCheck ───────────────────── v0.2.3
LogExpFunctions ────────────────── v1.0.1
LoggingExtras ──────────────────── v1.2.0
LoweredCodeUtils ───────────────── v3.8.0
Lz4_jll ────────────────────────── v1.10.1+0
MPIABI_jll ─────────────────────── v1.0.0+0
MPICH_jll ──────────────────────── v5.0.1+0
MPIPreferences ─────────────────── v0.1.12
MPItrampoline_jll ──────────────── v5.5.6+0
MacroTools ─────────────────────── v0.5.16
Makie ──────────────────────────── v0.24.14
MakieExtra ─────────────────────── v0.2.8
ManualMemory ───────────────────── v0.1.8
MappedArrays ───────────────────── v0.4.3
MarkdownTables ─────────────────── v1.1.0
MathTeXEngine ──────────────────── v0.6.9
MicrosoftMPI_jll ───────────────── v10.1.4+3
Missings ───────────────────────── v1.2.0
Mocking ────────────────────────── v0.8.1
MosaicViews ────────────────────── v0.3.4
MuladdMacro ────────────────────── v0.2.7
NCDatasets ─────────────────────── v0.14.15
NaNMath ────────────────────────── v1.1.4
NetCDF_jll ─────────────────────── v401.1000.101+0
Netpbm ─────────────────────────── v1.1.1
NonNegLeastSquares ─────────────── v0.4.1
Observables ────────────────────── v0.5.5
OffsetArrays ───────────────────── v1.17.0
Ogg_jll ────────────────────────── v1.3.6+0
OpenBLASConsistentFPCSR_jll ────── v0.3.34+0
OpenEXR ────────────────────────── v0.3.3
OpenEXR_jll ────────────────────── v3.4.14+0
OpenMPI_jll ────────────────────── v5.0.11+0
OpenSpecFun_jll ────────────────── v0.5.6+0
Opus_jll ───────────────────────── v1.6.1+0
OrderedCollections ─────────────── v2.0.1
PDMats ─────────────────────────── v0.11.41
PNGFiles ───────────────────────── v0.4.5
PackageCompiler ────────────────── v2.4.1
Packing ────────────────────────── v0.5.1
PaddedViews ────────────────────── v0.5.12
Pango_jll ──────────────────────── v1.58.2+0
Parameters ─────────────────────── v0.13.1
Parsers ────────────────────────── v2.8.7
Pixman_jll ─────────────────────── v0.46.4+0
PkgToSoftwareBOM ───────────────── v0.2.0
PkgVersion ─────────────────────── v0.3.3
PlotUtils ──────────────────────── v1.4.4
Polyester ──────────────────────── v0.7.19
PolyesterWeave ─────────────────── v0.2.2
PolygonOps ─────────────────────── v0.1.2
Polynomials ────────────────────── v4.1.2
PooledArrays ───────────────────── v1.4.3
PrecompileTools ────────────────── v1.3.4
Preferences ────────────────────── v1.5.2
PrettyTables ───────────────────── v3.4.8
Primes ─────────────────────────── v0.5.7
ProgressLogging ────────────────── v0.1.6
ProgressMeter ──────────────────── v1.11.0
PropertyDicts ──────────────────── v0.2.1
PtrArrays ──────────────────────── v1.4.0
PyFormattedStrings ─────────────── v0.1.13
QOI ────────────────────────────── v1.0.2
QuadGK ─────────────────────────── v2.11.3
RangeArrays ────────────────────── v0.3.2
Ratios ─────────────────────────── v0.4.5
Reexport ───────────────────────── v1.2.2
RegistryInstances ──────────────── v0.1.0
RelocatableFolders ─────────────── v1.0.1
Requires ───────────────────────── v1.3.1
Revise ─────────────────────────── v3.17.0
Rmath ──────────────────────────── v0.9.0
Rmath_jll ──────────────────────── v0.5.2+0
Roots ──────────────────────────── v3.0.8
RoundingEmulator ───────────────── v0.2.1
Runic ──────────────────────────── v1.10.0
SIMD ───────────────────────────── v3.7.2
SIMDTypes ──────────────────────── v0.1.0
SPDX ───────────────────────────── v0.5.0
SciMLPublic ────────────────────── v1.3.0
Scratch ────────────────────────── v1.3.0
SentinelArrays ─────────────────── v1.4.10
Setfield ───────────────────────── v1.1.2
ShaderAbstractions ─────────────── v0.5.0
SignedDistanceFields ───────────── v0.4.1
SimpleTraits ───────────────────── v0.9.6
Sixel ──────────────────────────── v0.1.5
Skipper ────────────────────────── v0.1.16
SortingAlgorithms ──────────────── v1.2.3
SpecialFunctions ───────────────── v2.9.0
StableRNGs ─────────────────────── v1.0.4
StackViews ─────────────────────── v0.1.2
Static ─────────────────────────── v1.4.6
StaticArrayInterface ───────────── v1.10.0
StaticArrays ───────────────────── v1.9.20
StaticArraysCore ───────────────── v1.4.4
Statistics ─────────────────────── v1.11.5
StatsAPI ───────────────────────── v1.8.0
StatsBase ──────────────────────── v0.34.13
StatsFuns ──────────────────────── v2.2.1
StrideArraysCore ───────────────── v0.5.9
StringManipulation ─────────────── v0.5.0
StructArrays ───────────────────── v0.7.3
StructHelpers ──────────────────── v1.6.0
StructUtils ────────────────────── v2.8.5
TZJData ────────────────────────── v1.5.1+2025b
TableTraits ────────────────────── v1.0.1
Tables ─────────────────────────── v1.14.0
TensorCore ─────────────────────── v0.1.1
TerminalLoggers ────────────────── v0.1.8
TestItemRunner ─────────────────── v1.3.2
TestItems ──────────────────────── v1.1.0
ThreadingUtilities ─────────────── v0.5.6
TiffImages ─────────────────────── v0.11.9
TimeZones ──────────────────────── v1.22.2
TranscodingStreams ─────────────── v0.11.3
TriplotBase ────────────────────── v0.1.0
URIs ───────────────────────────── v1.7.0
UnPack ─────────────────────────── v1.0.2
UnicodeFun ─────────────────────── v0.4.1
Unitful ────────────────────────── v1.28.0
VersionParsing ─────────────────── v1.3.0
WebP ───────────────────────────── v0.1.3
WoodburyMatrices ───────────────── v1.1.0
XML2_jll ───────────────────────── v2.13.9+0
XZ_jll ─────────────────────────── v5.8.3+0
Xorg_libX11_jll ────────────────── v1.8.13+0
Xorg_libXau_jll ────────────────── v1.0.13+0
Xorg_libXdmcp_jll ──────────────── v1.1.6+0
Xorg_libXext_jll ───────────────── v1.3.8+0
Xorg_libXfixes_jll ─────────────── v6.0.2+0
Xorg_libXrender_jll ────────────── v0.9.12+0
Xorg_libpciaccess_jll ──────────── v0.19.0+0
Xorg_libxcb_jll ────────────────── v1.17.1+0
Xorg_xtrans_jll ────────────────── v1.6.0+0
ZMQ ────────────────────────────── v1.5.1
ZeroMQ_jll ─────────────────────── v4.3.6+0
Zstd_jll ───────────────────────── v1.5.7+1
artifact Blosc                   44.2 KiB
artifact Bzip2                   503.5 KiB
artifact CRlibm                  169.5 KiB
artifact Cairo                   2.2 MiB
artifact CoreMath                643.9 KiB
artifact EarCut                  80.5 KiB
artifact Expat                   298.3 KiB
artifact FFMPEG                  11.9 MiB
artifact Fontconfig              984.8 KiB
artifact FreeType2               1.5 MiB
artifact FriBidi                 78.9 KiB
artifact GettextRuntime          543.0 KiB
artifact Giflib                  154.6 KiB
artifact Glib                    7.8 MiB
artifact Graphite2               120.3 KiB
artifact HDF5                    6.1 MiB
artifact HarfBuzz                1.9 MiB
artifact Hwloc                   3.5 MiB
artifact Imath                   184.9 KiB
artifact JpegTurbo               1.9 MiB
artifact LAME                    292.5 KiB
artifact LERC                    267.4 KiB
artifact LLVMOpenMP              680.4 KiB
artifact Libffi                  44.2 KiB
artifact Libglvnd                833.5 KiB
artifact Libiconv                1.9 MiB
artifact Libmount                6.9 MiB
artifact Libtiff                 2.4 MiB
artifact Libuuid                 3.9 MiB
artifact Lz4                     239.7 KiB
artifact MPICH                   8.8 MiB
artifact MakieAssets             24.9 MiB
artifact NetCDF                  970.6 KiB
artifact Ogg                     250.3 KiB
artifact OpenBLASConsistentFPCSR 10.2 MiB
artifact OpenEXR                 1.3 MiB
artifact OpenSpecFun             194.9 KiB
artifact Opus                    960.9 KiB
artifact Pango                   1.1 MiB
artifact Pixman                  390.8 KiB
artifact Rmath                   121.8 KiB
artifact XML2                    2.5 MiB
artifact XZ                      1.6 MiB
artifact Xorg_libX11             4.8 MiB
artifact Xorg_libXau             36.6 KiB
artifact Xorg_libXdmcp           67.7 KiB
artifact Xorg_libXext            286.6 KiB
artifact Xorg_libXfixes          59.0 KiB
artifact Xorg_libXrender         435.9 KiB
artifact Xorg_libpciaccess       26.2 KiB
artifact Xorg_libxcb             2.1 MiB
artifact Xorg_xtrans             48.2 KiB
artifact ZeroMQ                  316.1 KiB
artifact Zstd                    646.0 KiB
artifact aws_c_auth              130.3 KiB
artifact aws_c_cal               1.2 MiB
artifact aws_c_common            285.2 KiB
artifact aws_c_compression       13.4 KiB
artifact aws_c_http              393.6 KiB
artifact aws_c_io                181.7 KiB
artifact aws_c_s3                143.0 KiB
artifact aws_c_sdkutils          54.9 KiB
artifact aws_checksums           87.0 KiB
artifact isoband                 25.7 KiB
artifact libaec                  50.4 KiB
artifact libaom                  6.5 MiB
artifact libass                  429.9 KiB
artifact libdrm                  372.6 KiB
artifact libfdk_aac              2.8 MiB
artifact libpng                  329.4 KiB
artifact libsixel                177.3 KiB
artifact libsodium               1.6 MiB
artifact libva                   235.7 KiB
artifact libvorbis               271.0 KiB
artifact libwebp                 2.6 MiB
artifact libzip                  182.9 KiB
artifact licensecheck            2.4 MiB
artifact s2n_tls                 1.8 MiB
artifact tzjdata                 112.5 KiB
artifact x264                    2.1 MiB
artifact x265                    1.4 MiB
aws_c_auth_jll ─────────────────── v0.9.6+0
aws_c_cal_jll ──────────────────── v0.9.13+0
aws_c_common_jll ───────────────── v0.12.6+0
aws_c_compression_jll ──────────── v0.3.2+0
aws_c_http_jll ─────────────────── v0.10.15+0
aws_c_io_jll ───────────────────── v0.26.3+0
aws_c_s3_jll ───────────────────── v0.11.5+0
aws_c_sdkutils_jll ─────────────── v0.2.4+1
aws_checksums_jll ──────────────── v0.2.10+0
dlfcn_win32_jll ────────────────── v1.4.2+0
isoband_jll ────────────────────── v0.2.3+0
libaec_jll ─────────────────────── v1.1.7+0
libaom_jll ─────────────────────── v3.14.1+0
libass_jll ─────────────────────── v0.17.5+0
libdrm_jll ─────────────────────── v2.4.134+0
libfdk_aac_jll ─────────────────── v2.0.4+0
libpng_jll ─────────────────────── v1.6.58+0
libsixel_jll ───────────────────── v1.10.5+0
libsodium_jll ──────────────────── v1.0.21+0
libva_jll ──────────────────────── v2.23.0+0
libvorbis_jll ──────────────────── v1.3.8+0
libwebp_jll ────────────────────── v1.6.0+0
libzip_jll ─────────────────────── v1.11.4+0
licensecheck_jll ───────────────── v0.4.0+0
mpif_jll ───────────────────────── v1.0.0+0
s2n_tls_jll ────────────────────── v1.7.8+0
x264_jll ───────────────────────── v10164.0.1+0
x265_jll ───────────────────────── v4.1.0+0
